### PR TITLE
fix(auth): accept current Toss login state and use browser-like UA for account reads

### DIFF
--- a/auth-helper/tossctl_auth_helper/cli.py
+++ b/auth-helper/tossctl_auth_helper/cli.py
@@ -16,10 +16,11 @@ REQUIRED_COOKIE_NAMES = {
     "FTK",
     "browserSessionId",
 }
+# Toss's current web app still sets WTS-DEVICE-ID and login-method after a
+# successful QR login, but DEVICE_INFO is no longer guaranteed to appear.
 REQUIRED_LOCAL_STORAGE_KEYS = {
     "WTS-DEVICE-ID",
     "login-method",
-    "DEVICE_INFO",
 }
 
 

--- a/internal/client/account.go
+++ b/internal/client/account.go
@@ -314,6 +314,9 @@ func (c *Client) requireSession() error {
 func (c *Client) applySession(req *http.Request) {
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Referer", "https://www.tossinvest.com/account")
+	if req.Header.Get("User-Agent") == "" {
+		req.Header.Set("User-Agent", defaultBrowserUserAgent)
+	}
 
 	if c.session == nil {
 		return

--- a/internal/client/account_test.go
+++ b/internal/client/account_test.go
@@ -16,6 +16,9 @@ func TestAuthenticatedAccountMethodsFromFixtures(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("User-Agent"); got != defaultBrowserUserAgent {
+			t.Fatalf("unexpected user agent: %q", got)
+		}
 		fixturePath := authenticatedFixturePathForRequest(t, r.URL.Path)
 		http.ServeFile(w, r, fixturePath)
 	}))
@@ -98,6 +101,20 @@ func TestValidateSessionRequiresStoredSession(t *testing.T) {
 	err := client.ValidateSession(context.Background())
 	if !IsAuthError(err) {
 		t.Fatalf("expected auth error, got %v", err)
+	}
+}
+
+func TestApplySessionPreservesExplicitUserAgent(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+	req.Header.Set("User-Agent", "custom-agent/1.0")
+
+	client := New(Config{})
+	client.applySession(req)
+
+	if got := req.Header.Get("User-Agent"); got != "custom-agent/1.0" {
+		t.Fatalf("expected explicit user agent to be preserved, got %q", got)
 	}
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -18,6 +18,7 @@ import (
 const defaultAPIBaseURL = "https://wts-api.tossinvest.com"
 const defaultInfoBaseURL = "https://wts-info-api.tossinvest.com"
 const defaultCertBaseURL = "https://wts-cert-api.tossinvest.com"
+const defaultBrowserUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
 
 type Config struct {
 	HTTPClient    *http.Client


### PR DESCRIPTION
## 변경 사항

Closes #17.

This PR fixes two separate regressions that combined into the current auth/session breakage on macOS/Homebrew `tossctl` 0.3.5 as reproduced on **April 17, 2026**.

### 1) `auth login` helper drifted from current Toss web storage behavior

The Python Playwright helper currently waits for three localStorage keys before it saves the session:

- `WTS-DEVICE-ID`
- `login-method`
- `DEVICE_INFO`

In live QR-login repro on April 17, 2026, the Toss web app consistently produced:

- all required auth cookies (`SESSION`, `XSRF-TOKEN`, `UTK`, `LTK`, `FTK`, `browserSessionId`)
- `WTS-DEVICE-ID`
- `login-method`
- `qr-tabId`

but **did not reliably produce `DEVICE_INFO`**.

That caused `tossctl auth login` to stay stuck even after the browser was fully authenticated.

This PR removes `DEVICE_INFO` from the helper's hard-required success gate while keeping the other auth cookies/storage checks intact.

### 2) read-only `wts-api` calls were still sent with the default Go HTTP User-Agent

Using the exact same imported browser session, local repro showed:

- `GET /api/v1/account/list` with `Referer + X-XSRF-TOKEN` only -> `403`
- the same request with a **browser-like User-Agent** added -> `200`
- adding `Browser-Tab-Id`, `App-Version`, and `X-Tossinvest-Account` also remained `200`

That strongly suggests the server currently distinguishes browser-like requests from the default `Go-http-client/1.1` fingerprint for this auth surface.

This PR sets a browser-like default `User-Agent` for authenticated account reads, while preserving any explicitly supplied `User-Agent`.

## 영향 범위

- [x] 조회 (읽기 전용)
- [ ] 거래 (mutation)
- [ ] 설치 / CI
- [ ] 문서

## 테스트

- [x] `go test ./...` 통과
- [x] 수동 확인 완료

### 자동 테스트

```bash
go test ./...
python3 -m py_compile auth-helper/tossctl_auth_helper/cli.py
```

### 수동 검증 (April 17, 2026)

Live macOS/Homebrew repro with real QR login:

1. patched `tossctl auth login`
2. browser QR login completed
3. session saved successfully
4. `tossctl auth status` -> `Live Check: valid`
5. `tossctl account list --output json` -> success
6. `tossctl account summary --output json` -> success
7. `tossctl portfolio positions --output json` -> success

## 체크리스트

- [x] 기존 동작을 깨뜨리지 않음
- [x] 거래 관련 변경인 경우 안전장치(config gate, confirm token 등) 유지 확인

## 추가 노트

- This PR is intentionally scoped to the auth-helper success gate and the read-only account request fingerprint.
- It does **not** change trading mutations or permission gates.
- It does **not** attempt to solve the broader endpoint-family skew discussed in #15 / draft PR #16; it fixes a more basic blocker that prevented valid browser sessions from being recognized or reused reliably.
