### PR TITLE
Improve auth status validation and diagnostics

### DIFF
--- a/cmd/tossctl/errors.go
+++ b/cmd/tossctl/errors.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -22,6 +23,14 @@ func userFacingCommandError(err error) error {
 		return fmt.Errorf("no active session; run `tossctl auth login`")
 	}
 
+	var authErr *tossclient.AuthError
+	if errors.As(err, &authErr) {
+		return fmt.Errorf(
+			"stored session is not ready for authenticated reads: status %d at %s; run `tossctl auth login`",
+			authErr.StatusCode,
+			summarizeEndpoint(authErr.Endpoint),
+		)
+	}
 	if tossclient.IsAuthError(err) {
 		return fmt.Errorf("stored session is no longer valid; run `tossctl auth login`")
 	}
@@ -54,6 +63,20 @@ func userFacingCommandError(err error) error {
 	}
 
 	return err
+}
+
+func summarizeEndpoint(endpoint string) string {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return endpoint
+	}
+	if parsed.Path == "" {
+		return endpoint
+	}
+	if parsed.RawQuery == "" {
+		return parsed.Path
+	}
+	return parsed.Path + "?" + parsed.RawQuery
 }
 
 func userFacingTradingError(paths config.Paths, err error) error {

--- a/cmd/tossctl/errors_test.go
+++ b/cmd/tossctl/errors_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	tossclient "github.com/junghoonkye/tossinvest-cli/internal/client"
 	"github.com/junghoonkye/tossinvest-cli/internal/config"
 	"github.com/junghoonkye/tossinvest-cli/internal/trading"
 )
@@ -114,6 +115,29 @@ func TestUserFacingPlaceErrorFormatsPostPrepareFXGuidance(t *testing.T) {
 	}
 	if !strings.Contains(message, "accept_fx_consent=true") {
 		t.Fatalf("expected config guidance for automation, got %q", message)
+	}
+}
+
+func TestUserFacingCommandErrorIncludesAuthEndpointAndStatus(t *testing.T) {
+	t.Parallel()
+
+	err := userFacingCommandError(&tossclient.AuthError{
+		StatusCode: 403,
+		Endpoint:   "https://wts-cert-api.tossinvest.com/api/v3/my-assets/summaries/markets/all/overview",
+	})
+	if err == nil {
+		t.Fatal("expected transformed error")
+	}
+
+	text := err.Error()
+	if !strings.Contains(text, "status 403") {
+		t.Fatalf("expected status code in error, got %q", text)
+	}
+	if !strings.Contains(text, "/api/v3/my-assets/summaries/markets/all/overview") {
+		t.Fatalf("expected endpoint path in error, got %q", text)
+	}
+	if !strings.Contains(text, "tossctl auth login") {
+		t.Fatalf("expected login hint in error, got %q", text)
 	}
 }
 

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/junghoonkye/tossinvest-cli/internal/client"
 	"github.com/junghoonkye/tossinvest-cli/internal/session"
 )
 
@@ -168,6 +172,65 @@ func TestStatusCapturesValidationError(t *testing.T) {
 	}
 	if status.ValidationError != "session rejected" {
 		t.Fatalf("unexpected validation error: %q", status.ValidationError)
+	}
+}
+
+func TestStatusMarksHalfSessionInvalid(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	sessionPath := filepath.Join(tmpDir, "session.json")
+	sess := &session.Session{
+		Provider:    "playwright-storage-state",
+		Cookies:     map[string]string{"SESSION": "session-token"},
+		RetrievedAt: mustTime(t, "2026-03-11T05:00:00Z"),
+	}
+	if err := session.NewFileStore(sessionPath).Save(context.Background(), sess); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/account/list":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"result":{"accountList":[{"key":"1","name":"기본계좌","displayName":"기본계좌","type":"BROKERAGE","markets":["US"]}],"primaryKey":"1"}}`))
+		case "/api/v3/my-assets/summaries/markets/all/overview":
+			http.Error(w, "forbidden", http.StatusForbidden)
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	validator := client.New(client.Config{
+		HTTPClient:  server.Client(),
+		APIBaseURL:  server.URL,
+		InfoBaseURL: server.URL,
+		CertBaseURL: server.URL,
+		Session:     sess,
+	})
+
+	svc := NewService(
+		session.NewFileStore(sessionPath),
+		sessionPath,
+		Options{Validator: validator},
+	)
+
+	status, err := svc.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status returned error: %v", err)
+	}
+	if !status.Validated {
+		t.Fatal("expected validated status")
+	}
+	if status.Valid {
+		t.Fatal("expected invalid half-session status")
+	}
+	if status.ValidationError == "" {
+		t.Fatal("expected validation error detail")
+	}
+	if want := "/api/v3/my-assets/summaries/markets/all/overview"; !strings.Contains(status.ValidationError, want) {
+		t.Fatalf("expected validation error to mention %s, got %q", want, status.ValidationError)
 	}
 }
 

--- a/internal/client/account.go
+++ b/internal/client/account.go
@@ -299,8 +299,11 @@ func (c *Client) ValidateSession(ctx context.Context) error {
 		return err
 	}
 
-	var envelope accountListEnvelope
-	return c.getJSON(ctx, c.apiBaseURL+"/api/v1/account/list", &envelope)
+	if _, err := c.GetAccountSummary(ctx); err != nil {
+		return err
+	}
+	_, err := c.ListPositions(ctx)
+	return err
 }
 
 func (c *Client) requireSession() error {

--- a/internal/client/account_test.go
+++ b/internal/client/account_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -98,6 +99,132 @@ func TestValidateSessionRequiresStoredSession(t *testing.T) {
 	err := client.ValidateSession(context.Background())
 	if !IsAuthError(err) {
 		t.Fatalf("expected auth error, got %v", err)
+	}
+}
+
+func TestValidateSessionRejectsHalfSession(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v3/my-assets/summaries/markets/all/overview":
+			http.Error(w, "forbidden", http.StatusForbidden)
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		HTTPClient:  server.Client(),
+		APIBaseURL:  server.URL,
+		InfoBaseURL: server.URL,
+		CertBaseURL: server.URL,
+		Session: &session.Session{
+			Cookies: map[string]string{"SESSION": "test-session"},
+		},
+	})
+
+	err := client.ValidateSession(context.Background())
+	if err == nil {
+		t.Fatal("expected half-session validation error")
+	}
+	if !IsAuthError(err) {
+		t.Fatalf("expected auth error, got %v", err)
+	}
+
+	var authErr *AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected underlying auth error, got %T", err)
+	}
+	if authErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("unexpected status code: %d", authErr.StatusCode)
+	}
+	if authErr.Endpoint != server.URL+"/api/v3/my-assets/summaries/markets/all/overview" {
+		t.Fatalf("unexpected endpoint: %s", authErr.Endpoint)
+	}
+}
+
+func TestValidateSessionDoesNotDependOnAccountList(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v3/my-assets/summaries/markets/all/overview":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"result":{"totalAssetAmount":1,"evaluatedProfitAmount":0,"profitRate":0,"overviewByMarket":{"us":{"market":"us","pendingBuyOrderAmount":0,"evaluatedAmount":1,"principalAmount":1,"evaluatedProfitAmount":0,"profitRate":0,"totalAssetAmount":1,"orderableAmount":{"krw":0,"usd":1}}}}}`))
+		case "/api/v1/dashboard/common/cached-orderable-amount":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"result":{"orderableAmountKr":{"krw":0,"usd":0},"orderableAmountUs":{"krw":0,"usd":1}}}`))
+		case "/api/v1/my-assets/summaries/markets/kr/withdrawable-amount":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"result":{"krw":0}}`))
+		case "/api/v1/my-assets/summaries/markets/us/withdrawable-amount":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"result":{"usd":1}}`))
+		case "/api/v2/dashboard/asset/sections/all":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"result":{"sections":[{"type":"SORTED_OVERVIEW","data":{"products":[{"marketType":"us","items":[{"stockCode":"NVDA","stockName":"NVIDIA","quantity":1,"currentPrice":{"usd":1},"purchasePrice":{"usd":1},"evaluatedAmount":{"usd":1},"profitLossAmount":{"usd":0},"profitLossRate":{"usd":0},"dailyProfitLossAmount":{"usd":0},"dailyProfitLossRate":{"usd":0},"marketCode":"NASD"}]}]}}]}}`))
+		case "/api/v1/account/list":
+			http.Error(w, "forbidden", http.StatusForbidden)
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		HTTPClient:  server.Client(),
+		APIBaseURL:  server.URL,
+		InfoBaseURL: server.URL,
+		CertBaseURL: server.URL,
+		Session: &session.Session{
+			Cookies: map[string]string{"SESSION": "test-session"},
+		},
+	})
+
+	if err := client.ValidateSession(context.Background()); err != nil {
+		t.Fatalf("expected validation success, got %v", err)
+	}
+}
+
+func TestGetAccountSummaryReturnsCertEndpointAuthError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v3/my-assets/summaries/markets/all/overview":
+			http.Error(w, "forbidden", http.StatusForbidden)
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		HTTPClient:  server.Client(),
+		APIBaseURL:  server.URL,
+		InfoBaseURL: server.URL,
+		CertBaseURL: server.URL,
+		Session: &session.Session{
+			Cookies: map[string]string{"SESSION": "test-session"},
+		},
+	})
+
+	_, err := client.GetAccountSummary(context.Background())
+	if err == nil {
+		t.Fatal("expected summary error")
+	}
+
+	var authErr *AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected auth error, got %T", err)
+	}
+	if authErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("unexpected status code: %d", authErr.StatusCode)
+	}
+	if authErr.Endpoint != server.URL+"/api/v3/my-assets/summaries/markets/all/overview" {
+		t.Fatalf("unexpected endpoint: %s", authErr.Endpoint)
 	}
 }
 

--- a/internal/client/portfolio_test.go
+++ b/internal/client/portfolio_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -43,6 +44,46 @@ func TestListPositionsFromFixtures(t *testing.T) {
 	}
 	if positions[0].Name == "" {
 		t.Fatal("expected first position to have a name")
+	}
+}
+
+func TestListPositionsReturnsCertEndpointAuthError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/dashboard/asset/sections/all":
+			http.Error(w, "forbidden", http.StatusForbidden)
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		HTTPClient:  server.Client(),
+		APIBaseURL:  server.URL,
+		InfoBaseURL: server.URL,
+		CertBaseURL: server.URL,
+		Session: &session.Session{
+			Cookies: map[string]string{"SESSION": "test-session"},
+		},
+	})
+
+	_, err := client.ListPositions(context.Background())
+	if err == nil {
+		t.Fatal("expected positions error")
+	}
+
+	var authErr *AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected auth error, got %T", err)
+	}
+	if authErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("unexpected status code: %d", authErr.StatusCode)
+	}
+	if authErr.Endpoint != server.URL+"/api/v2/dashboard/asset/sections/all" {
+		t.Fatalf("unexpected endpoint: %s", authErr.Endpoint)
 	}
 }
 


### PR DESCRIPTION
# PR Draft

## Observed Behavior

`tossctl auth status` only validated `GET /api/v1/account/list`, while actual read-only commands depended on a different mix of endpoints.

In local repro, the stored session could skew by endpoint family:

- `portfolio positions` succeeded
- `account summary` failed on `GET /api/v1/my-assets/summaries/markets/kr/withdrawable-amount`
- `auth status` previously treated `account/list` as the whole truth

That created false positives and made auth/session failures harder to narrow down.

## Blind Spot

The previous validation path assumed that `account/list` was a sufficient proxy for authenticated read readiness.

It is not.

- `account summary` uses both `wts-cert-api` and `wts-api`
- `portfolio positions` uses `wts-cert-api`
- `account/list` can fail independently from those surfaces

This means a stored session can be partially usable or partially broken in ways that `auth status` did not describe accurately.

## Chosen Change

This PR does two things.

- Moves `ValidateSession()` away from `account/list` and toward the actual read surface used by `account summary` and `portfolio positions`
- Preserves endpoint/status details in user-facing auth errors so failures no longer collapse into a generic “session is no longer valid” message

Concretely:

- `ValidateSession()` now validates through `GetAccountSummary()` and `ListPositions()`
- auth-related CLI errors now include `status code + endpoint path`

## Safety

- No helper/import format changes
- No raw session artifact changes
- No trading mutation changes
- No raw cookies, storage state, account identifiers, or response bodies added to the repo

This keeps the PR focused on validation/diagnostics rather than speculative auth helper changes.

## Tests

Added or extended tests for:

- half-session rejection
- `account/list` failure that should not invalidate a session if `summary + positions` still work
- `summary` cert-api auth errors preserving endpoint/status
- `positions` cert-api auth errors preserving endpoint/status
- auth status surfacing invalid validation detail
- user-facing auth errors including endpoint path and status code

Verification run:

```bash
go test ./...
```

## Local Evidence

Local-only repro with a real stored session showed:

- `GET /api/v1/account/list` -> `403`
- `GET /api/v1/my-assets/summaries/markets/{kr,us}/withdrawable-amount` -> `403`
- `GET /api/v3/my-assets/summaries/markets/all/overview` -> `200`
- `GET /api/v1/dashboard/common/cached-orderable-amount` -> `200`
- `POST /api/v2/dashboard/asset/sections/all` -> `200`

That was enough to show that `account/list` was not a reliable proxy for the read-only portfolio/account surface.

## Unknowns

- The exact server-side reason for `wts-api` vs `wts-cert-api` skew is still unknown
- This PR does not solve the broader auth/session issue for every endpoint family
- This PR intentionally does not touch helper/import behavior because current local evidence did not justify that change
