### PR TITLE
fix(auth): 윈도우에서 fchmod 없이 로그인 상태를 저장하도록 수정

### DIFF
--- a/auth-helper/tests/test_cli.py
+++ b/auth-helper/tests/test_cli.py
@@ -1,0 +1,34 @@
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+from tossctl_auth_helper import cli
+
+
+class PrivatePermissionTests(unittest.TestCase):
+    def test_set_private_permissions_uses_chmod_when_fchmod_is_missing(self):
+        fake_os = types.SimpleNamespace(chmod=Mock())
+
+        with patch.object(cli, "os", fake_os):
+            cli._set_private_permissions(123)
+
+        fake_os.chmod.assert_called_once_with(123, 0o600)
+
+    def test_set_private_permissions_prefers_fchmod_when_available(self):
+        fake_os = types.SimpleNamespace(fchmod=Mock(), chmod=Mock())
+
+        with patch.object(cli, "os", fake_os):
+            cli._set_private_permissions(456)
+
+        fake_os.fchmod.assert_called_once_with(456, 0o600)
+        fake_os.chmod.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/auth-helper/tossctl_auth_helper/cli.py
+++ b/auth-helper/tossctl_auth_helper/cli.py
@@ -178,6 +178,17 @@ def decode_qr_url(page) -> str | None:
         return None
 
 
+def _set_private_permissions(fd: int, mode: int = 0o600) -> None:
+    fchmod = getattr(os, "fchmod", None)
+    if callable(fchmod):
+        fchmod(fd, mode)
+        return
+
+    chmod = getattr(os, "chmod", None)
+    if callable(chmod):
+        chmod(fd, mode)
+
+
 def save_qr_png(data_uri: str, output_path: Path) -> bool:
     # Write with 0600 permissions so other local users cannot read the QR and
     # complete login before the intended phone holder does. Overwrite on each
@@ -194,7 +205,7 @@ def save_qr_png(data_uri: str, output_path: Path) -> bool:
             0o600,
         )
         try:
-            os.fchmod(fd, 0o600)
+            _set_private_permissions(fd, 0o600)
             os.write(fd, payload)
         finally:
             os.close(fd)
@@ -357,7 +368,7 @@ def command_login(args: argparse.Namespace) -> int:
                         0o600,
                     )
                     try:
-                        os.fchmod(fd, 0o600)
+                        _set_private_permissions(fd, 0o600)
                         os.write(fd, payload)
                     finally:
                         os.close(fd)


### PR DESCRIPTION
## 요약
- Windows에서 `os.fchmod`가 없는 환경에서도 auth-helper가 로그인 상태 저장을 계속 진행하도록 수정했습니다.
- QR PNG 저장과 Playwright storage-state 저장 두 경로 모두 동일한 권한 설정 헬퍼를 사용하도록 정리했습니다.
- 작은 Python 단위 테스트를 추가해 `fchmod`가 있을 때/없을 때 동작을 검증했습니다.

## 배경
Windows 환경에서 `tossctl auth login` 진행 중 auth-helper가 `os.fchmod(...)` 호출에서 실패할 수 있었습니다.

`os.fchmod`는 Unix 계열에서는 자연스럽지만, Windows에서는 Python 버전에 따라 지원되지 않아서 로그인 흐름이 중간에 끊어질 수 있습니다.

이 프로젝트는 이미 Windows 릴리스 자산을 제공하고 있으므로, 해당 코드 경로도 Windows에서 안전하게 지나갈 수 있도록 보완하는 것이 맞다고 판단했습니다.

## 변경 내용
- `auth-helper/tossctl_auth_helper/cli.py`
  - `_set_private_permissions()` 헬퍼 추가
  - `os.fchmod`가 있으면 기존처럼 사용
  - 없으면 `os.chmod`로 대체 시도
- `auth-helper/tests/test_cli.py`
  - `fchmod`가 없는 경우 `chmod`로 대체되는지 확인
  - `fchmod`가 있는 경우 기존 우선순위를 유지하는지 확인

## 검증
다음 명령으로 테스트했습니다.

```bash
python -m unittest discover -s auth-helper/tests -v
```

로컬에서는 2개 테스트가 모두 통과했습니다.

## 범위
이번 PR은 Windows 호환성 중 `fchmod` 처리만 다룹니다.
Python 실행 경로(`python3`/`python`) 관련 문제는 별도 범위로 두었습니다.