### PR TITLE
feat(auth): support uv-managed Python for auth-helper

### DIFF
--- a/auth-helper/README.md
+++ b/auth-helper/README.md
@@ -28,3 +28,18 @@ python3 -m tossctl_auth_helper login --storage-state /tmp/tossctl-storage-state.
 > Google Chrome이 시스템에 설치되어 있어야 합니다. `playwright install chromium`은 더 이상 필요하지 않습니다.
 
 The helper emits JSON on stdout. On success it returns `status=ok` and the path of the saved Playwright storage-state file.
+
+## Python 선택 (tossctl auth login)
+
+`tossctl auth login`이 helper를 실행할 때 쓰는 Python은 아래 순서로 결정됩니다.
+
+1. `TOSSCTL_AUTH_HELPER_PYTHON` (명시적 override — 있으면 그대로 사용)
+2. uv tool이 관리하는 Python (있는 첫 번째가 선택됨)
+   - `$UV_TOOL_DIR/tossctl-auth-helper/bin/python`
+   - `$UV_TOOL_DIR/playwright/bin/python`
+   - `$XDG_DATA_HOME/uv/tools/...`
+   - `~/.local/share/uv/tools/...`
+   - Windows: `%APPDATA%/uv/tools/...` 또는 `Scripts/python.exe`
+3. PATH 상의 `python3`
+
+즉 `uv tool install ./auth-helper` 또는 `uv tool install playwright`로 준비해 두면 전역 python 환경을 오염시키지 않고 helper를 실행할 수 있습니다. 다른 Python을 쓰고 싶을 때는 `TOSSCTL_AUTH_HELPER_PYTHON`으로 덮어쓰면 됩니다.

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -52,7 +53,7 @@ type SessionValidator interface {
 func DefaultLoginConfig(cacheDir string) LoginConfig {
 	pythonBin := os.Getenv("TOSSCTL_AUTH_HELPER_PYTHON")
 	if pythonBin == "" {
-		pythonBin = "python3"
+		pythonBin = resolveDefaultPythonBin()
 	}
 
 	helperDir := os.Getenv("TOSSCTL_AUTH_HELPER_DIR")
@@ -70,6 +71,58 @@ func DefaultLoginConfig(cacheDir string) LoginConfig {
 		HelperDir:        helperDir,
 		StorageStatePath: storageStatePath,
 	}
+}
+
+func resolveDefaultPythonBin() string {
+	for _, candidate := range defaultPythonCandidates() {
+		if candidate == "" {
+			continue
+		}
+		if _, err := exec.LookPath(candidate); err == nil {
+			return candidate
+		}
+	}
+	return "python3"
+}
+
+func defaultPythonCandidates() []string {
+	var candidates []string
+	for _, toolDir := range uvToolDirs() {
+		for _, tool := range uvToolNames {
+			candidates = append(candidates,
+				filepath.Join(toolDir, tool, "bin", "python"),
+				filepath.Join(toolDir, tool, "bin", "python3"),
+				filepath.Join(toolDir, tool, "Scripts", "python.exe"),
+			)
+		}
+	}
+	return append(candidates, "python3")
+}
+
+// `playwright` works as a candidate even though it lacks the helper module —
+// `python -m tossctl_auth_helper` resolves from cfg.HelperDir (cmd.Dir).
+var uvToolNames = []string{"tossctl-auth-helper", "playwright"}
+
+func uvToolDirs() []string {
+	var dirs []string
+
+	if dir := os.Getenv("UV_TOOL_DIR"); dir != "" {
+		dirs = append(dirs, dir)
+	}
+
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+		dirs = append(dirs, filepath.Join(xdg, "uv", "tools"))
+	}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, ".local", "share", "uv", "tools"))
+	}
+
+	if appdata := os.Getenv("APPDATA"); appdata != "" {
+		dirs = append(dirs, filepath.Join(appdata, "uv", "tools"))
+	}
+
+	return dirs
 }
 
 func resolveDefaultHelperDir() string {

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -171,6 +171,49 @@ func TestStatusCapturesValidationError(t *testing.T) {
 	}
 }
 
+func TestDefaultLoginConfigHonorsExplicitPythonOverride(t *testing.T) {
+	t.Setenv("TOSSCTL_AUTH_HELPER_PYTHON", "/custom/path/to/python")
+	t.Setenv("UV_TOOL_DIR", "")
+	t.Setenv("XDG_DATA_HOME", "")
+
+	cfg := DefaultLoginConfig(t.TempDir())
+	if cfg.PythonBin != "/custom/path/to/python" {
+		t.Fatalf("expected explicit override to win, got %q", cfg.PythonBin)
+	}
+}
+
+func TestDefaultLoginConfigPrefersUvToolPython(t *testing.T) {
+	toolDir := t.TempDir()
+	pythonPath := filepath.Join(toolDir, "tossctl-auth-helper", "bin", "python")
+	if err := os.MkdirAll(filepath.Dir(pythonPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(pythonPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write python stub: %v", err)
+	}
+
+	t.Setenv("TOSSCTL_AUTH_HELPER_PYTHON", "")
+	t.Setenv("UV_TOOL_DIR", toolDir)
+
+	cfg := DefaultLoginConfig(t.TempDir())
+	if cfg.PythonBin != pythonPath {
+		t.Fatalf("expected uv tool python %q, got %q", pythonPath, cfg.PythonBin)
+	}
+}
+
+func TestDefaultLoginConfigFallsBackToPython3(t *testing.T) {
+	t.Setenv("TOSSCTL_AUTH_HELPER_PYTHON", "")
+	t.Setenv("UV_TOOL_DIR", filepath.Join(t.TempDir(), "nonexistent"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(t.TempDir(), "nonexistent"))
+	t.Setenv("APPDATA", "")
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := DefaultLoginConfig(t.TempDir())
+	if cfg.PythonBin != "python3" {
+		t.Fatalf("expected python3 fallback, got %q", cfg.PythonBin)
+	}
+}
+
 func mustTime(t *testing.T, value string) time.Time {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- detect a uv tool managed Python install when no explicit helper Python is configured
- keep `TOSSCTL_AUTH_HELPER_PYTHON` as the highest-priority override in all cases
- fall back to `python3` on PATH when no uv tool install is found
- document the resolution order in `auth-helper/README.md` and add unit tests covering each branch

## Why
`tossctl auth login` launches the Python auth-helper through `LoginConfig.PythonBin`. The default was hardcoded to `python3`, which quietly depends on the user's global Python environment having Playwright available.

Users who install the helper or Playwright via `uv tool install` end up with a working Playwright environment inside the uv tool directory, but `python3` on PATH still misses it and login fails with an import error.

This change adds detection for uv tool managed Python in the common locations (`$UV_TOOL_DIR`, `$XDG_DATA_HOME/uv/tools`, `~/.local/share/uv/tools`, `%APPDATA%/uv/tools`) so `tossctl auth login` works out of the box in uv-managed setups. It is not a uv dependency: when no uv tool install is present the behavior is unchanged, and the explicit `TOSSCTL_AUTH_HELPER_PYTHON` override always wins.

## Validation
- `go test ./internal/auth/...`
- unit tests cover the explicit override, uv tool detection, and the `python3` fallback paths
