### PR TITLE
feat(push): tossctl push listen — SSE 푸시 리스너

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **`tossctl push listen` — SSE 푸시 리스너** — 토스증권 웹이 `GET https://sse-message.tossinvest.com/api/v1/wts-notification` 로 제공하는 Server-Sent Events 채널 구독. 세션 쿠키 재사용, JSONL 로 stdout 출력, 기본 exponential backoff 재연결 (`--retry=false` 로 비활성 가능). Toss 는 thin notification 방식이라 payload 대신 `{"type":"pending-order-refresh",...}` 같은 "재조회하라" 신호만 내려줌. 구독 가능한 이벤트 타입과 의미는 `docs/reverse-engineering/push-events.md` 에 정리.
+
 ## [0.4.4] - 2026-04-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ tossctl account summary --output json
 | 거래내역 ledger | `transactions list --market us\|kr` (매매·입출금·배당·입출고) | O | O |
 | 현금 overview | `transactions overview --market us\|kr` (주문가능·출금가능·예정입금) | O | O |
 | CSV 내보내기 | `export positions --market`, `export orders --market`, `transactions list --output csv` | O | O |
+| 실시간 푸시 | `push listen` (SSE, JSONL 스트림 — 주문/가격 변경 알림) | O | O |
 
 ### 거래
 

--- a/cmd/tossctl/push.go
+++ b/cmd/tossctl/push.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/push"
+	"github.com/spf13/cobra"
+)
+
+func newPushCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "push",
+		Short: "Subscribe to Toss Securities push notifications (SSE)",
+	}
+
+	var retry bool
+
+	listenCmd := &cobra.Command{
+		Use:   "listen",
+		Short: "Stream SSE events as JSON lines to stdout",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			app, err := newAppContext(opts)
+			if err != nil {
+				return err
+			}
+			if app.session == nil {
+				return fmt.Errorf("no active session; run `tossctl auth login` first")
+			}
+
+			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer cancel()
+
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			handler := func(ev push.Event) {
+				_ = enc.Encode(ev)
+			}
+
+			listener := push.NewListener(
+				app.session,
+				push.WithLogger(func(format string, args ...any) {
+					fmt.Fprintf(cmd.ErrOrStderr(), format+"\n", args...)
+				}),
+			)
+
+			if retry {
+				err = listener.ListenWithRetry(ctx, handler)
+			} else {
+				err = listener.Listen(ctx, handler)
+			}
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		},
+	}
+	listenCmd.Flags().BoolVar(&retry, "retry", true, "Auto-reconnect with exponential backoff when the stream drops")
+
+	cmd.AddCommand(listenCmd)
+	return cmd
+}

--- a/cmd/tossctl/root.go
+++ b/cmd/tossctl/root.go
@@ -30,6 +30,7 @@ type appContext struct {
 	loginConfig       auth.LoginConfig
 	authService       *auth.Service
 	client            *tossclient.Client
+	session           *session.Session
 	permissionService *permissions.Service
 	lineageService    *orderlineage.Service
 	tradingService    *trading.Service
@@ -82,6 +83,7 @@ func newRootCmd() *cobra.Command {
 		newQuoteCmd(opts),
 		newOrderCmd(opts),
 		newExportCmd(opts),
+		newPushCmd(opts),
 	)
 
 	return cmd
@@ -139,6 +141,7 @@ func newAppContext(opts *rootOptions) (*appContext, error) {
 			Validator:   client,
 		}),
 		client:            client,
+		session:           sess,
 		permissionService: permissionService,
 		lineageService:    orderlineage.NewService(paths.LineageFile),
 		tradingService:    trading.NewService(permissionService, cfg.Trading, client),

--- a/docs/reverse-engineering/push-events.md
+++ b/docs/reverse-engineering/push-events.md
@@ -1,0 +1,66 @@
+# Push Events (SSE)
+
+Verified 2026-04-23 from the authenticated dashboard with the tossctl session.
+
+## Channel
+
+Toss Securities web does **not** use WebSocket. Server → client push is delivered via Server-Sent Events (SSE) on a single long-lived HTTP GET.
+
+- Endpoint: `GET https://sse-message.tossinvest.com/api/v1/wts-notification`
+- Required headers: `Accept: text/event-stream`, `Cache-Control: no-cache`
+- Auth: standard session cookies (`SESSION`, `XSRF-TOKEN`, `UTK`, `LTK`, `FTK`, `BTK`, `browserSessionId`, `deviceId`) — same set used for `wts-api` calls
+- Response: `Content-Type: text/event-stream; charset=UTF-8`, chunked
+
+A second push channel exists for OS-level Web Push (VAPID) via `GET https://wts-cert-api.tossinvest.com/api/v1/personalize/wts/browser-push/vapid` + a subscribe POST. Out of scope for the in-CLI listener.
+
+## Stream Shape
+
+On connect the server emits a `retry: 3600000` directive, then alternates SSE comment heartbeats (`:heartbeat`) with event frames. The server seems to re-emit the `retry` directive roughly every 2 seconds alongside heartbeats.
+
+Frames follow the standard SSE format:
+
+```
+id: <32-hex-char opaque id>
+data: <JSON payload>
+
+```
+
+`data` is always a single-line JSON object with at minimum `type` and `key`.
+
+## Observed Event Types
+
+Triggered by a single `order cancel` on a pending US order (MRVL, order id `2026-04-23/5`):
+
+| Event count | `data.type` | Other `data` fields |
+| --- | --- | --- |
+| 3 | `pending-order-refresh` | `key` (string, observed `"1"`) |
+| 3 | `purchase-price-refresh` | `msg.stockCode`, `key` |
+
+Example frames (timestamps from the capture run):
+
+```
+[18:57:38] {"id":"e8b4085b71ed4c5e8b2f16539cc7d8fd", "data":"{\"type\":\"pending-order-refresh\",\"key\":\"1\"}"}
+[18:57:38] {"id":"be147d920c45474381207babdc45e27d", "data":"{\"type\":\"purchase-price-refresh\",\"msg\":{\"stockCode\":\"US20000627001\"},\"key\":\"1\"}"}
+```
+
+The event count for a single cancel (prepare → cancel → reconcile) is 3 per type. Expect the same multiplicative pattern for place and amend flows.
+
+## Semantics
+
+Toss uses SSE as a **thin notification** channel — events signal "something changed, re-fetch the relevant resource" rather than carrying the payload. Consumers must pair each event type with a follow-up REST call to get the actual state.
+
+Suggested mapping for the CLI:
+
+| Event type | Re-fetch |
+| --- | --- |
+| `pending-order-refresh` | `/api/v1/trading/orders/histories/all/pending` |
+| `purchase-price-refresh` | `/api/v1/trading/orders/calculate/<stockCode>/average-price` + orderable-amount / cost-basis endpoints as needed |
+
+Unknown event types seen in the wild should be logged verbatim so the taxonomy can grow.
+
+## Known Unknowns
+
+- Event types triggered by `order place` and `order amend` — not yet captured on this channel.
+- Fill notifications during market hours — the cancel capture happened pre-open (US market closed), so fill-related events are not yet observed.
+- Long-idle behavior of the connection — Toss's `retry: 3600000` (1 hour) suggests they expect EventSource to auto-reconnect; the SESSION cookie is persistent and should survive reconnects, but token refresh behavior is not exercised.
+- Payload size ceiling — no frame larger than ~200 bytes has been observed.

--- a/docs/reverse-engineering/push-events.md
+++ b/docs/reverse-engineering/push-events.md
@@ -25,42 +25,55 @@ data: <JSON payload>
 
 ```
 
-`data` is always a single-line JSON object with at minimum `type` and `key`.
+`data` is a single-line JSON object with at minimum `type` and `key`.
 
 ## Observed Event Types
 
-Triggered by a single `order cancel` on a pending US order (MRVL, order id `2026-04-23/5`):
-
-| Event count | `data.type` | Other `data` fields |
+| `data.type` | Trigger | Payload |
 | --- | --- | --- |
-| 3 | `pending-order-refresh` | `key` (string, observed `"1"`) |
-| 3 | `purchase-price-refresh` | `msg.stockCode`, `key` |
+| `pending-order-refresh` | prepare/create/cancel/amend — any pending-list change | `{"key":"1"}` |
+| `purchase-price-refresh` | buying-power / average-price change for a stock | `{"msg":{"stockCode":"..."},"key":"1"}` |
+| `share-holdings` | holdings delta after a fill or external reconciliation | `{"msg":{"stockCode":"..."}}` |
+| `web-push` | rich human-readable notification (order success, etc.) | `{"msg":{"title":"...","message":"...","iconUrl":"...","buttonInfo":{"name":"...","url":"..."},"contentId":"..."}}` |
+| `order-refresh` | order state change (generic) | not captured live yet |
+| `price-refresh` | ticker price refresh | not captured live yet |
+| `icon-refresh` | icon asset refresh | not captured live yet |
+| `setting-refresh` | user preference change | not captured live yet |
 
-Example frames (timestamps from the capture run):
+Cancel of a single pending order emits `pending-order-refresh` + `purchase-price-refresh` each three times (prepare/cancel/reconcile). A successful buy fill adds `share-holdings` and `web-push`. Successful sell fills produce the same pattern (including `web-push`) at execution time, but not at the order-registration moment.
+
+Example frames captured live during a DELL buy:
 
 ```
-[18:57:38] {"id":"e8b4085b71ed4c5e8b2f16539cc7d8fd", "data":"{\"type\":\"pending-order-refresh\",\"key\":\"1\"}"}
-[18:57:38] {"id":"be147d920c45474381207babdc45e27d", "data":"{\"type\":\"purchase-price-refresh\",\"msg\":{\"stockCode\":\"US20000627001\"},\"key\":\"1\"}"}
+{"type":"purchase-price-refresh","msg":{"stockCode":"US20181228002"},"key":"1"}
+{"type":"pending-order-refresh","key":"1"}
+{"type":"share-holdings","msg":{"stockCode":"US20181228002"}}
+{"type":"web-push","msg":{"title":"델 테크놀로지스 1주 구매 성공","message":"주당 $213.4(315,319원)에 구매했어요.","iconUrl":"https://static.toss.im/icons/png/4x/icn-success-color.png","buttonInfo":{"name":"내역 보기","url":"/account/orders?..."},"contentId":"securities:WEBPUSH-..."}}
 ```
 
-The event count for a single cancel (prepare → cancel → reconcile) is 3 per type. Expect the same multiplicative pattern for place and amend flows.
+## Server-Initiated Reconnect (`event: connection-close`)
+
+Toss emits a named SSE event `connection-close` every few minutes. A client that ignores this event and waits for the TCP stream to drop ends up in a loop of rapid disconnect/reconnect because the server is already handing the subscription off to a new connection.
+
+When an SSE frame's `event:` field equals `connection-close`, immediately open a fresh stream without growing the backoff. The tossctl Go listener does this and bypasses the exponential backoff penalty for these graceful hand-offs.
 
 ## Semantics
 
 Toss uses SSE as a **thin notification** channel — events signal "something changed, re-fetch the relevant resource" rather than carrying the payload. Consumers must pair each event type with a follow-up REST call to get the actual state.
 
-Suggested mapping for the CLI:
-
 | Event type | Re-fetch |
 | --- | --- |
 | `pending-order-refresh` | `/api/v1/trading/orders/histories/all/pending` |
 | `purchase-price-refresh` | `/api/v1/trading/orders/calculate/<stockCode>/average-price` + orderable-amount / cost-basis endpoints as needed |
+| `share-holdings` | portfolio position for the changed stockCode |
+| `web-push` | no follow-up needed — the payload is already human-readable |
 
 Unknown event types seen in the wild should be logged verbatim so the taxonomy can grow.
 
 ## Known Unknowns
 
-- Event types triggered by `order place` and `order amend` — not yet captured on this channel.
-- Fill notifications during market hours — the cancel capture happened pre-open (US market closed), so fill-related events are not yet observed.
-- Long-idle behavior of the connection — Toss's `retry: 3600000` (1 hour) suggests they expect EventSource to auto-reconnect; the SESSION cookie is persistent and should survive reconnects, but token refresh behavior is not exercised.
-- Payload size ceiling — no frame larger than ~200 bytes has been observed.
+- `order-refresh`, `price-refresh`, `icon-refresh`, `setting-refresh` — not yet observed live.
+- Fill notifications for US during regular trading hours — captured only on pre-market order placements; outside-hours flow may differ.
+- Whether Toss enforces a single-SSE-per-session limit — not yet directly confirmed.
+- Long-idle behavior across the advertised `retry: 3600000` (1 h) window — in practice the server keeps emitting `connection-close` events well before that deadline.
+- Payload size ceiling — no frame larger than ~400 bytes has been observed.

--- a/internal/push/listen.go
+++ b/internal/push/listen.go
@@ -1,9 +1,5 @@
 // Package push subscribes to the Toss Securities SSE notification channel.
-//
-// Toss exposes a single long-lived HTTP GET stream at
-//   https://sse-message.tossinvest.com/api/v1/wts-notification
-// delivering thin "something changed, re-fetch" notifications.
-// See docs/reverse-engineering/push-events.md for the event taxonomy.
+// See docs/reverse-engineering/push-events.md for the channel and event taxonomy.
 package push
 
 import (
@@ -21,26 +17,28 @@ import (
 )
 
 const (
-	defaultStreamURL     = "https://sse-message.tossinvest.com/api/v1/wts-notification"
-	defaultUserAgent     = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
-	initialBackoff       = 2 * time.Second
-	maxBackoff           = 60 * time.Second
-	readDeadlineInterval = 0 // 0 = no read deadline; the server's heartbeats keep the connection warm
+	defaultStreamURL = "https://sse-message.tossinvest.com/api/v1/wts-notification"
+	defaultUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
+	initialBackoff   = 2 * time.Second
+	maxBackoff       = 60 * time.Second
 )
 
-// ErrNoSession is returned when the listener is started without valid session cookies.
 var ErrNoSession = errors.New("push: no active session cookies")
 
-// Event is a parsed SSE frame with its JSON data payload.
+// errConnectionClose signals Toss's graceful `event: connection-close` frame,
+// emitted every few minutes. The retry loop reconnects immediately without
+// growing the backoff so a routine hand-off is not treated as an outage.
+var errConnectionClose = errors.New("push: server requested reconnect")
+
 type Event struct {
 	ID       string         `json:"id,omitempty"`
+	Name     string         `json:"name,omitempty"`
 	Type     string         `json:"type"`
 	Msg      map[string]any `json:"msg,omitempty"`
-	Raw      map[string]any `json:"raw,omitempty"`      // full data payload as JSON
+	Raw      map[string]any `json:"raw,omitempty"`
 	Received time.Time      `json:"received"`
 }
 
-// Listener holds the dependencies for a single SSE subscription.
 type Listener struct {
 	session    *session.Session
 	streamURL  string
@@ -48,32 +46,27 @@ type Listener struct {
 	logf       func(format string, args ...any)
 }
 
-// Option customises a Listener.
 type Option func(*Listener)
 
-// WithStreamURL overrides the SSE endpoint (mostly for tests).
 func WithStreamURL(u string) Option {
 	return func(l *Listener) { l.streamURL = u }
 }
 
-// WithHTTPClient swaps the underlying HTTP client. Pass a client without
-// Timeout so the stream can stay open.
+// WithHTTPClient swaps the underlying HTTP client. The client must have no
+// Timeout because the SSE stream is long-lived.
 func WithHTTPClient(c *http.Client) Option {
 	return func(l *Listener) { l.httpClient = c }
 }
 
-// WithLogger routes informational logs (reconnects, backoff) somewhere
-// other than /dev/null.
 func WithLogger(logf func(string, ...any)) Option {
 	return func(l *Listener) { l.logf = logf }
 }
 
-// NewListener constructs a Listener using the session cookies from sess.
 func NewListener(sess *session.Session, opts ...Option) *Listener {
 	l := &Listener{
 		session:    sess,
 		streamURL:  defaultStreamURL,
-		httpClient: &http.Client{}, // no Timeout: SSE is long-lived
+		httpClient: &http.Client{},
 		logf:       func(string, ...any) {},
 	}
 	for _, opt := range opts {
@@ -82,9 +75,6 @@ func NewListener(sess *session.Session, opts ...Option) *Listener {
 	return l
 }
 
-// Listen opens the SSE stream once and calls handler for every parsed event.
-// It returns when ctx is cancelled or the connection ends. Retry logic is
-// the caller's responsibility; see ListenWithRetry.
 func (l *Listener) Listen(ctx context.Context, handler func(Event)) error {
 	if l.session == nil || len(l.session.Cookies) == 0 {
 		return ErrNoSession
@@ -119,9 +109,6 @@ func (l *Listener) Listen(ctx context.Context, handler func(Event)) error {
 	return parseStream(resp.Body, handler)
 }
 
-// ListenWithRetry wraps Listen in a reconnect loop with exponential backoff.
-// It returns only when ctx is cancelled, or when a fatal error (e.g.
-// missing session) is encountered.
 func (l *Listener) ListenWithRetry(ctx context.Context, handler func(Event)) error {
 	backoff := initialBackoff
 	for {
@@ -132,56 +119,67 @@ func (l *Listener) ListenWithRetry(ctx context.Context, handler func(Event)) err
 		if errors.Is(err, ErrNoSession) {
 			return err
 		}
-		if err != nil {
+
+		graceful := errors.Is(err, errConnectionClose)
+		switch {
+		case graceful:
+			l.logf("push: server requested graceful reconnect")
+		case err != nil:
 			l.logf("push: stream error, reconnecting in %s: %v", backoff, err)
-		} else {
+		default:
 			l.logf("push: stream closed by server, reconnecting in %s", backoff)
 		}
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(backoff):
+		if !graceful {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			continue
 		}
 
-		backoff *= 2
-		if backoff > maxBackoff {
-			backoff = maxBackoff
-		}
+		backoff = initialBackoff
 	}
 }
 
-// parseStream reads newline-delimited SSE lines from r, emitting one Event
-// per blank-line-terminated frame that has a parseable `data:` JSON object.
-// Frames without data (heartbeats, retry directives) are silently dropped.
 func parseStream(r io.Reader, handler func(Event)) error {
 	scanner := bufio.NewScanner(r)
-	// Default scanner buffer is 64KB; Toss events are tiny (<200B observed),
-	// but bump the max to 1MB just in case a future event type is larger.
+	// Toss events are tiny (<400B observed); 1MB is defensive headroom.
 	scanner.Buffer(make([]byte, 0, 4096), 1024*1024)
 
 	var (
-		id       string
-		dataBuf  strings.Builder
-		hasData  bool
+		id        string
+		eventName string
+		dataBuf   strings.Builder
+		hasData   bool
+		gotClose  bool
 	)
 	flush := func() {
 		defer func() {
 			id = ""
+			eventName = ""
 			dataBuf.Reset()
 			hasData = false
 		}()
+		if eventName == "connection-close" {
+			gotClose = true
+			return
+		}
 		if !hasData {
 			return
 		}
-		payload := dataBuf.String()
 		var parsed map[string]any
-		if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
-			// Non-JSON data frame — skip silently.
+		if err := json.Unmarshal([]byte(dataBuf.String()), &parsed); err != nil {
 			return
 		}
 		ev := Event{
 			ID:       id,
+			Name:     eventName,
 			Received: time.Now().UTC(),
 			Raw:      parsed,
 		}
@@ -198,15 +196,16 @@ func parseStream(r io.Reader, handler func(Event)) error {
 		line := scanner.Text()
 		if line == "" {
 			flush()
+			if gotClose {
+				return errConnectionClose
+			}
 			continue
 		}
 		if strings.HasPrefix(line, ":") {
-			// SSE comment line (used for Toss heartbeats).
 			continue
 		}
 		field, value, found := strings.Cut(line, ":")
 		if !found {
-			// Field name with no value ("event\n") — treat whole line as field, empty value.
 			field = line
 			value = ""
 		}
@@ -214,22 +213,21 @@ func parseStream(r io.Reader, handler func(Event)) error {
 		switch field {
 		case "id":
 			id = value
+		case "event":
+			eventName = value
 		case "data":
 			if hasData {
 				dataBuf.WriteByte('\n')
 			}
 			dataBuf.WriteString(value)
 			hasData = true
-		case "retry", "event":
-			// `retry` is a reconnect hint (unused here — we manage backoff).
-			// `event` is the named event type; Toss uses the `type` field
-			// inside `data` instead, so ignore this too.
 		}
 	}
 
-	// Trailing frame without blank-line terminator (rare, but SSE allows it).
 	flush()
-
+	if gotClose {
+		return errConnectionClose
+	}
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("push: read stream: %w", err)
 	}

--- a/internal/push/listen.go
+++ b/internal/push/listen.go
@@ -1,0 +1,237 @@
+// Package push subscribes to the Toss Securities SSE notification channel.
+//
+// Toss exposes a single long-lived HTTP GET stream at
+//   https://sse-message.tossinvest.com/api/v1/wts-notification
+// delivering thin "something changed, re-fetch" notifications.
+// See docs/reverse-engineering/push-events.md for the event taxonomy.
+package push
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/session"
+)
+
+const (
+	defaultStreamURL     = "https://sse-message.tossinvest.com/api/v1/wts-notification"
+	defaultUserAgent     = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
+	initialBackoff       = 2 * time.Second
+	maxBackoff           = 60 * time.Second
+	readDeadlineInterval = 0 // 0 = no read deadline; the server's heartbeats keep the connection warm
+)
+
+// ErrNoSession is returned when the listener is started without valid session cookies.
+var ErrNoSession = errors.New("push: no active session cookies")
+
+// Event is a parsed SSE frame with its JSON data payload.
+type Event struct {
+	ID       string         `json:"id,omitempty"`
+	Type     string         `json:"type"`
+	Msg      map[string]any `json:"msg,omitempty"`
+	Raw      map[string]any `json:"raw,omitempty"`      // full data payload as JSON
+	Received time.Time      `json:"received"`
+}
+
+// Listener holds the dependencies for a single SSE subscription.
+type Listener struct {
+	session    *session.Session
+	streamURL  string
+	httpClient *http.Client
+	logf       func(format string, args ...any)
+}
+
+// Option customises a Listener.
+type Option func(*Listener)
+
+// WithStreamURL overrides the SSE endpoint (mostly for tests).
+func WithStreamURL(u string) Option {
+	return func(l *Listener) { l.streamURL = u }
+}
+
+// WithHTTPClient swaps the underlying HTTP client. Pass a client without
+// Timeout so the stream can stay open.
+func WithHTTPClient(c *http.Client) Option {
+	return func(l *Listener) { l.httpClient = c }
+}
+
+// WithLogger routes informational logs (reconnects, backoff) somewhere
+// other than /dev/null.
+func WithLogger(logf func(string, ...any)) Option {
+	return func(l *Listener) { l.logf = logf }
+}
+
+// NewListener constructs a Listener using the session cookies from sess.
+func NewListener(sess *session.Session, opts ...Option) *Listener {
+	l := &Listener{
+		session:    sess,
+		streamURL:  defaultStreamURL,
+		httpClient: &http.Client{}, // no Timeout: SSE is long-lived
+		logf:       func(string, ...any) {},
+	}
+	for _, opt := range opts {
+		opt(l)
+	}
+	return l
+}
+
+// Listen opens the SSE stream once and calls handler for every parsed event.
+// It returns when ctx is cancelled or the connection ends. Retry logic is
+// the caller's responsibility; see ListenWithRetry.
+func (l *Listener) Listen(ctx context.Context, handler func(Event)) error {
+	if l.session == nil || len(l.session.Cookies) == 0 {
+		return ErrNoSession
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, l.streamURL, nil)
+	if err != nil {
+		return fmt.Errorf("push: build request: %w", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("User-Agent", defaultUserAgent)
+	req.Header.Set("Referer", "https://www.tossinvest.com/")
+	req.Header.Set("Origin", "https://www.tossinvest.com")
+	for name, value := range l.session.Cookies {
+		req.AddCookie(&http.Cookie{Name: name, Value: value})
+	}
+
+	resp, err := l.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("push: open stream: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("push: stream returned HTTP %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		return fmt.Errorf("push: unexpected content-type %q", ct)
+	}
+
+	return parseStream(resp.Body, handler)
+}
+
+// ListenWithRetry wraps Listen in a reconnect loop with exponential backoff.
+// It returns only when ctx is cancelled, or when a fatal error (e.g.
+// missing session) is encountered.
+func (l *Listener) ListenWithRetry(ctx context.Context, handler func(Event)) error {
+	backoff := initialBackoff
+	for {
+		err := l.Listen(ctx, handler)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if errors.Is(err, ErrNoSession) {
+			return err
+		}
+		if err != nil {
+			l.logf("push: stream error, reconnecting in %s: %v", backoff, err)
+		} else {
+			l.logf("push: stream closed by server, reconnecting in %s", backoff)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// parseStream reads newline-delimited SSE lines from r, emitting one Event
+// per blank-line-terminated frame that has a parseable `data:` JSON object.
+// Frames without data (heartbeats, retry directives) are silently dropped.
+func parseStream(r io.Reader, handler func(Event)) error {
+	scanner := bufio.NewScanner(r)
+	// Default scanner buffer is 64KB; Toss events are tiny (<200B observed),
+	// but bump the max to 1MB just in case a future event type is larger.
+	scanner.Buffer(make([]byte, 0, 4096), 1024*1024)
+
+	var (
+		id       string
+		dataBuf  strings.Builder
+		hasData  bool
+	)
+	flush := func() {
+		defer func() {
+			id = ""
+			dataBuf.Reset()
+			hasData = false
+		}()
+		if !hasData {
+			return
+		}
+		payload := dataBuf.String()
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
+			// Non-JSON data frame — skip silently.
+			return
+		}
+		ev := Event{
+			ID:       id,
+			Received: time.Now().UTC(),
+			Raw:      parsed,
+		}
+		if t, ok := parsed["type"].(string); ok {
+			ev.Type = t
+		}
+		if m, ok := parsed["msg"].(map[string]any); ok {
+			ev.Msg = m
+		}
+		handler(ev)
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			flush()
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			// SSE comment line (used for Toss heartbeats).
+			continue
+		}
+		field, value, found := strings.Cut(line, ":")
+		if !found {
+			// Field name with no value ("event\n") — treat whole line as field, empty value.
+			field = line
+			value = ""
+		}
+		value = strings.TrimPrefix(value, " ")
+		switch field {
+		case "id":
+			id = value
+		case "data":
+			if hasData {
+				dataBuf.WriteByte('\n')
+			}
+			dataBuf.WriteString(value)
+			hasData = true
+		case "retry", "event":
+			// `retry` is a reconnect hint (unused here — we manage backoff).
+			// `event` is the named event type; Toss uses the `type` field
+			// inside `data` instead, so ignore this too.
+		}
+	}
+
+	// Trailing frame without blank-line terminator (rare, but SSE allows it).
+	flush()
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("push: read stream: %w", err)
+	}
+	return nil
+}

--- a/internal/push/listen_test.go
+++ b/internal/push/listen_test.go
@@ -97,6 +97,26 @@ func TestListenSendsCookiesAndConsumesStream(t *testing.T) {
 	}
 }
 
+func TestParseStreamSignalsConnectionClose(t *testing.T) {
+	raw := strings.Join([]string{
+		"id: 1",
+		`data: {"type":"share-holdings"}`,
+		"",
+		"event: connection-close",
+		"data: bye",
+		"",
+	}, "\n")
+
+	var got []Event
+	err := parseStream(strings.NewReader(raw), func(ev Event) { got = append(got, ev) })
+	if err == nil || err.Error() != "push: server requested reconnect" {
+		t.Fatalf("expected errConnectionClose, got %v", err)
+	}
+	if len(got) != 1 || got[0].Type != "share-holdings" {
+		t.Fatalf("expected only the share-holdings event before close, got: %+v", got)
+	}
+}
+
 func TestListenRejectsNon200(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/internal/push/listen_test.go
+++ b/internal/push/listen_test.go
@@ -1,0 +1,114 @@
+package push
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/session"
+)
+
+func TestParseStreamExtractsDataEvents(t *testing.T) {
+	raw := strings.Join([]string{
+		":heartbeat",
+		"",
+		"retry: 3600000",
+		"",
+		"id: abc123",
+		`data: {"type":"pending-order-refresh","key":"1"}`,
+		"",
+		"id: def456",
+		`data: {"type":"purchase-price-refresh","msg":{"stockCode":"US20000627001"},"key":"1"}`,
+		"",
+		"id: skip",
+		"data: not-json",
+		"",
+	}, "\n")
+
+	var got []Event
+	if err := parseStream(strings.NewReader(raw), func(ev Event) {
+		got = append(got, ev)
+	}); err != nil {
+		t.Fatalf("parseStream returned error: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 valid events, got %d: %+v", len(got), got)
+	}
+	if got[0].ID != "abc123" || got[0].Type != "pending-order-refresh" {
+		t.Fatalf("event 0 mismatch: %+v", got[0])
+	}
+	if got[1].Type != "purchase-price-refresh" || got[1].Msg["stockCode"] != "US20000627001" {
+		t.Fatalf("event 1 mismatch: %+v", got[1])
+	}
+}
+
+func TestListenRequiresSession(t *testing.T) {
+	l := NewListener(&session.Session{})
+	err := l.Listen(context.Background(), func(Event) {})
+	if err != ErrNoSession {
+		t.Fatalf("expected ErrNoSession, got %v", err)
+	}
+}
+
+func TestListenSendsCookiesAndConsumesStream(t *testing.T) {
+	var sawCookie atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if c, err := r.Cookie("SESSION"); err == nil && c.Value == "sess-token" {
+			sawCookie.Store(true)
+		}
+		if r.Header.Get("Accept") != "text/event-stream" {
+			t.Errorf("missing Accept header: %q", r.Header.Get("Accept"))
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("ResponseWriter is not a Flusher")
+		}
+		// One frame then close.
+		_, _ = w.Write([]byte("id: 1\n"))
+		_, _ = w.Write([]byte(`data: {"type":"pending-order-refresh","key":"1"}` + "\n\n"))
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	l := NewListener(
+		&session.Session{Cookies: map[string]string{"SESSION": "sess-token"}},
+		WithStreamURL(srv.URL),
+	)
+
+	var events []Event
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := l.Listen(ctx, func(ev Event) { events = append(events, ev) }); err != nil {
+		t.Fatalf("Listen returned error: %v", err)
+	}
+
+	if !sawCookie.Load() {
+		t.Fatal("expected SESSION cookie on request")
+	}
+	if len(events) != 1 || events[0].Type != "pending-order-refresh" {
+		t.Fatalf("unexpected events: %+v", events)
+	}
+}
+
+func TestListenRejectsNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	l := NewListener(
+		&session.Session{Cookies: map[string]string{"SESSION": "x"}},
+		WithStreamURL(srv.URL),
+	)
+	err := l.Listen(context.Background(), func(Event) {})
+	if err == nil || !strings.Contains(err.Error(), "HTTP 401") {
+		t.Fatalf("expected HTTP 401 error, got %v", err)
+	}
+}


### PR DESCRIPTION
## 변경 사항

토스증권 웹이 제공하는 Server-Sent Events 채널 (`GET https://sse-message.tossinvest.com/api/v1/wts-notification`) 을 구독하는 최소 리스너를 추가합니다.

- 토스는 WebSocket 을 쓰지 않고 SSE 단일 스트림으로 서버→클라이언트 푸시를 제공
- 푸시는 **thin notification** 방식: payload 대신 `{"type":"pending-order-refresh",...}` 등 "재조회하라" 신호만 내려줌. 따라서 포워더/알림 봇의 기반 레이어로만 활용 가능
- 이 PR 은 프로토콜 파서 + CLI 구독 명령까지만 구현. 외부 채널(텔레그램/슬랙/웹훅) 어댑터는 후속 PR.

### 새 명령

```bash
# JSONL 로 stdout 스트림 (기본 exponential backoff 재연결)
tossctl push listen

# 재연결 비활성
tossctl push listen --retry=false
```

### 구조

- `internal/push/listen.go` — SSE 연결 + 프레임 파서 (id/data/retry/event/comment 지원, JSON payload 자동 디코딩, heartbeat/retry 조용히 drop)
- `cmd/tossctl/push.go` — `push listen` 서브커맨드, Ctrl+C 핸들링, stderr 재연결 로그
- `docs/reverse-engineering/push-events.md` — 채널 엔드포인트, 프레임 형식, 관찰된 이벤트 타입과 후속 재조회 매핑 정리

## 영향 범위

- [x] 조회 (읽기 전용) — SSE 구독만, 토스 서버에 mutation 없음
- [ ] 거래 (mutation)
- [ ] 설치 / CI
- [x] 문서

## 테스트

- [x] `make test` 통과 (`internal/push` 단위 테스트: 프레임 파싱, 세션 없을 때 거부, 쿠키 전송/스트림 소비, non-200 거부)
- [x] 수동 확인 — `tossctl push listen` 연결 → heartbeat 조용히 drop 확인. 실제 이벤트(pending-order-refresh, purchase-price-refresh)는 직전 USD 지정가 검증 중 Python probe 로 캡처 완료 (이 결과를 `docs/reverse-engineering/push-events.md` 에 반영)

## 체크리스트

- [x] 기존 동작을 깨뜨리지 않음 (새 명령 + 새 패키지, 기존 코드 `appContext` 에 `session` 필드 추가만 함)
- [x] 거래 관련 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)