### PR TITLE
test(output): add unit tests for output formatters

### DIFF
--- a/internal/output/config_test.go
+++ b/internal/output/config_test.go
@@ -1,0 +1,75 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/config"
+)
+
+func TestWriteConfigStatusJSON(t *testing.T) {
+	status := config.Status{
+		ConfigFile:    "/tmp/config.json",
+		Exists:        true,
+		SchemaVersion: 2,
+		Trading: config.Trading{
+			Grant: true,
+			Place: true,
+			Sell:  true,
+			KR:    false,
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteConfigStatus(&buf, FormatJSON, status); err != nil {
+		t.Fatalf("WriteConfigStatus JSON error: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"grant":true`) && !strings.Contains(buf.String(), `"grant": true`) {
+		t.Fatalf("expected grant:true in JSON output, got %s", buf.String())
+	}
+}
+
+func TestWriteConfigStatusTable(t *testing.T) {
+	status := config.Status{
+		ConfigFile:    "/tmp/config.json",
+		Exists:        true,
+		SchemaVersion: 2,
+		Trading: config.Trading{
+			Grant: true,
+			Place: true,
+			Sell:  false,
+			KR:    true,
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteConfigStatus(&buf, FormatTable, status); err != nil {
+		t.Fatalf("WriteConfigStatus Table error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "Trading KR: true") {
+		t.Fatalf("expected Trading KR: true in table output, got %s", output)
+	}
+	if !strings.Contains(output, "Trading Sell: false") {
+		t.Fatalf("expected Trading Sell: false, got %s", output)
+	}
+}
+
+func TestWriteConfigStatusCSV(t *testing.T) {
+	status := config.Status{
+		ConfigFile:    "/tmp/config.json",
+		Exists:        true,
+		SchemaVersion: 2,
+		Trading:       config.Trading{},
+	}
+	var buf bytes.Buffer
+	if err := WriteConfigStatus(&buf, FormatCSV, status); err != nil {
+		t.Fatalf("WriteConfigStatus CSV error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 CSV lines, got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], "kr") {
+		t.Fatalf("expected kr column in CSV header, got %s", lines[0])
+	}
+}

--- a/internal/output/format_test.go
+++ b/internal/output/format_test.go
@@ -1,0 +1,29 @@
+package output
+
+import "testing"
+
+func TestParseFormat(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    Format
+		wantErr bool
+	}{
+		{"table", FormatTable, false},
+		{"json", FormatJSON, false},
+		{"csv", FormatCSV, false},
+		{"TABLE", FormatTable, false},
+		{"  Json  ", FormatJSON, false},
+		{"yaml", "", true},
+		{"", "", true},
+	}
+	for _, tt := range tests {
+		got, err := ParseFormat(tt.input)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ParseFormat(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ParseFormat(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/output/portfolio_test.go
+++ b/internal/output/portfolio_test.go
@@ -1,0 +1,124 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/domain"
+)
+
+var testPositions = []domain.Position{
+	{
+		ProductCode:     "A005930",
+		Symbol:          "005930",
+		Name:            "삼성전자",
+		MarketType:      "KR_STOCK",
+		MarketCode:      "KSP",
+		Quantity:        10,
+		AveragePrice:    70000,
+		CurrentPrice:    80000,
+		MarketValue:     800000,
+		UnrealizedPnL:   100000,
+		ProfitRate:      0.1429,
+		DailyProfitLoss: 5000,
+		DailyProfitRate: 0.0063,
+	},
+	{
+		ProductCode:  "US20220809012",
+		Symbol:       "TSLL",
+		Name:         "TSLL",
+		MarketType:   "US_STOCK",
+		MarketCode:   "NSQ",
+		Quantity:     100,
+		AveragePrice: 15000,
+		CurrentPrice: 12000,
+		MarketValue:  1200000,
+	},
+}
+
+func TestWritePositionsJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WritePositions(&buf, FormatJSON, testPositions); err != nil {
+		t.Fatalf("WritePositions JSON error: %v", err)
+	}
+	var parsed []domain.Position
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("JSON unmarshal error: %v", err)
+	}
+	if len(parsed) != 2 {
+		t.Fatalf("expected 2 positions, got %d", len(parsed))
+	}
+	if parsed[0].Symbol != "005930" {
+		t.Fatalf("expected 005930, got %s", parsed[0].Symbol)
+	}
+}
+
+func TestWritePositionsCSV(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WritePositions(&buf, FormatCSV, testPositions); err != nil {
+		t.Fatalf("WritePositions CSV error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 { // header + 2 rows
+		t.Fatalf("expected 3 CSV lines, got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], "product_code") {
+		t.Fatalf("expected CSV header, got %s", lines[0])
+	}
+	if !strings.Contains(lines[1], "005930") {
+		t.Fatalf("expected 005930 in first row, got %s", lines[1])
+	}
+}
+
+func TestWritePositionsTable(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WritePositions(&buf, FormatTable, testPositions); err != nil {
+		t.Fatalf("WritePositions Table error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "삼성전자") {
+		t.Fatalf("expected 삼성전자 in table output")
+	}
+	if !strings.Contains(output, "TSLL") {
+		t.Fatalf("expected TSLL in table output")
+	}
+}
+
+func TestWritePositionsEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WritePositions(&buf, FormatJSON, nil); err != nil {
+		t.Fatalf("WritePositions empty error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "null") && !strings.Contains(buf.String(), "[]") {
+		// Go json encodes nil slice as null
+	}
+}
+
+func TestWriteAllocationCSV(t *testing.T) {
+	markets := map[string]domain.AccountMarketSummary{
+		"us": {Market: "us", TotalAssetAmount: 1000000, PrincipalAmount: 900000, EvaluatedProfitAmount: 100000, ProfitRate: 0.1111},
+		"kr": {Market: "kr", TotalAssetAmount: 500000, PrincipalAmount: 400000, EvaluatedProfitAmount: 100000, ProfitRate: 0.25},
+	}
+	var buf bytes.Buffer
+	if err := WriteAllocation(&buf, FormatCSV, markets); err != nil {
+		t.Fatalf("WriteAllocation CSV error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 { // header + 2 rows
+		t.Fatalf("expected 3 CSV lines, got %d", len(lines))
+	}
+	// kr should come before us (sorted)
+	if !strings.HasPrefix(lines[1], "kr") {
+		t.Fatalf("expected kr first (sorted), got %s", lines[1])
+	}
+}
+
+func TestWritePositionsUnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := WritePositions(&buf, "yaml", testPositions)
+	if err == nil {
+		t.Fatal("expected error for unsupported format")
+	}
+}


### PR DESCRIPTION
## Summary
Add 10 unit tests for `internal/output` package (previously had no tests):
- `format_test.go`: ParseFormat with valid/invalid inputs
- `portfolio_test.go`: WritePositions JSON/CSV/table, WriteAllocation CSV, empty input, unsupported format
- `config_test.go`: WriteConfigStatus JSON/table/CSV including kr/sell fields

## Test plan
- [x] All 10 new tests pass
- [x] `make test` full suite passes