### PR TITLE
feat: display USD values for US stock positions

### DIFF
--- a/internal/client/portfolio.go
+++ b/internal/client/portfolio.go
@@ -109,6 +109,14 @@ func (c *Client) ListPositions(ctx context.Context) ([]domain.Position, error) {
 				ProfitRate:      coalesceMoney(item.ProfitLossRate.KRW, item.ProfitLossRate.USD),
 				DailyProfitLoss: coalesceMoney(item.DailyProfitLossAmount.KRW, item.DailyProfitLossAmount.USD),
 				DailyProfitRate: coalesceMoney(item.DailyProfitLossRate.KRW, item.DailyProfitLossRate.USD),
+
+				AveragePriceUSD:    derefFloat(item.PurchasePrice.USD),
+				CurrentPriceUSD:    derefFloat(item.CurrentPrice.USD),
+				MarketValueUSD:     derefFloat(item.EvaluatedAmount.USD),
+				UnrealizedPnLUSD:   derefFloat(item.ProfitLossAmount.USD),
+				ProfitRateUSD:      derefFloat(item.ProfitLossRate.USD),
+				DailyProfitLossUSD: derefFloat(item.DailyProfitLossAmount.USD),
+				DailyProfitRateUSD: derefFloat(item.DailyProfitLossRate.USD),
 			})
 		}
 	}
@@ -150,6 +158,13 @@ func coalesceMoney(values ...*float64) float64 {
 		if value != nil {
 			return *value
 		}
+	}
+	return 0
+}
+
+func derefFloat(p *float64) float64 {
+	if p != nil {
+		return *p
 	}
 	return 0
 }

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -52,6 +52,14 @@ type Position struct {
 	ProfitRate      float64 `json:"profit_rate,omitempty"`
 	DailyProfitLoss float64 `json:"daily_profit_loss,omitempty"`
 	DailyProfitRate float64 `json:"daily_profit_rate,omitempty"`
+
+	AveragePriceUSD    float64 `json:"average_price_usd,omitempty"`
+	CurrentPriceUSD    float64 `json:"current_price_usd,omitempty"`
+	MarketValueUSD     float64 `json:"market_value_usd,omitempty"`
+	UnrealizedPnLUSD   float64 `json:"unrealized_pnl_usd,omitempty"`
+	ProfitRateUSD      float64 `json:"profit_rate_usd,omitempty"`
+	DailyProfitLossUSD float64 `json:"daily_profit_loss_usd,omitempty"`
+	DailyProfitRateUSD float64 `json:"daily_profit_rate_usd,omitempty"`
 }
 
 type Order struct {

--- a/internal/output/portfolio.go
+++ b/internal/output/portfolio.go
@@ -18,7 +18,7 @@ func WritePositions(w io.Writer, format Format, positions []domain.Position) err
 		return encoder.Encode(positions)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
-		if err := writer.Write([]string{"product_code", "symbol", "name", "market_type", "market_code", "quantity", "average_price", "current_price", "market_value", "unrealized_pnl", "profit_rate", "daily_profit_loss", "daily_profit_rate"}); err != nil {
+		if err := writer.Write([]string{"product_code", "symbol", "name", "market_type", "market_code", "quantity", "average_price", "current_price", "market_value", "unrealized_pnl", "profit_rate", "daily_profit_loss", "daily_profit_rate", "average_price_usd", "current_price_usd", "market_value_usd", "unrealized_pnl_usd", "profit_rate_usd", "daily_profit_loss_usd", "daily_profit_rate_usd"}); err != nil {
 			return err
 		}
 		for _, position := range positions {
@@ -36,6 +36,13 @@ func WritePositions(w io.Writer, format Format, positions []domain.Position) err
 				formatFloat(position.ProfitRate),
 				formatFloat(position.DailyProfitLoss),
 				formatFloat(position.DailyProfitRate),
+				formatFloat(position.AveragePriceUSD),
+				formatFloat(position.CurrentPriceUSD),
+				formatFloat(position.MarketValueUSD),
+				formatFloat(position.UnrealizedPnLUSD),
+				formatFloat(position.ProfitRateUSD),
+				formatFloat(position.DailyProfitLossUSD),
+				formatFloat(position.DailyProfitRateUSD),
 			}); err != nil {
 				return err
 			}
@@ -46,7 +53,7 @@ func WritePositions(w io.Writer, format Format, positions []domain.Position) err
 		for _, position := range positions {
 			if _, err := fmt.Fprintf(
 				w,
-				"- %s (%s) qty=%s avg=%s last=%s value=%s pnl=%s rate=%.2f%% day_pnl=%s day_rate=%.2f%%\n",
+				"- %s (%s) qty=%s avg=%s last=%s value=%s pnl=%s rate=%.2f%% day_pnl=%s day_rate=%.2f%%",
 				position.Name,
 				position.Symbol,
 				formatFloat(position.Quantity),
@@ -58,6 +65,24 @@ func WritePositions(w io.Writer, format Format, positions []domain.Position) err
 				formatFloat(position.DailyProfitLoss),
 				position.DailyProfitRate*100,
 			); err != nil {
+				return err
+			}
+			if position.MarketType == "US_STOCK" {
+				if _, err := fmt.Fprintf(
+					w,
+					" avg_usd=%s last_usd=%s value_usd=%s pnl_usd=%s rate_usd=%.2f%% day_pnl_usd=%s day_rate_usd=%.2f%%",
+					formatFloat(position.AveragePriceUSD),
+					formatFloat(position.CurrentPriceUSD),
+					formatFloat(position.MarketValueUSD),
+					formatFloat(position.UnrealizedPnLUSD),
+					position.ProfitRateUSD*100,
+					formatFloat(position.DailyProfitLossUSD),
+					position.DailyProfitRateUSD*100,
+				); err != nil {
+					return err
+				}
+			}
+			if _, err := fmt.Fprint(w, "\n"); err != nil {
 				return err
 			}
 		}

--- a/internal/output/portfolio_test.go
+++ b/internal/output/portfolio_test.go
@@ -26,15 +26,22 @@ var testPositions = []domain.Position{
 		DailyProfitRate: 0.0063,
 	},
 	{
-		ProductCode:  "US20220809012",
-		Symbol:       "TSLL",
-		Name:         "TSLL",
-		MarketType:   "US_STOCK",
-		MarketCode:   "NSQ",
-		Quantity:     100,
-		AveragePrice: 15000,
-		CurrentPrice: 12000,
-		MarketValue:  1200000,
+		ProductCode:        "US20220809012",
+		Symbol:             "TSLL",
+		Name:               "TSLL",
+		MarketType:         "US_STOCK",
+		MarketCode:         "NSQ",
+		Quantity:           100,
+		AveragePrice:       15000,
+		CurrentPrice:       12000,
+		MarketValue:        1200000,
+		AveragePriceUSD:    10.50,
+		CurrentPriceUSD:    8.40,
+		MarketValueUSD:     840,
+		UnrealizedPnLUSD:   -210,
+		ProfitRateUSD:      -0.20,
+		DailyProfitLossUSD: -15,
+		DailyProfitRateUSD: -0.0175,
 	},
 }
 
@@ -67,6 +74,9 @@ func TestWritePositionsCSV(t *testing.T) {
 	if !strings.Contains(lines[0], "product_code") {
 		t.Fatalf("expected CSV header, got %s", lines[0])
 	}
+	if !strings.Contains(lines[0], "average_price_usd") {
+		t.Fatalf("expected USD columns in CSV header, got %s", lines[0])
+	}
 	if !strings.Contains(lines[1], "005930") {
 		t.Fatalf("expected 005930 in first row, got %s", lines[1])
 	}
@@ -83,6 +93,16 @@ func TestWritePositionsTable(t *testing.T) {
 	}
 	if !strings.Contains(output, "TSLL") {
 		t.Fatalf("expected TSLL in table output")
+	}
+	if !strings.Contains(output, "last_usd=") {
+		t.Fatalf("expected USD fields for US_STOCK in table output")
+	}
+	// KR_STOCK should not have USD fields
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "삼성전자") && strings.Contains(line, "last_usd=") {
+			t.Fatalf("KR_STOCK should not have USD fields, got %s", line)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

The portfolio API already returns USD values for all monetary fields, but they were discarded by `coalesceMoney()`. This PR adds USD support:

- Add 7 USD fields to `Position` struct with `omitempty` JSON tags
- Populate USD fields from API response `.USD` pointers via new `derefFloat()` helper
- Table output: append USD columns for `US_STOCK` positions only
- CSV output: include USD columns for all rows
- JSON output: USD fields appear automatically (omitted when zero for KR stocks)

KRW fields and KR stock behavior are completely unchanged.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] New test assertions for USD columns in CSV header and table output
- [x] Negative test: KR_STOCK lines don't contain USD fields

Closes #10