### PR TITLE
fix(auth): 시스템 Chrome으로 전환하여 브라우저 차단 해결

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ tossctl auth login
 tossctl account summary --output json
 ```
 
-`auth login`은 Playwright 기반 브라우저 로그인이 필요합니다.
+`auth login`은 Playwright + Google Chrome 기반 브라우저 로그인이 필요합니다.
 
 ```bash
 python3 -m pip install playwright
-python3 -m playwright install chromium
 ```
+
+> Google Chrome이 시스템에 설치되어 있어야 합니다.
 
 > Windows, Homebrew, 소스 빌드 등 다른 설치 방법은 [설치](#설치) 섹션을 참고하세요.
 
@@ -262,7 +263,6 @@ make build
 
 cd auth-helper
 python3 -m pip install -e .
-python3 -m playwright install chromium
 ```
 
 </details>

--- a/auth-helper/README.md
+++ b/auth-helper/README.md
@@ -22,8 +22,9 @@ The helper exists to isolate browser automation from the main CLI.
 ```bash
 cd auth-helper
 python3 -m pip install -e .
-python3 -m playwright install chromium
 python3 -m tossctl_auth_helper login --storage-state /tmp/tossctl-storage-state.json
 ```
+
+> Google Chrome이 시스템에 설치되어 있어야 합니다. `playwright install chromium`은 더 이상 필요하지 않습니다.
 
 The helper emits JSON on stdout. On success it returns `status=ok` and the path of the saved Playwright storage-state file.

--- a/auth-helper/tossctl_auth_helper/cli.py
+++ b/auth-helper/tossctl_auth_helper/cli.py
@@ -82,7 +82,7 @@ def command_login(args: argparse.Namespace) -> int:
         return emit(
             {
                 "status": "error",
-                "message": "python package 'playwright' is required. Install it with 'pip install playwright' and then run 'python -m playwright install chromium'.",
+                "message": "python package 'playwright' is required. Install it with 'pip install playwright'. Google Chrome must also be installed on your system.",
             }
         )
 
@@ -91,7 +91,7 @@ def command_login(args: argparse.Namespace) -> int:
 
     try:
         with sync_playwright() as playwright:
-            browser = playwright.chromium.launch(headless=False)
+            browser = playwright.chromium.launch(headless=False, channel="chrome")
             context = browser.new_context()
             page = context.new_page()
             log("Opened browser for Toss Securities login.")
@@ -143,7 +143,8 @@ def command_login(args: argparse.Namespace) -> int:
         message = str(exc)
         if "Executable doesn't exist" in message:
             message = (
-                "Playwright browser is not installed. Run 'python -m playwright install chromium' and try again."
+                "Google Chrome is not installed or could not be found. "
+                "Install Chrome from https://www.google.com/chrome/ and try again."
             )
         return emit({"status": "error", "message": message})
 

--- a/internal/doctor/service.go
+++ b/internal/doctor/service.go
@@ -131,7 +131,7 @@ func (s *Service) RunAuth(ctx context.Context) (AuthReport, error) {
 		checkPath("auth_helper_dir", s.loginConfig.HelperDir),
 		checkPythonModule(s.loginConfig, "tossctl_auth_helper", "auth helper module is importable", "auth helper module is not importable"),
 		checkPythonModule(s.loginConfig, "playwright", "python playwright package is installed", "python playwright package is not installed"),
-		checkChromium(s.loginConfig),
+		checkChrome(s.loginConfig),
 		checkSession(sessionStatus),
 	}
 
@@ -219,62 +219,53 @@ func checkPythonModule(cfg auth.LoginConfig, module, successSummary, failSummary
 	}
 }
 
-func checkChromium(cfg auth.LoginConfig) Check {
+func checkChrome(cfg auth.LoginConfig) Check {
 	path, err := exec.LookPath(cfg.PythonBin)
 	if err != nil {
 		return Check{
-			Name:    "chromium",
+			Name:    "chrome",
 			Status:  CheckFail,
-			Summary: "chromium check skipped because python is unavailable",
+			Summary: "chrome check skipped because python is unavailable",
 		}
 	}
 
-	script := `import os
+	script := `import json, subprocess, sys
 from playwright.sync_api import sync_playwright
 p = sync_playwright().start()
-chromium_path = p.chromium.executable_path
-p.stop()
-if chromium_path and os.path.exists(chromium_path):
-    print(chromium_path)
+try:
+    b = p.chromium.launch(headless=True, channel="chrome")
+    ua = b.new_page().evaluate("navigator.userAgent")
+    b.close()
+    print(ua)
+except Exception as e:
+    print("ERROR:" + str(e), file=sys.stderr)
+    sys.exit(1)
+finally:
+    p.stop()
 `
 	cmd := exec.Command(path, "-c", script)
 	cmd.Dir = cfg.HelperDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return Check{
-			Name:    "chromium",
-			Status:  CheckWarn,
-			Summary: "playwright chromium is not ready",
-			Detail:  chromiumFailureDetail(string(output)),
+		detail := strings.TrimSpace(string(output))
+		if strings.Contains(detail, "Executable doesn't exist") || strings.Contains(detail, "channel") {
+			detail = "Google Chrome is not installed. Install from https://www.google.com/chrome/"
 		}
-	}
-	chromiumPath := strings.TrimSpace(string(output))
-	if chromiumPath == "" {
 		return Check{
-			Name:    "chromium",
+			Name:    "chrome",
 			Status:  CheckWarn,
-			Summary: "playwright chromium is not ready",
-			Detail:  fmt.Sprintf("Run `%s -m playwright install chromium`.", cfg.PythonBin),
+			Summary: "Google Chrome is not available via Playwright",
+			Detail:  firstLine(detail),
 		}
 	}
 
+	ua := strings.TrimSpace(string(output))
 	return Check{
-		Name:    "chromium",
+		Name:    "chrome",
 		Status:  CheckOK,
-		Summary: "playwright chromium is installed",
-		Detail:  chromiumPath,
+		Summary: "Google Chrome is available",
+		Detail:  ua,
 	}
-}
-
-func chromiumFailureDetail(output string) string {
-	detail := strings.TrimSpace(output)
-	if detail == "" {
-		return "Run `python3 -m playwright install chromium`."
-	}
-	if strings.Contains(detail, "Executable doesn't exist") {
-		return "Run `python3 -m playwright install chromium`."
-	}
-	return firstLine(detail)
 }
 
 func firstLine(value string) string {


### PR DESCRIPTION
## Summary

- Playwright 번들 Chromium 대신 시스템 Google Chrome을 사용하도록 변경
- `tossctl doctor`의 브라우저 체크를 Chrome 기반으로 업데이트
- 문서에서 `playwright install chromium` 안내 제거, Chrome 설치 필요 안내 추가

## 원인 분석

토스증권이 `Sec-Ch-Ua` HTTP 헤더에서 `"Google Chrome"` 브랜드 존재 여부를 확인하도록 브라우저 감지를 강화함.

| | Playwright Chromium | System Chrome |
|---|---|---|
| `Sec-Ch-Ua` | `"Chromium";v="145"` | `"Chromium";v="146", "Google Chrome";v="146"` |
| 토스증권 | **차단** | **정상** |

Chromium은 구조적으로 `"Google Chrome"` 브랜드를 포함하지 않으므로, 버전 업데이트로는 해결 불가.

## 변경 사항

- `auth-helper/cli.py`: `playwright.chromium.launch(channel="chrome")` 추가
- `internal/doctor/service.go`: `checkChromium` → `checkChrome`
- `README.md`, `auth-helper/README.md`: 설치 안내 업데이트

## Test plan

- [x] `make test` 전체 통과
- [x] `tossctl auth login` — Chrome 창에서 QR 로그인 정상 완료
- [x] `tossctl portfolio positions` — 데이터 조회 정상
- [x] `tossctl doctor` — Chrome 감지 정상 (`[ok] chrome: Google Chrome is available`)

Closes #13