### PR TITLE
feat(transactions): 거래내역 ledger + overview 읽기 전용 커맨드

### DIFF
--- a/cmd/tossctl/root.go
+++ b/cmd/tossctl/root.go
@@ -77,6 +77,7 @@ func newRootCmd() *cobra.Command {
 		newAccountCmd(opts),
 		newPortfolioCmd(opts),
 		newOrdersCmd(opts),
+		newTransactionsCmd(opts),
 		newWatchlistCmd(opts),
 		newQuoteCmd(opts),
 		newOrderCmd(opts),

--- a/cmd/tossctl/transactions.go
+++ b/cmd/tossctl/transactions.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tossclient "github.com/junghoonkye/tossinvest-cli/internal/client"
+	"github.com/junghoonkye/tossinvest-cli/internal/domain"
+	"github.com/junghoonkye/tossinvest-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newTransactionsCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "transactions",
+		Short: "Read transaction ledger (trades, cash flow, stock in/out)",
+		Long: "Read-only access to Toss Securities' 거래내역 ledger. " +
+			"Covers trades, deposits/withdrawals, dividends, and stock in/out per market. " +
+			"Toss caps a single query at 200 days and paginates.",
+	}
+
+	cmd.AddCommand(newTransactionsListCmd(opts))
+	cmd.AddCommand(newTransactionsOverviewCmd(opts))
+	return cmd
+}
+
+type transactionsListFlags struct {
+	market    string
+	fromStr   string
+	toStr     string
+	filter    string
+	size      int
+	number    int
+	all       bool
+	pageLimit int
+}
+
+func newTransactionsListCmd(opts *rootOptions) *cobra.Command {
+	flags := &transactionsListFlags{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List transactions (trades + cash flow) for a market",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			app, err := newAppContext(opts)
+			if err != nil {
+				return err
+			}
+
+			to, err := parseTransactionDate(flags.toStr, time.Now().In(tossclient.KoreaLocation))
+			if err != nil {
+				return fmt.Errorf("invalid --to: %w", err)
+			}
+			from, err := parseTransactionDate(flags.fromStr, to.AddDate(0, 0, -30))
+			if err != nil {
+				return fmt.Errorf("invalid --from: %w", err)
+			}
+
+			ctx := cmd.Context()
+			var items []domain.Transaction
+			if flags.all {
+				items, err = app.client.ListAllTransactions(ctx, flags.market, from, to, flags.filter, flags.size, flags.pageLimit)
+				if err != nil {
+					return userFacingCommandError(err)
+				}
+			} else {
+				page, err := app.client.ListTransactions(ctx, flags.market, from, to, flags.filter, flags.size, flags.number)
+				if err != nil {
+					return userFacingCommandError(err)
+				}
+				items = page.Items
+				if !page.LastPage && page.Next != nil && app.format == output.FormatTable {
+					fmt.Fprintf(cmd.ErrOrStderr(),
+						"(more pages available; pass --all or --number=%d to fetch next)\n",
+						page.Next.Number,
+					)
+				}
+			}
+
+			return output.WriteTransactions(cmd.OutOrStdout(), app.format, items)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.market, "market", "kr", "Market: kr or us")
+	cmd.Flags().StringVar(&flags.fromStr, "from", "", "Start date YYYY-MM-DD (default: to - 30 days)")
+	cmd.Flags().StringVar(&flags.toStr, "to", "", "End date YYYY-MM-DD (default: today)")
+	cmd.Flags().StringVar(&flags.filter, "filter", "all", "Filter: all|trade|cash|inout|cash-alt or 0|1|2|3|6")
+	cmd.Flags().IntVar(&flags.size, "size", tossclient.TransactionsDefaultPageSize, "Page size")
+	cmd.Flags().IntVar(&flags.number, "number", 0, "Page index (0-based); ignored when --all")
+	cmd.Flags().BoolVar(&flags.all, "all", false, "Page through automatically until last page")
+	cmd.Flags().IntVar(&flags.pageLimit, "page-limit", tossclient.TransactionsDefaultPageLimit, "Max pages when --all is set")
+	return cmd
+}
+
+func newTransactionsOverviewCmd(opts *rootOptions) *cobra.Command {
+	var market string
+	cmd := &cobra.Command{
+		Use:   "overview",
+		Short: "Show cash overview for a market (orderable, withdrawable, upcoming deposits)",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			app, err := newAppContext(opts)
+			if err != nil {
+				return err
+			}
+			overview, err := app.client.GetTransactionsOverview(cmd.Context(), market)
+			if err != nil {
+				return userFacingCommandError(err)
+			}
+			return output.WriteTransactionsOverview(cmd.OutOrStdout(), app.format, overview)
+		},
+	}
+	cmd.Flags().StringVar(&market, "market", "kr", "Market: kr or us")
+	return cmd
+}
+
+func parseTransactionDate(value string, fallback time.Time) (time.Time, error) {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return fallback, nil
+	}
+	return time.ParseInLocation("2006-01-02", v, tossclient.KoreaLocation)
+}

--- a/docs/reverse-engineering/rpc-catalog.md
+++ b/docs/reverse-engineering/rpc-catalog.md
@@ -94,6 +94,15 @@ These are approved CLI targets. Initial authenticated discovery happened on 2026
 
 Watchlist-specific endpoints are still not isolated. The `/account` page did not clearly expose a standalone watchlist read path in the first authenticated capture.
 
+## Transactions Ledger
+
+Captured via `/my-assets` navigation on 2026-04-19. Covers trades, cash flow, dividends, and stock in/out per market.
+
+| Status | Method | Host | Path | Purpose | Observed shape | CLI mapping | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `auth` | `GET` | `wts-api.tossinvest.com` | `/api/v3/my-assets/transactions/markets/{market}` | paginated transaction ledger | `.result.body[]` with `type`, `transactionType.{code,displayName}`, `stockCode`, `stockName`, `quantity`, `amount`, `adjustedAmount`, `commissionAmount`, `totalTaxAmount`, `balanceAmount`, `date`, `dateTime`, `settlementDate`, `referenceType`, `referenceId`, `compositeKey` | `transactions list` | `market` = `kr` or `us`. Query params: `size`, `filters` (0=all, 1=trades, 2=cash/dividend, 3=stock in-out, 6=alt cash; 4/5/7 return 500), `range.from`, `range.to`. `size` is honored; `range.from` and `number` are silently ignored — Toss returns up to `size` entries within the tail of `range.to`. Items are grouped by `type` ASC (1 = trade records, 2 = cash-flow records), then DESC by `dateTime`/`date` inside each group. US `type=1` trades populate only `settlementDate` (T+2); client range-filter falls back to `compositeKey.orderDate` to match execution day. Client pages older data by re-issuing with `range.to` set to the earliest date seen, dedupes by SortKey (derived from `compositeKey`), and filters items to the caller's `[from, to]` window. Max range = 200 days (client-side guard). |
+| `auth` | `GET` | `wts-api.tossinvest.com` | `/api/v3/my-assets/transactions/markets/{market}/overview` | cash overview per market | `.result` with `orderableAmount`, `withdrawableAmount.amount0..3`, `depositAmount.amount0..3`, `estimateSettlementAmount.day1..2`, `withdrawableAmountBottomSheet` | `transactions overview` | `depositAmount` buckets represent upcoming settlement credits; `estimateSettlementAmount` shows buy/sell amounts clearing on each upcoming settlement date. |
+
 ## Read-Only Policy Notes
 
 The Go client should only admit endpoints that are:

--- a/internal/client/transactions.go
+++ b/internal/client/transactions.go
@@ -1,0 +1,547 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/domain"
+)
+
+const (
+	TransactionsMaxRangeDays     = 200
+	TransactionsDefaultPageSize  = 50
+	TransactionsDefaultPageLimit = 10
+)
+
+type TransactionFilter int
+
+const (
+	TransactionFilterAll     TransactionFilter = 0
+	TransactionFilterTrades  TransactionFilter = 1
+	TransactionFilterCash    TransactionFilter = 2
+	TransactionFilterInOut   TransactionFilter = 3
+	TransactionFilterCashAlt TransactionFilter = 6
+)
+
+// KoreaLocation is the timezone Toss uses for ledger day boundaries.
+//
+// Most sibling endpoints (account, completed_orders, trading) rely on `time.Local`
+// implicitly because the typical user machine is already KST. Transactions is the
+// first endpoint whose date-range semantics are visible to the user (--from/--to
+// mapping to Toss's calendar day), so we make the conversion explicit. Siblings
+// can migrate to this variable if they ever need day-granularity correctness on
+// non-KST runners (e.g. CI). Fixed +09:00 fallback covers images without tzdata.
+var KoreaLocation = func() *time.Location {
+	if loc, err := time.LoadLocation("Asia/Seoul"); err == nil {
+		return loc
+	}
+	return time.FixedZone("KST", 9*3600)
+}()
+
+func normalizeTransactionMarket(value string) (string, error) {
+	m := strings.ToLower(strings.TrimSpace(value))
+	if m != "kr" && m != "us" {
+		return "", fmt.Errorf("unsupported market %q; use kr or us", value)
+	}
+	return m, nil
+}
+
+func normalizeTransactionRange(from, to time.Time) (time.Time, time.Time, error) {
+	if to.IsZero() {
+		to = time.Now().In(KoreaLocation)
+	}
+	if from.IsZero() {
+		from = to.AddDate(0, 0, -30)
+	}
+	if from.After(to) {
+		return time.Time{}, time.Time{}, fmt.Errorf("range.from must be on or before range.to")
+	}
+	if days := int(to.Sub(from).Hours()/24) + 1; days > TransactionsMaxRangeDays {
+		return time.Time{}, time.Time{}, fmt.Errorf(
+			"date range %d days exceeds Toss limit of %d days; split the query",
+			days, TransactionsMaxRangeDays,
+		)
+	}
+	return from, to, nil
+}
+
+type transactionsEnvelope struct {
+	Result struct {
+		PagingParam struct {
+			Number  int             `json:"number"`
+			Size    int             `json:"size"`
+			Key     string          `json:"key"`
+			Filters json.RawMessage `json:"filters"`
+			Type    json.RawMessage `json:"type"`
+		} `json:"pagingParam"`
+		Body     []json.RawMessage `json:"body"`
+		LastPage bool              `json:"lastPage"`
+		AllAsset bool              `json:"allAsset"`
+	} `json:"result"`
+}
+
+type transactionOverviewEnvelope struct {
+	Result struct {
+		OrderableAmount         amountPair                     `json:"orderableAmount"`
+		WithdrawableAmount      map[string]json.RawMessage     `json:"withdrawableAmount"`
+		DisplayWithdrawable     map[string]json.RawMessage     `json:"displayWithdrawableAmount"`
+		DepositAmount           map[string]json.RawMessage     `json:"depositAmount"`
+		EstimateSettlement      map[string]json.RawMessage     `json:"estimateSettlementAmount"`
+		WithdrawableBottomSheet []withdrawableBottomSheetEntry `json:"withdrawableAmountBottomSheet"`
+	} `json:"result"`
+}
+
+type amountPair struct {
+	KRW *float64 `json:"krw"`
+	USD *float64 `json:"usd"`
+}
+
+type withdrawableBottomSheetEntry struct {
+	Title  string     `json:"title"`
+	Amount amountPair `json:"amount"`
+}
+
+// ListTransactions fetches a single page from the transactions endpoint.
+// filter accepts the same strings as parseTransactionFilter ("all"/"trade"/...
+// or the numeric form). size<=0 uses TransactionsDefaultPageSize.
+func (c *Client) ListTransactions(ctx context.Context, market string, from, to time.Time, filter string, size, number int) (domain.TransactionPage, error) {
+	if err := c.requireSession(); err != nil {
+		return domain.TransactionPage{}, err
+	}
+	market, err := normalizeTransactionMarket(market)
+	if err != nil {
+		return domain.TransactionPage{}, err
+	}
+	from, to, err = normalizeTransactionRange(from, to)
+	if err != nil {
+		return domain.TransactionPage{}, err
+	}
+	filterVal, err := parseTransactionFilter(filter)
+	if err != nil {
+		return domain.TransactionPage{}, err
+	}
+	if size <= 0 {
+		size = TransactionsDefaultPageSize
+	}
+	if number < 0 {
+		number = 0
+	}
+
+	params := url.Values{}
+	params.Set("size", strconv.Itoa(size))
+	params.Set("filters", strconv.Itoa(int(filterVal)))
+	params.Set("range.from", from.Format("2006-01-02"))
+	params.Set("range.to", to.Format("2006-01-02"))
+	if number > 0 {
+		params.Set("number", strconv.Itoa(number))
+	}
+
+	endpoint := fmt.Sprintf(
+		"%s/api/v3/my-assets/transactions/markets/%s?%s",
+		c.apiBaseURL, market, params.Encode(),
+	)
+
+	var envelope transactionsEnvelope
+	if err := c.getJSON(ctx, endpoint, &envelope); err != nil {
+		return domain.TransactionPage{}, err
+	}
+
+	// Toss's ledger ignores range.from and always returns up to `size` entries counting
+	// backward from range.to. Filter client-side so callers see only the requested window.
+	fromDay, toDayExclusive := transactionRangeBounds(from, to)
+	page := domain.TransactionPage{
+		Market:   market,
+		Items:    make([]domain.Transaction, 0, len(envelope.Result.Body)),
+		LastPage: envelope.Result.LastPage,
+	}
+	for _, raw := range envelope.Result.Body {
+		tx := parseTransaction(raw, market)
+		if !transactionWithinRange(tx, fromDay, toDayExclusive) {
+			continue
+		}
+		page.Items = append(page.Items, tx)
+	}
+	if !envelope.Result.LastPage {
+		page.Next = &domain.PagingParam{
+			Number:  envelope.Result.PagingParam.Number + 1,
+			Size:    envelope.Result.PagingParam.Size,
+			Key:     envelope.Result.PagingParam.Key,
+			Filters: rawJSONScalarToString(envelope.Result.PagingParam.Filters),
+			Type:    rawJSONScalarToString(envelope.Result.PagingParam.Type),
+		}
+	}
+	return page, nil
+}
+
+// ListAllTransactions pages through by narrowing range.to toward from.
+//
+// Toss's transactions endpoint ignores number/key/cursor and only honours the
+// range.to bound. To fetch older items we re-request with range.to set to the
+// oldest date seen in the previous page, then deduplicate by SortKey (since the
+// boundary date repeats across pages). pageLimit<=0 defaults to
+// TransactionsDefaultPageLimit to avoid runaway loops.
+func (c *Client) ListAllTransactions(ctx context.Context, market string, from, to time.Time, filter string, size, pageLimit int) ([]domain.Transaction, error) {
+	if pageLimit <= 0 {
+		pageLimit = TransactionsDefaultPageLimit
+	}
+	// Normalize once up front so loop comparisons use the canonical range.
+	market, err := normalizeTransactionMarket(market)
+	if err != nil {
+		return nil, err
+	}
+	from, to, err = normalizeTransactionRange(from, to)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{})
+	all := make([]domain.Transaction, 0)
+	currentTo := to
+	for i := 0; i < pageLimit; i++ {
+		page, err := c.ListTransactions(ctx, market, from, currentTo, filter, size, 0)
+		if err != nil {
+			return nil, err
+		}
+		// ListTransactions already filters by the range, so we watch the
+		// earliest date here to decide when to stop paging.
+		newThisPage := 0
+		var earliest time.Time
+		var earliestSet bool
+		for _, tx := range page.Items {
+			if tx.SortKey != "" {
+				if _, dup := seen[tx.SortKey]; dup {
+					continue
+				}
+				seen[tx.SortKey] = struct{}{}
+			}
+			all = append(all, tx)
+			newThisPage++
+			if d := extractTransactionDate(tx); !d.IsZero() {
+				if !earliestSet || d.Before(earliest) {
+					earliest = d
+					earliestSet = true
+				}
+			}
+		}
+		if page.LastPage {
+			return all, nil
+		}
+		if newThisPage == 0 || !earliestSet {
+			return all, nil
+		}
+		// snap earliest to midnight so range.to has day granularity
+		earliestDay := time.Date(earliest.Year(), earliest.Month(), earliest.Day(), 0, 0, 0, 0, earliest.Location())
+		if !earliestDay.Before(currentTo) {
+			// would not advance: break to avoid infinite loop when >size entries share one day
+			return all, nil
+		}
+		if earliestDay.Before(from) {
+			return all, nil
+		}
+		currentTo = earliestDay
+	}
+	return all, nil
+}
+
+// transactionRangeBounds returns the inclusive [fromDay, toDayExclusive) window
+// used to filter items against the caller-provided range, at day granularity in KST.
+func transactionRangeBounds(from, to time.Time) (time.Time, time.Time) {
+	fromKST := from.In(KoreaLocation)
+	toKST := to.In(KoreaLocation)
+	fromDay := time.Date(fromKST.Year(), fromKST.Month(), fromKST.Day(), 0, 0, 0, 0, KoreaLocation)
+	toDayExclusive := time.Date(toKST.Year(), toKST.Month(), toKST.Day(), 0, 0, 0, 0, KoreaLocation).AddDate(0, 0, 1)
+	return fromDay, toDayExclusive
+}
+
+// transactionWithinRange returns true when the tx's event date falls in [fromDay, toDayExclusive).
+// Items without a parsable date are kept (we cannot confidently exclude them).
+func transactionWithinRange(tx domain.Transaction, fromDay, toDayExclusive time.Time) bool {
+	d := extractTransactionDate(tx)
+	if d.IsZero() {
+		return true
+	}
+	return !d.Before(fromDay) && d.Before(toDayExclusive)
+}
+
+// extractTransactionDate returns the event date to use for range filtering.
+// Priority: DateTime → Date → OrderDate → SettlementDate.
+// OrderDate is preferred over SettlementDate because US type=1 trade records
+// only populate SettlementDate (usually T+2), which would mis-filter a trade
+// executed on 2026-04-17 out of a `--to 2026-04-19` window.
+func extractTransactionDate(tx domain.Transaction) time.Time {
+	if tx.DateTime != "" {
+		for _, layout := range []string{"2006-01-02 15:04:05.000", "2006-01-02 15:04:05.999", "2006-01-02 15:04:05"} {
+			if t, err := time.ParseInLocation(layout, tx.DateTime, KoreaLocation); err == nil {
+				return t
+			}
+		}
+	}
+	if tx.Date != "" {
+		if t, err := time.ParseInLocation("2006-01-02", tx.Date, KoreaLocation); err == nil {
+			return t
+		}
+	}
+	if tx.OrderDate != "" {
+		if t, err := time.ParseInLocation("2006-01-02", tx.OrderDate, KoreaLocation); err == nil {
+			return t
+		}
+	}
+	if tx.SettlementDate != "" {
+		if t, err := time.ParseInLocation("2006-01-02", tx.SettlementDate, KoreaLocation); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+// GetTransactionsOverview fetches the `/overview` summary for a market.
+func (c *Client) GetTransactionsOverview(ctx context.Context, market string) (domain.TransactionOverview, error) {
+	if err := c.requireSession(); err != nil {
+		return domain.TransactionOverview{}, err
+	}
+	m := strings.ToLower(strings.TrimSpace(market))
+	if m != "kr" && m != "us" {
+		return domain.TransactionOverview{}, fmt.Errorf("unsupported market %q; use kr or us", market)
+	}
+
+	endpoint := fmt.Sprintf("%s/api/v3/my-assets/transactions/markets/%s/overview", c.apiBaseURL, m)
+	var envelope transactionOverviewEnvelope
+	if err := c.getJSON(ctx, endpoint, &envelope); err != nil {
+		return domain.TransactionOverview{}, err
+	}
+
+	overview := domain.TransactionOverview{Market: m}
+	overview.OrderableKRW = pointerFloat(envelope.Result.OrderableAmount.KRW)
+	overview.OrderableUSD = pointerFloat(envelope.Result.OrderableAmount.USD)
+	overview.Withdrawable = parseSettlementBuckets(envelope.Result.WithdrawableAmount)
+	overview.DisplayWithdrawable = parseSettlementBuckets(envelope.Result.DisplayWithdrawable)
+	overview.Deposit = parseSettlementBuckets(envelope.Result.DepositAmount)
+	overview.EstimateSettlement = parseSettlementEstimates(envelope.Result.EstimateSettlement)
+	for _, item := range envelope.Result.WithdrawableBottomSheet {
+		overview.WithdrawableBottomSheet = append(overview.WithdrawableBottomSheet, domain.WithdrawableBottomSheetEntry{
+			Title: item.Title,
+			KRW:   pointerFloat(item.Amount.KRW),
+			USD:   pointerFloat(item.Amount.USD),
+		})
+	}
+	return overview, nil
+}
+
+func parseSettlementBuckets(flat map[string]json.RawMessage) []domain.SettlementBucket {
+	if len(flat) == 0 {
+		return nil
+	}
+	buckets := make([]domain.SettlementBucket, 0, 4)
+	for i := 0; i < 4; i++ {
+		amountKey := fmt.Sprintf("amount%d", i)
+		dateKey := fmt.Sprintf("date%d", i)
+		amountRaw, hasAmount := flat[amountKey]
+		dateRaw, hasDate := flat[dateKey]
+		if !hasAmount && !hasDate {
+			continue
+		}
+		b := domain.SettlementBucket{}
+		if hasDate {
+			_ = json.Unmarshal(dateRaw, &b.Date)
+		}
+		if hasAmount {
+			var pair amountPair
+			if err := json.Unmarshal(amountRaw, &pair); err == nil {
+				b.KRW = pointerFloat(pair.KRW)
+				b.USD = pointerFloat(pair.USD)
+			}
+		}
+		if b.Date == "" && b.KRW == 0 && b.USD == 0 {
+			continue
+		}
+		buckets = append(buckets, b)
+	}
+	return buckets
+}
+
+func parseSettlementEstimates(flat map[string]json.RawMessage) []domain.SettlementEstimate {
+	if len(flat) == 0 {
+		return nil
+	}
+	out := make([]domain.SettlementEstimate, 0, len(flat))
+	for i := 1; i <= 4; i++ {
+		raw, ok := flat[fmt.Sprintf("day%d", i)]
+		if !ok {
+			continue
+		}
+		var payload struct {
+			SettlementKorDate string  `json:"settlementKorDate"`
+			BuyAmount         float64 `json:"buyAmount"`
+			SellAmount        float64 `json:"sellAmount"`
+		}
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			continue
+		}
+		if payload.SettlementKorDate == "" && payload.BuyAmount == 0 && payload.SellAmount == 0 {
+			continue
+		}
+		out = append(out, domain.SettlementEstimate{
+			Date:       payload.SettlementKorDate,
+			BuyAmount:  payload.BuyAmount,
+			SellAmount: payload.SellAmount,
+		})
+	}
+	return out
+}
+
+func parseTransaction(raw json.RawMessage, market string) domain.Transaction {
+	tx := domain.Transaction{Market: market, Raw: raw}
+	switch market {
+	case "us":
+		tx.Currency = "USD"
+	default:
+		tx.Currency = "KRW"
+	}
+
+	var payload struct {
+		Type            string `json:"type"`
+		TransactionType struct {
+			Code        string `json:"code"`
+			DisplayName string `json:"displayName"`
+		} `json:"transactionType"`
+		DisplayType      string  `json:"displayType"`
+		Summary          *string `json:"summary"`
+		StockCode        string  `json:"stockCode"`
+		StockName        string  `json:"stockName"`
+		Quantity         float64 `json:"quantity"`
+		Amount           float64 `json:"amount"`
+		AdjustedAmount   float64 `json:"adjustedAmount"`
+		CommissionAmount float64 `json:"commissionAmount"`
+		TotalTaxAmount   float64 `json:"totalTaxAmount"`
+		BalanceAmount    float64 `json:"balanceAmount"`
+		Date             *string `json:"date"`
+		DateTime         *string `json:"dateTime"`
+		SettlementDate   *string `json:"settlementDate"`
+		ReferenceType    *string `json:"referenceType"`
+		ReferenceID      *string `json:"referenceId"`
+		CompositeKey     struct {
+			OrderDate string `json:"orderDate"`
+			Date      string `json:"date"`
+			TradeType string `json:"tradeType"`
+			StockCode string `json:"stockCode"`
+			ID        any    `json:"id"`
+			No        any    `json:"no"`
+		} `json:"compositeKey"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return tx
+	}
+
+	tx.Type = payload.Type
+	tx.Code = payload.TransactionType.Code
+	tx.DisplayName = payload.TransactionType.DisplayName
+	tx.DisplayType = payload.DisplayType
+	if payload.Summary != nil {
+		tx.Summary = *payload.Summary
+	}
+	tx.StockCode = payload.StockCode
+	tx.StockName = payload.StockName
+	tx.Quantity = payload.Quantity
+	tx.Amount = payload.Amount
+	tx.AdjustedAmount = payload.AdjustedAmount
+	tx.CommissionAmount = payload.CommissionAmount
+	tx.TaxAmount = payload.TotalTaxAmount
+	tx.BalanceAmount = payload.BalanceAmount
+	if payload.Date != nil {
+		tx.Date = *payload.Date
+	}
+	if payload.DateTime != nil {
+		tx.DateTime = *payload.DateTime
+	}
+	if payload.SettlementDate != nil {
+		tx.SettlementDate = *payload.SettlementDate
+	}
+	if payload.ReferenceType != nil {
+		tx.ReferenceType = *payload.ReferenceType
+	}
+	if payload.ReferenceID != nil {
+		tx.ReferenceID = *payload.ReferenceID
+	}
+	tx.TradeType = payload.CompositeKey.TradeType
+	tx.OrderDate = payload.CompositeKey.OrderDate
+
+	switch payload.Type {
+	case "1":
+		tx.Category = "trade"
+	case "2":
+		tx.Category = "cash"
+	default:
+		tx.Category = "other"
+	}
+
+	tx.SortKey = buildTransactionSortKey(tx, payload.CompositeKey.ID, payload.CompositeKey.No, payload.CompositeKey.OrderDate, payload.CompositeKey.Date)
+	return tx
+}
+
+func buildTransactionSortKey(tx domain.Transaction, id, no any, orderDate, date string) string {
+	var builder strings.Builder
+	switch {
+	case tx.DateTime != "":
+		builder.WriteString(tx.DateTime)
+	case tx.Date != "":
+		builder.WriteString(tx.Date)
+	case orderDate != "":
+		builder.WriteString(orderDate)
+	case date != "":
+		builder.WriteString(date)
+	}
+	if id != nil {
+		builder.WriteString("|")
+		builder.WriteString(fmt.Sprint(id))
+	}
+	if no != nil {
+		builder.WriteString("|")
+		builder.WriteString(fmt.Sprint(no))
+	}
+	return builder.String()
+}
+
+// rawJSONScalarToString unwraps a json.RawMessage scalar (string or number) into its
+// bare string form. This avoids leaking JSON quoting into output fields when Toss sends
+// e.g. "0" instead of 0 in pagingParam.filters/type.
+func rawJSONScalarToString(raw json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return trimmed
+}
+
+// parseTransactionFilter accepts numeric ("0"/"1"/...) or named
+// ("all"/"trade"/"cash"/"inout"/"cash-alt") filter values.
+func parseTransactionFilter(value string) (TransactionFilter, error) {
+	if n, err := strconv.Atoi(strings.TrimSpace(value)); err == nil {
+		switch TransactionFilter(n) {
+		case TransactionFilterAll, TransactionFilterTrades, TransactionFilterCash,
+			TransactionFilterInOut, TransactionFilterCashAlt:
+			return TransactionFilter(n), nil
+		}
+		return 0, fmt.Errorf("unsupported filter %d; use 0|1|2|3|6", n)
+	}
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "all":
+		return TransactionFilterAll, nil
+	case "trade", "trades":
+		return TransactionFilterTrades, nil
+	case "cash", "deposit", "withdrawal":
+		return TransactionFilterCash, nil
+	case "inout", "stock-io", "transfer":
+		return TransactionFilterInOut, nil
+	case "cash-alt", "cashalt":
+		return TransactionFilterCashAlt, nil
+	}
+	return 0, fmt.Errorf("unsupported filter %q; use all|trade|cash|inout|cash-alt or 0|1|2|3|6", value)
+}

--- a/internal/client/transactions_test.go
+++ b/internal/client/transactions_test.go
@@ -1,0 +1,427 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/domain"
+	"github.com/junghoonkye/tossinvest-cli/internal/session"
+)
+
+func TestListTransactionsParsesTradeAndCashEntries(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/my-assets/transactions/markets/kr" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("range.from") != "2024-01-01" {
+			t.Fatalf("range.from = %q", q.Get("range.from"))
+		}
+		if q.Get("range.to") != "2024-01-15" {
+			t.Fatalf("range.to = %q", q.Get("range.to"))
+		}
+		if q.Get("filters") != "0" {
+			t.Fatalf("filters = %q", q.Get("filters"))
+		}
+		if q.Get("size") != "50" {
+			t.Fatalf("size = %q", q.Get("size"))
+		}
+		_, _ = w.Write([]byte(`{
+			"result": {
+				"pagingParam": {"number": 0, "size": 50, "key": "abc", "range": "", "filters": "0", "type": ""},
+				"body": [
+					{
+						"type": "1",
+						"transactionType": {"code": "5", "displayName": "매수"},
+						"displayType": "50",
+						"summary": null,
+						"stockCode": "A999001",
+						"stockName": "샘플종목1",
+						"productName": "샘플종목1",
+						"quantity": 10.0,
+						"amount": 1000000.0,
+						"adjustedAmount": -1000000.0,
+						"commissionAmount": 0.0,
+						"totalTaxAmount": 0.0,
+						"date": "2024-01-15",
+						"settlementDate": "2024-01-17",
+						"compositeKey": {"orderDate": "2024-01-15", "tradeType": "buy", "stockCode": "A999001", "assetIoType": null, "id": null}
+					},
+					{
+						"type": "2",
+						"transactionType": {"code": "1", "displayName": "입금"},
+						"displayType": "13",
+						"summary": "배당금입금",
+						"stockCode": "A999002",
+						"stockName": "샘플종목2",
+						"quantity": 0.0,
+						"amount": 10000.0,
+						"adjustedAmount": 8000.0,
+						"commissionAmount": 0.0,
+						"totalTaxAmount": 2000.0,
+						"balanceAmount": 500000.0,
+						"cancelTradeYn": false,
+						"summaryNo": "0001",
+						"tradeTypeName": "배당금입금",
+						"dateTime": "2024-01-15 10:00:00.000",
+						"referenceType": null,
+						"compositeKey": {"date": "2024-01-15", "no": 1}
+					}
+				],
+				"lastPage": true,
+				"allAsset": true
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		HTTPClient:  server.Client(),
+		APIBaseURL:  server.URL,
+		InfoBaseURL: server.URL,
+		CertBaseURL: server.URL,
+		Session: &session.Session{
+			Cookies: map[string]string{"SESSION": "test-session"},
+		},
+	})
+
+	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.Local)
+	to := time.Date(2024, 1, 15, 0, 0, 0, 0, time.Local)
+	page, err := client.ListTransactions(context.Background(), "kr", from, to, "all", 0, 0)
+	if err != nil {
+		t.Fatalf("ListTransactions returned error: %v", err)
+	}
+
+	if len(page.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(page.Items))
+	}
+	if !page.LastPage {
+		t.Fatal("expected lastPage=true")
+	}
+
+	trade := page.Items[0]
+	if trade.Category != "trade" {
+		t.Fatalf("first item category = %q, want trade", trade.Category)
+	}
+	if trade.DisplayName != "매수" {
+		t.Fatalf("trade displayName = %q", trade.DisplayName)
+	}
+	if trade.AdjustedAmount != -1000000.0 {
+		t.Fatalf("trade adjusted = %v", trade.AdjustedAmount)
+	}
+	if trade.Currency != "KRW" {
+		t.Fatalf("trade currency = %q", trade.Currency)
+	}
+	if trade.SettlementDate != "2024-01-17" {
+		t.Fatalf("trade settlement = %q", trade.SettlementDate)
+	}
+	if trade.TradeType != "buy" {
+		t.Fatalf("trade tradeType = %q", trade.TradeType)
+	}
+
+	cash := page.Items[1]
+	if cash.Category != "cash" {
+		t.Fatalf("second item category = %q, want cash", cash.Category)
+	}
+	if cash.Summary != "배당금입금" {
+		t.Fatalf("cash summary = %q", cash.Summary)
+	}
+	if cash.BalanceAmount != 500000.0 {
+		t.Fatalf("cash balance = %v", cash.BalanceAmount)
+	}
+	if cash.DateTime != "2024-01-15 10:00:00.000" {
+		t.Fatalf("cash datetime = %q", cash.DateTime)
+	}
+}
+
+func TestListTransactionsRejectsOversizeRange(t *testing.T) {
+	t.Parallel()
+	client := New(Config{
+		Session: &session.Session{Cookies: map[string]string{"x": "y"}},
+	})
+	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	_, err := client.ListTransactions(context.Background(), "kr", from, to, "all", 0, 0)
+	if err == nil {
+		t.Fatal("expected error for oversize range")
+	}
+}
+
+func TestListTransactionsRejectsInvalidMarket(t *testing.T) {
+	t.Parallel()
+	client := New(Config{
+		Session: &session.Session{Cookies: map[string]string{"x": "y"}},
+	})
+	_, err := client.ListTransactions(context.Background(), "jp", time.Time{}, time.Time{}, "all", 0, 0)
+	if err == nil {
+		t.Fatal("expected error for unsupported market")
+	}
+}
+
+func TestListAllTransactionsPagesUntilLastPage(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		to := r.URL.Query().Get("range.to")
+		switch to {
+		case "2026-04-19":
+			// First page: oldest item on 2026-04-01 — client should narrow range.to to 2026-04-01 next.
+			_, _ = w.Write([]byte(`{"result":{"pagingParam":{"number":0,"size":2},"body":[
+				{"type":"1","transactionType":{"code":"5","displayName":"매수"},"stockCode":"A","stockName":"A Inc","amount":100,"adjustedAmount":-100,"date":"2026-04-01","compositeKey":{"orderDate":"2026-04-01","tradeType":"buy","id":111}}
+			],"lastPage":false}}`))
+		case "2026-04-01":
+			_, _ = w.Write([]byte(`{"result":{"pagingParam":{"number":0,"size":2},"body":[
+				{"type":"2","transactionType":{"code":"1","displayName":"입금"},"stockCode":"B","stockName":"B Inc","amount":50,"adjustedAmount":50,"dateTime":"2026-03-15 10:00:00.000","compositeKey":{"date":"2026-03-15","no":2}}
+			],"lastPage":true}}`))
+		default:
+			t.Fatalf("unexpected range.to=%s (call #%d)", to, calls)
+		}
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		HTTPClient:  server.Client(),
+		APIBaseURL:  server.URL,
+		InfoBaseURL: server.URL,
+		CertBaseURL: server.URL,
+		Session:     &session.Session{Cookies: map[string]string{"SESSION": "x"}},
+	})
+
+	items, err := client.ListAllTransactions(
+		context.Background(), "kr",
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.Local),
+		time.Date(2026, 4, 19, 0, 0, 0, 0, time.Local),
+		"all", 0, 5,
+	)
+	if err != nil {
+		t.Fatalf("ListAllTransactions error: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 page fetches, got %d", calls)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if items[0].Category != "trade" || items[1].Category != "cash" {
+		t.Fatalf("unexpected categories: %v / %v", items[0].Category, items[1].Category)
+	}
+}
+
+func TestGetTransactionsOverviewParsesBuckets(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/my-assets/transactions/markets/kr/overview" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"result":{
+			"orderableAmount":{"krw":100000,"usd":null},
+			"withdrawableAmount":{
+				"amount0":{"krw":100000,"usd":null},"date0":"2024-01-15",
+				"amount1":{"krw":100000,"usd":null},"date1":"2024-01-16",
+				"amount2":null,"date2":null,
+				"amount3":null,"date3":null
+			},
+			"depositAmount":{
+				"amount0":{"krw":1000,"usd":null},"date0":"2024-01-17",
+				"amount1":null,"date1":null,
+				"amount2":null,"date2":null,
+				"amount3":null,"date3":null
+			},
+			"estimateSettlementAmount":{
+				"day1":{"settlementKorDate":"2024-01-16","buyAmount":1000,"sellAmount":0},
+				"day2":{"settlementKorDate":"2024-01-17","buyAmount":0,"sellAmount":2000}
+			},
+			"withdrawableAmountBottomSheet":[
+				{"title":"출금가능금액","amount":{"krw":100000,"usd":null}}
+			]
+		}}`))
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		HTTPClient:  server.Client(),
+		APIBaseURL:  server.URL,
+		InfoBaseURL: server.URL,
+		CertBaseURL: server.URL,
+		Session:     &session.Session{Cookies: map[string]string{"SESSION": "x"}},
+	})
+
+	ov, err := client.GetTransactionsOverview(context.Background(), "kr")
+	if err != nil {
+		t.Fatalf("GetTransactionsOverview error: %v", err)
+	}
+	if ov.OrderableKRW != 100000 {
+		t.Fatalf("orderableKRW = %v", ov.OrderableKRW)
+	}
+	if len(ov.Withdrawable) != 2 {
+		t.Fatalf("withdrawable buckets = %d (want 2)", len(ov.Withdrawable))
+	}
+	if len(ov.Deposit) != 1 {
+		t.Fatalf("deposit buckets = %d (want 1)", len(ov.Deposit))
+	}
+	if len(ov.EstimateSettlement) != 2 {
+		t.Fatalf("settlement = %d", len(ov.EstimateSettlement))
+	}
+	if ov.EstimateSettlement[1].SellAmount != 2000 {
+		t.Fatalf("settlement day2 sell = %v", ov.EstimateSettlement[1].SellAmount)
+	}
+	if len(ov.WithdrawableBottomSheet) != 1 || ov.WithdrawableBottomSheet[0].Title != "출금가능금액" {
+		t.Fatalf("bottom sheet parse failed: %+v", ov.WithdrawableBottomSheet)
+	}
+}
+
+func TestExtractTransactionDatePrefersOrderDateOverSettlement(t *testing.T) {
+	t.Parallel()
+	// US type=1 trade records leave date/dateTime null; only orderDate (past)
+	// and settlementDate (future T+2) are set. The range filter must use
+	// orderDate so a trade placed on 2026-04-17 isn't excluded from --to 2026-04-19.
+	tx := domain.Transaction{
+		OrderDate:      "2026-04-17",
+		SettlementDate: "2026-04-21",
+	}
+	got := extractTransactionDate(tx)
+	want := time.Date(2026, 4, 17, 0, 0, 0, 0, KoreaLocation)
+	if !got.Equal(want) {
+		t.Fatalf("extractTransactionDate = %v, want %v (OrderDate must win over SettlementDate)", got, want)
+	}
+}
+
+func TestListTransactionsFiltersOutOfRangeItems(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":{
+			"pagingParam":{"number":0,"size":50,"key":"","filters":"0","type":""},
+			"body":[
+				{"type":"1","transactionType":{"code":"5","displayName":"매수"},"stockCode":"A999001","amount":200,"adjustedAmount":-200,"date":"2024-02-01"},
+				{"type":"1","transactionType":{"code":"5","displayName":"매수"},"stockCode":"A999002","amount":100,"adjustedAmount":-100,"date":"2024-01-10"}
+			],
+			"lastPage":true
+		}}`))
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		HTTPClient:  server.Client(),
+		APIBaseURL:  server.URL,
+		InfoBaseURL: server.URL,
+		CertBaseURL: server.URL,
+		Session:     &session.Session{Cookies: map[string]string{"SESSION": "x"}},
+	})
+
+	page, err := client.ListTransactions(
+		context.Background(), "kr",
+		time.Date(2024, 1, 15, 0, 0, 0, 0, KoreaLocation),
+		time.Date(2024, 2, 28, 0, 0, 0, 0, KoreaLocation),
+		"all", 0, 0,
+	)
+	if err != nil {
+		t.Fatalf("ListTransactions error: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("expected 1 item after range filter (Toss ignores range.from), got %d", len(page.Items))
+	}
+	if page.Items[0].StockCode != "A999001" {
+		t.Fatalf("expected to keep 2024-02-01 item, got StockCode=%q", page.Items[0].StockCode)
+	}
+}
+
+func TestListTransactionsUnwrapsPagingScalars(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":{
+			"pagingParam":{"number":0,"size":50,"key":"abc","filters":"0","type":""},
+			"body":[{"type":"1","transactionType":{"code":"5","displayName":"매수"},"amount":1,"adjustedAmount":-1,"date":"2026-04-17"}],
+			"lastPage":false
+		}}`))
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		HTTPClient:  server.Client(),
+		APIBaseURL:  server.URL,
+		InfoBaseURL: server.URL,
+		CertBaseURL: server.URL,
+		Session:     &session.Session{Cookies: map[string]string{"SESSION": "x"}},
+	})
+
+	page, err := client.ListTransactions(
+		context.Background(), "kr",
+		time.Date(2026, 4, 1, 0, 0, 0, 0, KoreaLocation),
+		time.Date(2026, 4, 19, 0, 0, 0, 0, KoreaLocation),
+		"all", 0, 0,
+	)
+	if err != nil {
+		t.Fatalf("ListTransactions error: %v", err)
+	}
+	if page.Next == nil {
+		t.Fatal("expected Next pagination cursor")
+	}
+	if page.Next.Filters != "0" {
+		t.Fatalf("Next.Filters = %q, want %q (no JSON quoting)", page.Next.Filters, "0")
+	}
+	if page.Next.Type != "" {
+		t.Fatalf("Next.Type = %q, want empty", page.Next.Type)
+	}
+}
+
+func TestRawJSONScalarToString(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		``:        "",
+		`null`:    "",
+		`"0"`:     "0",
+		`"hello"`: "hello",
+		`42`:      "42",
+	}
+	for in, want := range cases {
+		got := rawJSONScalarToString([]byte(in))
+		if got != want {
+			t.Fatalf("rawJSONScalarToString(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseTransactionFilter(t *testing.T) {
+	t.Parallel()
+	cases := map[string]TransactionFilter{
+		"":         TransactionFilterAll,
+		"all":      TransactionFilterAll,
+		"trade":    TransactionFilterTrades,
+		"trades":   TransactionFilterTrades,
+		"cash":     TransactionFilterCash,
+		"inout":    TransactionFilterInOut,
+		"transfer": TransactionFilterInOut,
+		"cash-alt": TransactionFilterCashAlt,
+		"cashalt":  TransactionFilterCashAlt,
+		"0":        TransactionFilterAll,
+		"1":        TransactionFilterTrades,
+		"2":        TransactionFilterCash,
+		"3":        TransactionFilterInOut,
+		"6":        TransactionFilterCashAlt,
+	}
+	for in, want := range cases {
+		got, err := parseTransactionFilter(in)
+		if err != nil {
+			t.Fatalf("parseTransactionFilter(%q) error: %v", in, err)
+		}
+		if got != want {
+			t.Fatalf("parseTransactionFilter(%q) = %v, want %v", in, got, want)
+		}
+	}
+
+	if _, err := parseTransactionFilter("42"); err == nil {
+		t.Fatal("expected error for unsupported numeric")
+	}
+	if _, err := parseTransactionFilter("garbage"); err == nil {
+		t.Fatal("expected error for unknown name")
+	}
+}

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -88,6 +88,78 @@ type WatchlistItem struct {
 	Last     float64 `json:"last,omitempty"`
 }
 
+type Transaction struct {
+	Type             string          `json:"type"`
+	Category         string          `json:"category"`
+	Code             string          `json:"code,omitempty"`
+	DisplayName      string          `json:"display_name,omitempty"`
+	DisplayType      string          `json:"display_type,omitempty"`
+	Summary          string          `json:"summary,omitempty"`
+	Market           string          `json:"market"`
+	Currency         string          `json:"currency"`
+	StockCode        string          `json:"stock_code,omitempty"`
+	StockName        string          `json:"stock_name,omitempty"`
+	Quantity         float64         `json:"quantity,omitempty"`
+	Amount           float64         `json:"amount"`
+	AdjustedAmount   float64         `json:"adjusted_amount"`
+	CommissionAmount float64         `json:"commission_amount,omitempty"`
+	TaxAmount        float64         `json:"tax_amount,omitempty"`
+	BalanceAmount    float64         `json:"balance_amount,omitempty"`
+	Date             string          `json:"date,omitempty"`
+	DateTime         string          `json:"datetime,omitempty"`
+	OrderDate        string          `json:"order_date,omitempty"`
+	SettlementDate   string          `json:"settlement_date,omitempty"`
+	TradeType        string          `json:"trade_type,omitempty"`
+	ReferenceType    string          `json:"reference_type,omitempty"`
+	ReferenceID      string          `json:"reference_id,omitempty"`
+	SortKey          string          `json:"sort_key,omitempty"`
+	Raw              json.RawMessage `json:"raw,omitempty"`
+}
+
+type TransactionPage struct {
+	Market   string        `json:"market"`
+	Items    []Transaction `json:"items"`
+	LastPage bool          `json:"last_page"`
+	Next     *PagingParam  `json:"next,omitempty"`
+}
+
+type PagingParam struct {
+	Number  int    `json:"number,omitempty"`
+	Size    int    `json:"size,omitempty"`
+	Key     string `json:"key,omitempty"`
+	Filters string `json:"filters,omitempty"`
+	Type    string `json:"type,omitempty"`
+}
+
+type TransactionOverview struct {
+	Market                  string                         `json:"market"`
+	OrderableKRW            float64                        `json:"orderable_krw"`
+	OrderableUSD            float64                        `json:"orderable_usd"`
+	Withdrawable            []SettlementBucket             `json:"withdrawable,omitempty"`
+	DisplayWithdrawable     []SettlementBucket             `json:"display_withdrawable,omitempty"`
+	Deposit                 []SettlementBucket             `json:"deposit,omitempty"`
+	EstimateSettlement      []SettlementEstimate           `json:"estimate_settlement,omitempty"`
+	WithdrawableBottomSheet []WithdrawableBottomSheetEntry `json:"withdrawable_bottom_sheet,omitempty"`
+}
+
+type SettlementBucket struct {
+	Date string  `json:"date,omitempty"`
+	KRW  float64 `json:"krw,omitempty"`
+	USD  float64 `json:"usd,omitempty"`
+}
+
+type SettlementEstimate struct {
+	Date       string  `json:"date,omitempty"`
+	BuyAmount  float64 `json:"buy_amount,omitempty"`
+	SellAmount float64 `json:"sell_amount,omitempty"`
+}
+
+type WithdrawableBottomSheetEntry struct {
+	Title string  `json:"title"`
+	KRW   float64 `json:"krw,omitempty"`
+	USD   float64 `json:"usd,omitempty"`
+}
+
 type Quote struct {
 	ProductCode    string    `json:"product_code,omitempty"`
 	Symbol         string    `json:"symbol"`

--- a/internal/output/transactions.go
+++ b/internal/output/transactions.go
@@ -1,0 +1,259 @@
+package output
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/domain"
+)
+
+func WriteTransactions(w io.Writer, format Format, items []domain.Transaction) error {
+	switch format {
+	case FormatJSON:
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(items)
+	case FormatCSV:
+		writer := csv.NewWriter(w)
+		if err := writer.Write([]string{
+			"date", "datetime", "market", "currency", "category", "type", "display_type", "code", "display_name",
+			"stock_code", "stock_name", "quantity", "amount", "adjusted_amount",
+			"commission", "tax", "balance", "settlement_date", "summary",
+			"reference_type", "reference_id", "sort_key",
+		}); err != nil {
+			return err
+		}
+		for _, it := range items {
+			if err := writer.Write([]string{
+				it.Date,
+				it.DateTime,
+				it.Market,
+				it.Currency,
+				it.Category,
+				it.Type,
+				it.DisplayType,
+				it.Code,
+				it.DisplayName,
+				it.StockCode,
+				it.StockName,
+				strconv.FormatFloat(it.Quantity, 'f', -1, 64),
+				strconv.FormatFloat(it.Amount, 'f', -1, 64),
+				strconv.FormatFloat(it.AdjustedAmount, 'f', -1, 64),
+				strconv.FormatFloat(it.CommissionAmount, 'f', -1, 64),
+				strconv.FormatFloat(it.TaxAmount, 'f', -1, 64),
+				strconv.FormatFloat(it.BalanceAmount, 'f', -1, 64),
+				it.SettlementDate,
+				it.Summary,
+				it.ReferenceType,
+				it.ReferenceID,
+				it.SortKey,
+			}); err != nil {
+				return err
+			}
+		}
+		writer.Flush()
+		return writer.Error()
+	case FormatTable:
+		if len(items) == 0 {
+			_, err := fmt.Fprintln(w, "No transactions in range")
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "Transactions: %d\n", len(items)); err != nil {
+			return err
+		}
+		headers := []string{"일시", "시장", "유형", "종목", "수량", "금액", "순현금", "잔고"}
+		rows := make([][]string, 0, len(items))
+		for _, it := range items {
+			when := it.DateTime
+			if when == "" {
+				when = it.Date
+			}
+			if when == "" {
+				when = it.SettlementDate
+			}
+			if len(when) > 19 {
+				when = when[:19]
+			}
+			label := it.DisplayName
+			if it.Summary != "" && it.Summary != it.DisplayName {
+				label = it.DisplayName + " (" + it.Summary + ")"
+			}
+			name := it.StockName
+			if name == "" {
+				name = it.StockCode
+			}
+			rows = append(rows, []string{
+				when,
+				strings.ToUpper(it.Market),
+				label,
+				truncateName(name, 14),
+				formatQty(it.Quantity),
+				formatAmountByMarket(it.Market, it.Amount),
+				formatAmountByMarket(it.Market, it.AdjustedAmount),
+				formatAmountByMarket(it.Market, it.BalanceAmount),
+			})
+		}
+		return renderTable(w, headers, rows)
+	default:
+		return fmt.Errorf("unsupported output format: %s", format)
+	}
+}
+
+func WriteTransactionsOverview(w io.Writer, format Format, overview domain.TransactionOverview) error {
+	switch format {
+	case FormatJSON:
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(overview)
+	case FormatCSV:
+		writer := csv.NewWriter(w)
+		if err := writer.Write([]string{"section", "date", "krw", "usd", "note"}); err != nil {
+			return err
+		}
+		writeBuckets := func(section string, list []domain.SettlementBucket) error {
+			for _, b := range list {
+				if err := writer.Write([]string{
+					section, b.Date,
+					strconv.FormatFloat(b.KRW, 'f', -1, 64),
+					strconv.FormatFloat(b.USD, 'f', -1, 64),
+					"",
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		if err := writer.Write([]string{"orderable", "", strconv.FormatFloat(overview.OrderableKRW, 'f', -1, 64), strconv.FormatFloat(overview.OrderableUSD, 'f', -1, 64), ""}); err != nil {
+			return err
+		}
+		if err := writeBuckets("withdrawable", overview.Withdrawable); err != nil {
+			return err
+		}
+		if err := writeBuckets("display_withdrawable", overview.DisplayWithdrawable); err != nil {
+			return err
+		}
+		if err := writeBuckets("deposit", overview.Deposit); err != nil {
+			return err
+		}
+		for _, e := range overview.EstimateSettlement {
+			if err := writer.Write([]string{
+				"settlement", e.Date,
+				strconv.FormatFloat(e.BuyAmount, 'f', -1, 64),
+				strconv.FormatFloat(e.SellAmount, 'f', -1, 64),
+				"buy/sell",
+			}); err != nil {
+				return err
+			}
+		}
+		for _, b := range overview.WithdrawableBottomSheet {
+			if err := writer.Write([]string{
+				"withdrawable_breakdown", "",
+				strconv.FormatFloat(b.KRW, 'f', -1, 64),
+				strconv.FormatFloat(b.USD, 'f', -1, 64),
+				b.Title,
+			}); err != nil {
+				return err
+			}
+		}
+		writer.Flush()
+		return writer.Error()
+	case FormatTable:
+		market := strings.ToUpper(overview.Market)
+		if _, err := fmt.Fprintf(w, "Market: %s\n", market); err != nil {
+			return err
+		}
+		// Toss returns the US orderable/settlement amounts both in USD and in their
+		// KRW equivalence; they represent the same money, not two separate pools.
+		// Table view shows only the market's primary currency; JSON preserves both.
+		primary := primaryCurrencyCode(overview.Market)
+		if _, err := fmt.Fprintf(w, "Orderable: %s %s\n", primary,
+			pickPrimaryAmount(overview.Market, overview.OrderableKRW, overview.OrderableUSD)); err != nil {
+			return err
+		}
+		if err := renderBucketsForMarket(w, "Withdrawable:", "날짜", primary, overview.Market, overview.Withdrawable); err != nil {
+			return err
+		}
+		if err := renderBucketsForMarket(w, "Display withdrawable:", "날짜", primary, overview.Market, overview.DisplayWithdrawable); err != nil {
+			return err
+		}
+		if err := renderBucketsForMarket(w, "Deposit schedule:", "날짜", primary, overview.Market, overview.Deposit); err != nil {
+			return err
+		}
+		if len(overview.EstimateSettlement) > 0 {
+			fmt.Fprintln(w, "\nEstimated settlement:")
+			headers := []string{"날짜", "매수", "매도"}
+			rows := make([][]string, 0, len(overview.EstimateSettlement))
+			for _, e := range overview.EstimateSettlement {
+				rows = append(rows, []string{
+					e.Date,
+					formatAmountByMarket(overview.Market, e.BuyAmount),
+					formatAmountByMarket(overview.Market, e.SellAmount),
+				})
+			}
+			if err := renderTable(w, headers, rows); err != nil {
+				return err
+			}
+		}
+		if len(overview.WithdrawableBottomSheet) > 0 {
+			fmt.Fprintln(w, "\nWithdrawable breakdown:")
+			headers := []string{"항목", primary}
+			rows := make([][]string, 0, len(overview.WithdrawableBottomSheet))
+			for _, b := range overview.WithdrawableBottomSheet {
+				rows = append(rows, []string{b.Title, pickPrimaryAmount(overview.Market, b.KRW, b.USD)})
+			}
+			if err := renderTable(w, headers, rows); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported output format: %s", format)
+	}
+}
+
+func formatAmountByMarket(market string, v float64) string {
+	if strings.EqualFold(market, "us") {
+		return formatUSD(v)
+	}
+	return formatKRW(v)
+}
+
+// primaryCurrencyCode returns the column header label for the market's primary
+// currency (USD for us, KRW for everything else including kr).
+func primaryCurrencyCode(market string) string {
+	if strings.EqualFold(market, "us") {
+		return "USD"
+	}
+	return "KRW"
+}
+
+// pickPrimaryAmount formats the market-primary currency amount. Toss returns USD
+// market values as both KRW-equivalent and USD; they are the same money so table
+// view shows only USD for US and KRW for KR.
+func pickPrimaryAmount(market string, krw, usd float64) string {
+	if strings.EqualFold(market, "us") {
+		return formatUSD(usd)
+	}
+	return formatKRW(krw)
+}
+
+// renderBucketsForMarket prints a settlement bucket table with a single amount
+// column matching the market's primary currency.
+func renderBucketsForMarket(w io.Writer, title, dateHeader, primary, market string, buckets []domain.SettlementBucket) error {
+	if len(buckets) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintln(w, "\n"+title); err != nil {
+		return err
+	}
+	headers := []string{dateHeader, primary}
+	rows := make([][]string, 0, len(buckets))
+	for _, b := range buckets {
+		rows = append(rows, []string{b.Date, pickPrimaryAmount(market, b.KRW, b.USD)})
+	}
+	return renderTable(w, headers, rows)
+}

--- a/internal/output/transactions_test.go
+++ b/internal/output/transactions_test.go
@@ -1,0 +1,206 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/domain"
+)
+
+var testTransactions = []domain.Transaction{
+	{
+		Type:           "1",
+		Category:       "trade",
+		Code:           "5",
+		DisplayName:    "매수",
+		DisplayType:    "50",
+		Market:         "kr",
+		Currency:       "KRW",
+		StockCode:      "A999001",
+		StockName:      "샘플종목1",
+		Quantity:       10,
+		Amount:         1000000,
+		AdjustedAmount: -1000000,
+		Date:           "2024-01-15",
+		SettlementDate: "2024-01-17",
+		TradeType:      "buy",
+		SortKey:        "2024-01-15|A999001",
+	},
+	{
+		Type:           "2",
+		Category:       "cash",
+		Code:           "1",
+		DisplayName:    "입금",
+		DisplayType:    "13",
+		Summary:        "배당금입금",
+		Market:         "kr",
+		Currency:       "KRW",
+		StockCode:      "A999002",
+		StockName:      "샘플종목2",
+		Amount:         10000,
+		AdjustedAmount: 8000,
+		TaxAmount:      2000,
+		BalanceAmount:  500000,
+		DateTime:       "2024-01-15 10:00:00.000",
+		SortKey:        "2024-01-15 10:00:00.000|0001",
+	},
+}
+
+var testOverview = domain.TransactionOverview{
+	Market:       "kr",
+	OrderableKRW: 100000,
+	Withdrawable: []domain.SettlementBucket{
+		{Date: "2024-01-15", KRW: 100000},
+		{Date: "2024-01-16", KRW: 100000},
+	},
+	DisplayWithdrawable: []domain.SettlementBucket{
+		{Date: "2024-01-15", KRW: 100000},
+	},
+	Deposit: []domain.SettlementBucket{
+		{Date: "2024-01-17", KRW: 1000},
+	},
+	EstimateSettlement: []domain.SettlementEstimate{
+		{Date: "2024-01-16", BuyAmount: 1000},
+		{Date: "2024-01-17", SellAmount: 2000},
+	},
+	WithdrawableBottomSheet: []domain.WithdrawableBottomSheetEntry{
+		{Title: "출금가능금액", KRW: 100000},
+	},
+}
+
+func TestWriteTransactionsJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteTransactions(&buf, FormatJSON, testTransactions); err != nil {
+		t.Fatalf("WriteTransactions JSON error: %v", err)
+	}
+	var parsed []domain.Transaction
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("JSON unmarshal error: %v", err)
+	}
+	if len(parsed) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(parsed))
+	}
+	if parsed[0].DisplayName != "매수" {
+		t.Fatalf("parsed[0].DisplayName = %q", parsed[0].DisplayName)
+	}
+}
+
+func TestWriteTransactionsCSV(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteTransactions(&buf, FormatCSV, testTransactions); err != nil {
+		t.Fatalf("WriteTransactions CSV error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 CSV lines (header + 2), got %d", len(lines))
+	}
+	header := lines[0]
+	for _, col := range []string{"display_type", "display_name", "adjusted_amount", "sort_key"} {
+		if !strings.Contains(header, col) {
+			t.Fatalf("CSV header missing column %q: %s", col, header)
+		}
+	}
+	if !strings.Contains(lines[1], "샘플종목1") {
+		t.Fatalf("expected 샘플종목1 row, got %s", lines[1])
+	}
+	if !strings.Contains(lines[2], "배당금입금") {
+		t.Fatalf("expected 배당 row, got %s", lines[2])
+	}
+}
+
+func TestWriteTransactionsTable(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteTransactions(&buf, FormatTable, testTransactions); err != nil {
+		t.Fatalf("WriteTransactions Table error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "Transactions: 2") {
+		t.Fatalf("expected count header, got %s", output)
+	}
+	if !strings.Contains(output, "샘플종목1") {
+		t.Fatalf("expected 샘플종목1 in table output")
+	}
+	if !strings.Contains(output, "매수") {
+		t.Fatalf("expected 매수 in table output")
+	}
+	if !strings.Contains(output, "배당금입금") {
+		t.Fatalf("expected summary annotation in table output")
+	}
+}
+
+func TestWriteTransactionsTableEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteTransactions(&buf, FormatTable, nil); err != nil {
+		t.Fatalf("WriteTransactions empty error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No transactions in range") {
+		t.Fatalf("expected empty-state message, got %s", buf.String())
+	}
+}
+
+func TestWriteTransactionsUnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteTransactions(&buf, "yaml", testTransactions); err == nil {
+		t.Fatal("expected error for unsupported format")
+	}
+}
+
+func TestWriteTransactionsOverviewCSV(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteTransactionsOverview(&buf, FormatCSV, testOverview); err != nil {
+		t.Fatalf("WriteTransactionsOverview CSV error: %v", err)
+	}
+	out := buf.String()
+	for _, section := range []string{
+		"orderable", "withdrawable", "display_withdrawable", "deposit", "settlement", "withdrawable_breakdown",
+	} {
+		if !strings.Contains(out, section) {
+			t.Fatalf("CSV missing section %q:\n%s", section, out)
+		}
+	}
+}
+
+func TestWriteTransactionsOverviewTable(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteTransactionsOverview(&buf, FormatTable, testOverview); err != nil {
+		t.Fatalf("WriteTransactionsOverview Table error: %v", err)
+	}
+	out := buf.String()
+	for _, heading := range []string{
+		"Market: KR", "Orderable:", "Withdrawable:", "Display withdrawable:",
+		"Deposit schedule:", "Estimated settlement:", "Withdrawable breakdown:",
+	} {
+		if !strings.Contains(out, heading) {
+			t.Fatalf("Table missing %q:\n%s", heading, out)
+		}
+	}
+	if !strings.Contains(out, "출금가능금액") {
+		t.Fatalf("bottom sheet title missing in table:\n%s", out)
+	}
+}
+
+func TestWriteTransactionsOverviewJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteTransactionsOverview(&buf, FormatJSON, testOverview); err != nil {
+		t.Fatalf("WriteTransactionsOverview JSON error: %v", err)
+	}
+	var parsed domain.TransactionOverview
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("JSON unmarshal error: %v", err)
+	}
+	if parsed.Market != "kr" || parsed.OrderableKRW != 100000 {
+		t.Fatalf("unexpected parse: %+v", parsed)
+	}
+	if len(parsed.DisplayWithdrawable) != 1 {
+		t.Fatalf("display_withdrawable round-trip failed: %+v", parsed.DisplayWithdrawable)
+	}
+}
+
+func TestWriteTransactionsOverviewUnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteTransactionsOverview(&buf, "yaml", testOverview); err == nil {
+		t.Fatal("expected error for unsupported format")
+	}
+}


### PR DESCRIPTION
## 변경 사항

`tossctl transactions` 커맨드 그룹을 추가해 `/my-assets` 거래내역 엔드포인트를 읽기 전용으로 노출합니다.

- `tossctl transactions list` — 시장별(kr/us) 거래·현금흐름·주식 입출고를 `[from, to]` 범위로 조회. `--filter`(0/1/2/3/6 또는 all/trade/cash/inout/cash-alt), `--size`, `--number`, `--all`(자동 페이징) 지원.
- `tossctl transactions overview` — 주문가능·출금가능·예상 결제 요약.
- 출력 포맷: table / JSON / CSV. 테이블은 시장 기본 통화 한 열만, JSON/CSV는 `krw`/`usd` 둘 다 보존.
- 날짜 경계는 Asia/Seoul 기준(tzdata 미설치 시 +09:00 폴백).

### 구현 주의점
- Toss가 `range.from`과 `number`를 무시하고 `range.to`에서 `size`개만 역방향으로 반환 → 클라이언트가 `range.to`를 좁히며 페이징 + `SortKey` 기반 dedup + `[from, to]` 윈도우 필터.
- US `type=1` 거래 레코드는 `date`/`dateTime` 없이 `settlementDate`(T+2)만 채워지므로, range 필터는 `compositeKey.orderDate`를 우선 사용.

엔드포인트 계약은 [docs/reverse-engineering/rpc-catalog.md](docs/reverse-engineering/rpc-catalog.md)에 추가.

## 영향 범위

- [x] 조회 (읽기 전용)
- [ ] 거래 (mutation)
- [ ] 설치 / CI
- [x] 문서

## 테스트

- [x] \`make test\` 통과 (신규 유닛 테스트: client 7건 + output 9건)
- [x] 수동 확인 완료 (KR/US 실계정 smoke: overview + list 각 포맷, --all 페이징, --filter 조합)

## 체크리스트

- [x] 기존 동작을 깨뜨리지 않음
- [x] 거래 관련 변경 없음 — mutation 경로 무추가, 기존 config gate/confirm token 미변경