### PR TITLE
feat(trading): US 지정가 주문에서 USD 가격 입력 허용

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **US 지정가 주문에서 USD 가격 입력 허용** — `order place --currency-mode USD --price 158.01 ...`. 기존엔 비 fractional 경로가 `CurrencyMode=KRW`만 허용해 `Live Ready=false`로 떨어졌음. 입력만 USD로 받고 와이어 페이로드는 기존과 동일하게 `currencyMode="KRW"`+USD 가격 필드 (캡처된 토스 웹 UI 스펙과 일치). `--currency-mode KRW`(기본)는 환율 변환 경로 그대로 유지.
+
 ## [0.4.3] - 2026-04-23
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ tossctl account summary --output json
 
 | 기능 | 커맨드 | 필요 config |
 |------|--------|-------------|
-| 지정가 매수 (US/KR) | `order place --side buy --price <KRW>` | `place` |
-| 지정가 매도 (US/KR) | `order place --side sell --price <KRW>` | `place` + `sell` |
+| 지정가 매수 (US/KR) | `order place --side buy --price <value>` | `place` |
+| 지정가 매도 (US/KR) | `order place --side sell --price <value>` | `place` + `sell` |
 | 국내주식 거래 | `order place --market kr` | `place` + `kr` |
 | 소수점 매수 (US) | `order place --fractional --amount <KRW>` | `place` + `fractional` |
 | 주문 취소 | `order cancel --order-id <id>` | `cancel` |
@@ -122,6 +122,8 @@ tossctl account summary --output json
 | 거래 권한 관리 | `order permissions grant\|status\|revoke` | `place`/`cancel`/`amend` 중 하나 |
 
 모든 거래는 `allow_live_order_actions=true`도 필요합니다. 소수점 주문은 시장가(market order)로 자동 전환되며, 금액(KRW) 기반입니다.
+
+US 지정가는 `--currency-mode`로 가격 해석을 선택합니다: `KRW` (기본, 서버 환율로 USD 변환) 또는 `USD` (입력을 USD 가격 그대로 전송). 예: `order place --symbol MRVL --side buy --qty 1 --price 158.01 --currency-mode USD`.
 
 ### Safety Model
 

--- a/docs/trading/rpc-catalog.md
+++ b/docs/trading/rpc-catalog.md
@@ -443,6 +443,7 @@ Current inference:
 - amend sends USD price precision even while `currencyMode` remains `KRW`
 - the browser-side USD conversion matched `700 / 1472.8 = 0.4753`
 - `withOrderKey` appears on `correct/prepare` but not on `correct`
+- CLI behaviour (`tossctl order place`): `--currency-mode KRW` (default) divides the input by the live exchange rate before sending; `--currency-mode USD` sends the USD value as-is. In both cases the wire payload keeps `currencyMode: "KRW"` to match every captured order/prepare body.
 
 ### Pending Order Inline Cancel Path
 

--- a/internal/client/trading.go
+++ b/internal/client/trading.go
@@ -816,24 +816,33 @@ func buildPlaceBody(productCode, marketCode string, intent orderintent.PlaceInte
 	var orderAmount float64
 	orderPriceType := "00" // limit
 
-	if intent.Fractional {
+	switch {
+	case intent.Fractional:
 		// Fractional: market order, amount-based
 		priceValue = 0
 		quantityValue = 0
 		orderAmount = math.Round(intent.Amount)
 		orderPriceType = "01" // market
-	} else if intent.Market == "kr" {
+	case intent.Market == "kr":
 		priceValue = intent.Price
 		quantityValue = intent.Quantity
-	} else {
+	case intent.CurrencyMode == "USD":
+		// US limit + USD input: price field carries USD as-is.
+		priceValue = round2(intent.Price)
+		quantityValue = intent.Quantity
+	default:
+		// US limit + KRW input: convert to USD using server-provided rate.
 		priceValue = round2(intent.Price / meta.ExchangeRate)
 		quantityValue = intent.Quantity
 	}
 
+	// Toss wire payload always uses currencyMode="KRW" even for US orders;
+	// the price field carries USD in that case. Matches every captured
+	// order/prepare body in docs/trading/rpc-catalog.md.
 	payload := map[string]any{
 		"stockCode":              productCode,
 		"market":                 marketCode,
-		"currencyMode":           intent.CurrencyMode,
+		"currencyMode":           "KRW",
 		"tradeType":              intent.Side,
 		"price":                  priceValue,
 		"quantity":               quantityValue,

--- a/internal/client/trading_test.go
+++ b/internal/client/trading_test.go
@@ -427,6 +427,48 @@ func TestBuildPlaceBodySellTradeType(t *testing.T) {
 	}
 }
 
+func TestBuildPlaceBodyUSDLimitPriceAsIs(t *testing.T) {
+	intent, err := orderintent.NormalizePlace(orderintent.PlaceInput{
+		Symbol:       "MRVL",
+		Market:       "us",
+		Side:         "buy",
+		OrderType:    "limit",
+		Quantity:     1,
+		Price:        158.01,
+		CurrencyMode: "USD",
+	})
+	if err != nil {
+		t.Fatalf("NormalizePlace returned error: %v", err)
+	}
+
+	// ExchangeRate deliberately non-1 to prove the USD path ignores it.
+	meta := stockPriceMetadata{Close: 158.01, CloseKRW: 233000, ExchangeRate: 1477.6}
+
+	body, err := buildPlaceBody("US20000627001", "NSQ", intent, meta, true)
+	if err != nil {
+		t.Fatalf("buildPlaceBody returned error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+	// USD input: price must be sent as-is, not divided by ExchangeRate.
+	if payload["price"] != 158.01 {
+		t.Fatalf("expected USD price 158.01 as-is, got %v", payload["price"])
+	}
+	// Wire payload must keep currencyMode=KRW (Toss spec) even when CLI input was USD.
+	if payload["currencyMode"] != "KRW" {
+		t.Fatalf("expected wire currencyMode KRW, got %v", payload["currencyMode"])
+	}
+	if payload["orderPriceType"] != "00" {
+		t.Fatalf("expected limit orderPriceType 00, got %v", payload["orderPriceType"])
+	}
+	if payload["allowAutoExchange"] != true {
+		t.Fatal("expected allowAutoExchange=true for US orders")
+	}
+}
+
 func TestBuildPlaceBodyKRRawKRWPrice(t *testing.T) {
 	intent, err := orderintent.NormalizePlace(orderintent.PlaceInput{
 		Symbol:       "290080",

--- a/internal/trading/service.go
+++ b/internal/trading/service.go
@@ -49,7 +49,7 @@ func NewService(permissionService *permissions.Service, policy config.Trading, b
 func (s *Service) PreviewPlace(intent orderintent.PlaceIntent) Preview {
 	canonical := orderintent.CanonicalPlace(intent)
 	warnings := []string{
-		"Live place supports US/KR buy/sell limit orders and US fractional (market) orders in KRW.",
+		"Live place supports US/KR buy/sell limit orders (US accepts KRW or USD price input) and US fractional (market) orders.",
 		"US orders may still require funding, FX consent, or product-risk acknowledgement before submission.",
 	}
 	liveReady := placeIntentSupported(intent)
@@ -238,13 +238,18 @@ func placeIntentSupported(intent orderintent.PlaceIntent) bool {
 		return false
 	}
 	if intent.Fractional {
-		// fractional orders: US market + market order, KRW or USD
+		// fractional: US market + market order, KRW or USD
 		return intent.Market == "us" && intent.OrderType == "market" &&
 			(intent.CurrencyMode == "KRW" || intent.CurrencyMode == "USD")
 	}
-	// non-fractional: KRW only, limit only
-	if intent.CurrencyMode != "KRW" {
+	// non-fractional: limit only. KR requires KRW. US accepts KRW
+	// (converted to USD via exchange rate at request time) or USD
+	// (sent to server as-is in the price field — see buildPlaceBody).
+	if intent.OrderType != "limit" {
 		return false
 	}
-	return intent.OrderType == "limit"
+	if intent.Market == "kr" {
+		return intent.CurrencyMode == "KRW"
+	}
+	return intent.CurrencyMode == "KRW" || intent.CurrencyMode == "USD"
 }

--- a/internal/trading/service_test.go
+++ b/internal/trading/service_test.go
@@ -429,6 +429,20 @@ func TestPlaceIntentSupportedRejectsFractionalLimit(t *testing.T) {
 	}
 }
 
+func TestPlaceIntentSupportedAcceptsUSLimitUSD(t *testing.T) {
+	intent := orderintent.PlaceIntent{Symbol: "MRVL", Market: "us", Side: "buy", OrderType: "limit", Quantity: 1, Price: 158.01, CurrencyMode: "USD"}
+	if !placeIntentSupported(intent) {
+		t.Fatal("expected true for US limit order with USD price input")
+	}
+}
+
+func TestPlaceIntentSupportedRejectsKRLimitUSD(t *testing.T) {
+	intent := orderintent.PlaceIntent{Symbol: "290080", Market: "kr", Side: "buy", OrderType: "limit", Quantity: 1, Price: 10, CurrencyMode: "USD"}
+	if placeIntentSupported(intent) {
+		t.Fatal("expected false for KR limit order with USD price input")
+	}
+}
+
 func TestPlaceIntentSupportedRejectsFractionalKR(t *testing.T) {
 	intent := orderintent.PlaceIntent{Symbol: "290080", Market: "kr", Side: "buy", OrderType: "market", Amount: 8000, CurrencyMode: "KRW", Fractional: true}
 	if placeIntentSupported(intent) {


### PR DESCRIPTION
## 변경 사항

`tossctl order place --currency-mode USD --price 157.74 ...` 가 기존엔 비 fractional 경로에서 `placeIntentSupported` 가 `KRW` 만 허용해 `Live Ready=false` 로 떨어졌습니다. US 지정가 주문에서 USD 가격 입력을 허용하도록 수정했습니다.

- `placeIntentSupported`: US 지정가 + USD 허용 (KR 은 여전히 KRW only)
- `buildPlaceBody`: `CurrencyMode=USD` 분기 추가 — 입력 가격을 환율 변환 없이 USD 값 그대로 `price` 필드에 실음. 와이어 페이로드 `currencyMode` 는 항상 `"KRW"` (`docs/trading/rpc-catalog.md`의 실 웹 UI 캡처와 일치 — 토스 서버는 `currencyMode=KRW` + `price` 필드에 USD 값을 싣는 스펙)
- 단위 테스트: USD 가격 as-is 전송 + wire `currencyMode=KRW` 검증, US USD 수용 / KR USD 거부 케이스

## 영향 범위

- [ ] 조회 (읽기 전용)
- [x] 거래 (mutation)
- [ ] 설치 / CI
- [x] 문서

## 테스트

- [x] `make test` 통과
- [x] 수동 확인 완료 — MRVL 1주 `$157.74` USD 지정가 주문 → 서버 기록 `orderUsdPrice: 157.74`, `orderPrice: 233076` KRW 로 정확히 매핑. 주문 취소 완료.

## 체크리스트

- [x] 기존 동작을 깨뜨리지 않음 (`--currency-mode KRW` 기본 경로 동일, `buildPlaceBody` 기존 테스트 전부 통과)
- [x] 거래 관련 변경 — 안전장치(`place` config, `--execute`, `--dangerously-skip-permissions`, `--confirm` 토큰) 전부 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)