### PR TITLE
fix(auth): 로그인 유지 2차 인증까지 대기하여 영속 SESSION 저장

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **영속(Persistent) 세션 캡처** — `auth login` 이 폰의 "이 기기 로그인 유지" 2차 인증까지 기다린 뒤에 storage state 를 저장. 그 결과 `SESSION` 쿠키가 1년짜리 영속 쿠키로 저장되어 서버 idle timeout 면제 (≈1시간 후에도 401 나지 않음).
+- `auth status` / `auth import-playwright-state` 출력에 `Persistence` 필드 추가 — `persistent (expires ...)` 또는 `session-scoped (≈1h idle timeout)` 로 세션 수명 표시. JSON 출력에 `expires_at`, `persistent` 필드 포함.
+
+### Fixed
+- **1시간 뒤 401 재발** — 과거 `auth login` 이 QR 1차 인증 직후 종료하여 session-scoped SESSION 만 저장했고, 이로 인해 약 1시간 idle 후 서버가 세션을 invalidate 했던 문제. 이제 "이 기기 로그인 유지" 2차 확인까지 기다리며, 그 결과 얻은 persistent SESSION 을 저장하므로 긴 idle 에도 재로그인 불필요. (참고: `docs/reverse-engineering/auth-notes.md` — Session Lifetime 섹션)
+
 ## [0.3.6] - 2026-04-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ tossctl account summary --output json
 
 > `auth login`에는 Google Chrome과 Python이 필요하며, 설치 스크립트가 자동으로 설정합니다.
 > Windows, Homebrew, 소스 빌드 등 다른 설치 방법은 [설치](#설치) 섹션을 참고하세요.
+>
+> QR 스캔 후 폰에 뜨는 **"이 기기 로그인 유지"** 확인 프롬프트까지 꼭 눌러주세요.
+> 이 2차 확인을 건너뛰면 세션이 약 1시간 idle 후 만료되어 재로그인이 필요해집니다.
+> 정상 캡처 여부는 `tossctl auth status` 의 `Persistence: persistent cookie (expires ...)` 로 확인할 수 있습니다.
 
 ## 지원 범위
 

--- a/auth-helper/tossctl_auth_helper/cli.py
+++ b/auth-helper/tossctl_auth_helper/cli.py
@@ -23,6 +23,15 @@ REQUIRED_LOCAL_STORAGE_KEYS = {
     "login-method",
 }
 
+# When the user confirms "이 기기 로그인 유지" on their phone after QR auth,
+# Toss calls POST /api/v1/wts-login-device/check-with-login, whose response
+# re-issues the SESSION cookie with Max-Age=31536000 (1 year). If we save
+# storage state before that second confirmation, the SESSION is only
+# session-scoped (expires=-1) and the server invalidates it after ≈1h idle.
+# We wait for the persistent cookie before saving so the CLI inherits the
+# long-lived session.
+PERSISTENT_SESSION_MIN_TTL_SECONDS = 7 * 24 * 3600  # > 1 week out = definitely persistent
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -75,6 +84,17 @@ def local_storage_keys(storage_state: dict) -> set[str]:
     return set()
 
 
+def has_persistent_session_cookie(storage_state: dict) -> bool:
+    threshold = time.time() + PERSISTENT_SESSION_MIN_TTL_SECONDS
+    for cookie in storage_state.get("cookies", []):
+        if cookie.get("name") != "SESSION":
+            continue
+        expires = cookie.get("expires")
+        if isinstance(expires, (int, float)) and expires >= threshold:
+            return True
+    return False
+
+
 def command_login(args: argparse.Namespace) -> int:
     try:
         from playwright.sync_api import Error as PlaywrightError
@@ -100,19 +120,31 @@ def command_login(args: argparse.Namespace) -> int:
             log("Complete QR login in the browser window. The helper will continue after account cookies appear.")
 
             deadline = time.monotonic() + args.timeout_seconds
+            initial_auth_notified = False
             while time.monotonic() < deadline:
                 storage_state = context.storage_state()
                 cookies = {cookie["name"]: cookie["value"] for cookie in storage_state.get("cookies", [])}
                 storage_keys = local_storage_keys(storage_state)
                 current_url = page.url
 
-                if (
+                initial_auth_done = (
                     REQUIRED_COOKIE_NAMES.issubset(cookies.keys())
                     and REQUIRED_LOCAL_STORAGE_KEYS.issubset(storage_keys)
                     and "signin" not in current_url
-                ):
+                )
+
+                if initial_auth_done and not initial_auth_notified:
+                    log(
+                        "First-step login captured. "
+                        "Now confirm '이 기기 로그인 유지' on your phone "
+                        "to obtain the persistent (long-lived) session."
+                    )
+                    initial_auth_notified = True
+
+                if initial_auth_done and has_persistent_session_cookie(storage_state):
                     page.wait_for_timeout(1500)
                     storage_state = context.storage_state()
+                    final_cookie_count = len(storage_state.get("cookies", []))
                     storage_state_path.write_text(
                         json.dumps(storage_state, indent=2),
                         encoding="utf-8",
@@ -121,9 +153,12 @@ def command_login(args: argparse.Namespace) -> int:
                     return emit(
                         {
                             "status": "ok",
-                            "message": "Captured authenticated Toss Securities storage state.",
+                            "message": (
+                                "Captured authenticated Toss Securities storage state "
+                                "with persistent SESSION cookie."
+                            ),
                             "storage_state_path": str(storage_state_path),
-                            "cookie_count": len(cookies),
+                            "cookie_count": final_cookie_count,
                             "origin_count": len(storage_state.get("origins", [])),
                         }
                     )
@@ -131,15 +166,18 @@ def command_login(args: argparse.Namespace) -> int:
                 page.wait_for_timeout(1000)
 
             browser.close()
-            return emit(
-                {
-                    "status": "error",
-                    "message": (
-                        f"Timed out after {args.timeout_seconds} seconds waiting for login to complete. "
-                        "A full authenticated web session was not observed."
-                    ),
-                }
-            )
+            if not initial_auth_notified:
+                timeout_message = (
+                    f"Timed out after {args.timeout_seconds} seconds. "
+                    "QR login was not completed — scan the QR code in the browser window first."
+                )
+            else:
+                timeout_message = (
+                    f"Timed out after {args.timeout_seconds} seconds. "
+                    "QR scan completed but no persistent SESSION was captured. "
+                    "Make sure you confirmed '이 기기 로그인 유지' on your phone."
+                )
+            return emit({"status": "error", "message": timeout_message})
     except PlaywrightError as exc:
         message = str(exc)
         if "Executable doesn't exist" in message:

--- a/cmd/tossctl/auth.go
+++ b/cmd/tossctl/auth.go
@@ -147,11 +147,17 @@ func writeAuthStatus(w io.Writer, format output.Format, status auth.Status) erro
 			}
 		}
 
+		persistence := "session-scoped cookie (≈1h idle timeout — re-login and confirm '이 기기 로그인 유지' for long-lived session)"
+		if status.ExpiresAt != nil {
+			persistence = fmt.Sprintf("persistent cookie (expires %s)", status.ExpiresAt.Format("2006-01-02 15:04:05Z07:00"))
+		}
+
 		_, err := fmt.Fprintf(
 			w,
-			"Session: %s\nProvider: %s\nLive Check: %s\nRetrieved At: %s\nSession File: %s\n",
+			"Session: %s\nProvider: %s\nPersistence: %s\nLive Check: %s\nRetrieved At: %s\nSession File: %s\n",
 			state,
 			status.Provider,
+			persistence,
 			liveCheck,
 			status.RetrievedAt.Format("2006-01-02 15:04:05Z07:00"),
 			status.SessionFile,
@@ -180,6 +186,8 @@ func writeImportResult(w io.Writer, format output.Format, sessionFile string, se
 		"storage_keys": len(sess.Storage),
 		"session_file": sessionFile,
 		"retrieved_at": sess.RetrievedAt,
+		"expires_at":   sess.ExpiresAt,
+		"persistent":   sess.ExpiresAt != nil,
 		"has_xsrf":     sess.Headers["X-XSRF-TOKEN"] != "",
 	}
 
@@ -191,10 +199,15 @@ func writeImportResult(w io.Writer, format output.Format, sessionFile string, se
 	case output.FormatCSV:
 		return fmt.Errorf("csv output is not supported for auth import")
 	case output.FormatTable:
+		persistence := "session-scoped cookie (≈1h idle timeout)"
+		if sess.ExpiresAt != nil {
+			persistence = fmt.Sprintf("persistent cookie (expires %s)", sess.ExpiresAt.Format("2006-01-02 15:04:05Z07:00"))
+		}
 		_, err := fmt.Fprintf(
 			w,
-			"Imported session\nProvider: %s\nCookies: %d\nStorage Keys: %d\nSession File: %s\n",
+			"Imported session\nProvider: %s\nPersistence: %s\nCookies: %d\nStorage Keys: %d\nSession File: %s\n",
 			sess.Provider,
+			persistence,
 			len(sess.Cookies),
 			len(sess.Storage),
 			sessionFile,

--- a/docs/reverse-engineering/auth-notes.md
+++ b/docs/reverse-engineering/auth-notes.md
@@ -1,6 +1,6 @@
 # Auth Notes
 
-Verified from public page behavior on 2026-03-11. Last updated 2026-04-17 (v0.3.6 — `DEVICE_INFO` 요건 제거, HTTP 기본 UA 갱신).
+Verified from public page behavior on 2026-03-11. Last updated 2026-04-21 (persistent SESSION via "이 기기 로그인 유지" capture).
 
 ## Public Behavior
 
@@ -65,6 +65,33 @@ Instead:
 - whether request signing or CSRF tokens are needed for authenticated read endpoints
 - whether session state differs between phone and QR flows
 - whether the web app refreshes sessions silently
+
+## Session Lifetime
+
+Two distinct SESSION cookie shapes exist and their idle-timeout behavior differs:
+
+| SESSION kind | `Set-Cookie` attributes | Server idle timeout | Triggered by |
+|---|---|---|---|
+| session-scoped (default after QR) | `SESSION=...; Secure; HttpOnly; SameSite=Strict` (no `Max-Age`) | **≈1 hour sliding** — every authenticated call resets to `now + 1h` | `POST /api/v3/login/ticket` after QR auth step 1 |
+| persistent (long-lived) | `SESSION=...; Max-Age=31536000; Expires=<1 year ahead>; HttpOnly` | **Exempt** — survives multi-hour idle (verified with 60+ min idle probe, 200 OK after gap) | `POST /api/v1/wts-login-device/check-with-login` **after** user confirms "이 기기 로그인 유지" on phone |
+
+Consequences:
+- If the CLI captures storage state right after QR step 1 only, the saved SESSION is session-scoped and the CLI will 401 after ≈1h of inactivity.
+- To obtain the persistent SESSION the QR flow has a **second** confirmation step on the Toss app ("이 기기 로그인 유지"). The Python auth-helper waits for this before saving (`has_persistent_session_cookie` — SESSION `expires` > 1 week out).
+- `GET /api/v1/session/expired-at` returns the current session expiry as KST RFC3339. It also bumps the server-side idle timer (we could not isolate it as a pure read in tests).
+- No "silent re-auth via long-lived token" exists. Without a valid SESSION the server's `/api/v3/init` issues a fresh guest SESSION and the page redirects to `/signin`. `UTK/LTK/FTK/BTK` alone do not prove identity.
+- Browser tabs appear to "persist for days" only because (a) the dashboard polls authenticated APIs every 3–30 seconds while the tab is open (≈460 calls observed over 18 min of user idle), keeping the idle timer warm, or (b) the browser has a persistent SESSION from having confirmed "이 기기 로그인 유지".
+
+## Logout Behavior (Set-Cookie on 2xx)
+
+Several `wts-cert-api.tossinvest.com` endpoints respond to 2xx requests with `Set-Cookie: SESSION=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax` — an instruction to **delete** the client-side SESSION cookie. Observed at least on:
+
+- `GET /api/v1/dashboard/common/cached-orderable-amount`
+- `POST /api/v1/dashboard/asset/sections/all`
+- `POST /api/v2/dashboard/asset/sections/all`
+- `GET /api/v1/properties/member/shared`
+
+Browsers and the tossctl CLI both **ignore** this (CLI has no cookie jar; browsers apparently don't honor the delete either, because their existing SESSION has `SameSite=Strict` while the delete instruction carries `SameSite=Lax`, producing a cookie-jar mismatch). If the CLI ever adopts an `http.CookieJar` naively, it will self-destruct its session on these responses. The safe rule is: **never apply `SESSION=; Max-Age=0` delete instructions**.
 
 ## HTTP Client Fingerprinting
 

--- a/internal/auth/playwright.go
+++ b/internal/auth/playwright.go
@@ -11,8 +11,9 @@ import (
 
 type playwrightStorageState struct {
 	Cookies []struct {
-		Name  string `json:"name"`
-		Value string `json:"value"`
+		Name    string  `json:"name"`
+		Value   string  `json:"value"`
+		Expires float64 `json:"expires"`
 	} `json:"cookies"`
 	Origins []struct {
 		Origin       string `json:"origin"`
@@ -44,6 +45,10 @@ func (s *Service) ImportPlaywrightState(ctx context.Context, path string) (*sess
 
 	for _, cookie := range state.Cookies {
 		sess.Cookies[cookie.Name] = cookie.Value
+		if cookie.Name == "SESSION" && cookie.Expires > 0 {
+			expiresAt := time.Unix(int64(cookie.Expires), 0).UTC()
+			sess.ExpiresAt = &expiresAt
+		}
 	}
 
 	for _, origin := range state.Origins {


### PR DESCRIPTION
## 변경 사항

`auth-helper` 가 QR 1차 인증 직후 종료하여 session-scoped `SESSION` 쿠키만 저장하던 문제 수정. 이제 폰의 "이 기기 로그인 유지" 2차 확인까지 기다려 Toss 서버가 `POST /api/v1/wts-login-device/check-with-login` 응답으로 내려주는 `Max-Age=31536000` 짜리 **persistent SESSION** 을 받아 저장. 기존에는 약 1시간 idle 후 서버가 세션을 invalidate 해서 CLI 가 401 을 받았음.

`auth status` / `import-playwright-state` 출력에 `Persistence` 필드 추가 (세션 수명 가시성). `docs/reverse-engineering/auth-notes.md` 에 Session Lifetime + Logout Behavior (SESSION 삭제 지시 무시해야 하는 이유) 섹션 추가.

## 영향 범위

- [x] 조회 (읽기 전용) — auth login 플로우, status 표시
- [ ] 거래 (mutation)
- [ ] 설치 / CI
- [x] 문서

## 테스트

- [x] `make test` 통과
- [x] `go vet ./...` 통과
- [x] 수동 E2E: `auth login` → 1차 안내 출력 → 2차 "이 기기 로그인 유지" 확인 → persistent 저장 확인
- [x] 60+분 idle 후 `account list` 여전히 200 OK (이전엔 401)
- [x] `auth status` 가 `Persistence: persistent cookie (expires 2027-04-21 ...)` 표시

## 체크리스트

- [x] 기존 동작을 깨뜨리지 않음 — QR 로그인 후 폰에 뜨는 "이 기기 로그인 유지" 프롬프트(토스 앱 표준 플로우)에 확인 한 번 더 눌러주면 됨. README/CHANGELOG 에 안내 반영
- [ ] 거래 관련 변경 — N/A

## 참고

- 서버 세션 TTL: session-scoped = sliding 1h idle timeout, persistent = 해당 timeout 면제 (상세는 `docs/reverse-engineering/auth-notes.md` Session Lifetime 섹션)
- `SESSION=; Max-Age=0` Set-Cookie 삭제 지시가 여러 `wts-cert-api` 엔드포인트 응답에 붙지만, 브라우저·CLI 둘 다 무시해야 정상 동작 (`auth-notes.md` Logout Behavior 섹션)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)