### PR TITLE
feat(auth): tossctl auth extend — 폰 승인으로 서버 측 ~7일 활성 만료 갱신

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.6] - Unreleased
+
+### Added
+- **`tossctl auth extend`** — 폰 토스 앱 푸시 승인을 통해 세션 만료를 연장합니다. 블로킹 + 스피너 UX, `--timeout` (기본 120초). 사용 endpoint: `POST /api/v1/wts-login-extend/doc/request` → polling `GET /doc/{txId}/status` (`REQUESTED` → `COMPLETED`) → `POST /api/v1/wts-login-extend/{txId}/state` (필수 finalize) → `GET /api/v1/session/expired-at`. 약 7일 연장됩니다.
+- **24h 만료 경고** — 모든 명령 시작 시 서버 측 세션 만료가 24시간 미만으로 남았으면 stderr 한 줄로 경고 (`⚠ session expires in ~21h 58m; run`tossctl auth extend`to renew`). `--output json` 모드에서는 표시되지 않음.
+- **`session.json` 에 `server_expires_at` 필드 추가** — 서버 측 ~7일 만료 시계 (기존 `expires_at` 의 1년 쿠키 만료와 별개).
+
 ## [0.4.5] - 2026-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ tossctl account summary --output json
 > **GUI 없는 환경 (SSH 서버·CI):** `tossctl auth login --headless [--qr-output /tmp/toss-qr.png]`.
 > QR URL 과 확인 문자(answerLetter)가 stderr 로 출력되며, URL 을 폰으로 전달해 탭하면 카메라 없이 Toss 앱에서 인증할 수 있습니다. `--qr-output` 파일은 `0600` 권한으로 저장됩니다.
 
+### 세션 연장
+
+토스 서버는 SESSION 쿠키(1년 `Max-Age`)와 별개로 약 7일짜리 활성 만료 시계를 운영합니다. 만료 24시간 전부터 모든 명령에 다음과 같은 stderr 경고가 표시됩니다.
+
+```
+⚠ session expires in ~18h; run `tossctl auth extend` to renew
+```
+
+`tossctl auth extend` 는 폰의 토스 앱에 푸시를 보내고 승인을 기다립니다.
+
+```
+$ tossctl auth extend
+Waiting for approval in the Toss app on your phone...
+✓ Extension complete. New expiry: 2026-05-13 07:03 KST (took 4s)
+```
+
+기본 timeout 은 120초이며 `--timeout 60s` 처럼 단축할 수 있습니다.
+
 ## 지원 범위
 
 ### 조회 (읽기 전용)

--- a/cmd/tossctl/auth.go
+++ b/cmd/tossctl/auth.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/junghoonkye/tossinvest-cli/internal/auth"
 	"github.com/junghoonkye/tossinvest-cli/internal/doctor"
@@ -49,8 +53,36 @@ func newAuthCmd(opts *rootOptions) *cobra.Command {
 	loginCmd.Flags().BoolVar(&loginHeadless, "headless", false, "Run Chrome headless (required for remote/CLI-only login)")
 	loginCmd.Flags().StringVar(&loginQROutput, "qr-output", "", "Path to write the current QR PNG (forward to phone via messenger)")
 
+	var extendTimeout time.Duration
+	extendCmd := &cobra.Command{
+		Use:   "extend",
+		Short: "Extend session via Toss app push approval",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			app, err := newAppContext(opts)
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer cancel()
+
+			fmt.Fprintln(cmd.ErrOrStderr(), "Waiting for approval in the Toss app on your phone...")
+			stop := startSpinner(cmd.ErrOrStderr(), "Waiting for approval", isTerminal(cmd.ErrOrStderr()))
+			defer stop()
+
+			result, err := app.authService.Extend(ctx, extendTimeout)
+			stop()
+			if err != nil {
+				return userFacingCommandError(err)
+			}
+			return writeExtendResult(cmd.OutOrStdout(), result)
+		},
+	}
+	extendCmd.Flags().DurationVar(&extendTimeout, "timeout", 120*time.Second, "Maximum time to wait for phone approval")
+
 	cmd.AddCommand(
 		loginCmd,
+		extendCmd,
 		&cobra.Command{
 			Use:   "import-playwright-state <path>",
 			Short: "Import Playwright storage state into tossctl session storage",
@@ -167,12 +199,17 @@ func writeAuthStatus(w io.Writer, format output.Format, status auth.Status) erro
 			persistence = fmt.Sprintf("persistent cookie (expires %s)", status.ExpiresAt.Format("2006-01-02 15:04:05Z07:00"))
 		}
 
+		if _, err := fmt.Fprintf(w, "Session: %s\nProvider: %s\nPersistence: %s\n", state, status.Provider, persistence); err != nil {
+			return err
+		}
+		if status.ServerExpiresAt != nil {
+			if _, err := fmt.Fprintf(w, "Server Expiry: %s\n", status.ServerExpiresAt.In(kstZone).Format("2006-01-02 15:04 MST")); err != nil {
+				return err
+			}
+		}
 		_, err := fmt.Fprintf(
 			w,
-			"Session: %s\nProvider: %s\nPersistence: %s\nLive Check: %s\nRetrieved At: %s\nSession File: %s\n",
-			state,
-			status.Provider,
-			persistence,
+			"Live Check: %s\nRetrieved At: %s\nSession File: %s\n",
 			liveCheck,
 			status.RetrievedAt.Format("2006-01-02 15:04:05Z07:00"),
 			status.SessionFile,
@@ -257,4 +294,69 @@ func writeLogoutResult(w io.Writer, format output.Format, sessionFile string, cl
 	default:
 		return fmt.Errorf("unsupported format: %s", format)
 	}
+}
+
+// kstZone is the named time.Location used for displaying server-side expiry
+// times. /api/v1/session/expired-at returns RFC3339Nano with a numeric +09:00
+// offset, which time.Parse stores as an anonymous FixedZone (empty name) —
+// formatting that with "MST" would print "+0900" instead of "KST". Pinning to
+// a named zone before formatting guarantees the human-readable label.
+var kstZone = time.FixedZone("KST", 9*3600)
+
+func writeExtendResult(w io.Writer, result *auth.ExtendResult) error {
+	_, err := fmt.Fprintf(
+		w,
+		"✓ Extension complete. New expiry: %s (took %s)\n",
+		result.ServerExpiresAt.In(kstZone).Format("2006-01-02 15:04 MST"),
+		result.Elapsed.Round(time.Second),
+	)
+	return err
+}
+
+// startSpinner returns a stop function. In non-TTY mode it writes nothing.
+// Safe to call stop() more than once.
+func startSpinner(w io.Writer, label string, tty bool) func() {
+	if !tty {
+		return func() {}
+	}
+	frames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+	stopCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		i := 0
+		for {
+			select {
+			case <-stopCh:
+				fmt.Fprint(w, "\r\033[K")
+				return
+			case <-ticker.C:
+				fmt.Fprintf(w, "\r%s %s", frames[i%len(frames)], label)
+				i++
+			}
+		}
+	}()
+	stopped := false
+	return func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		close(stopCh)
+		<-doneCh
+	}
+}
+
+func isTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
 }

--- a/cmd/tossctl/auth_extend_test.go
+++ b/cmd/tossctl/auth_extend_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/auth"
+	"github.com/junghoonkye/tossinvest-cli/internal/output"
+)
+
+func TestWriteAuthStatusIncludesServerExpiryInKST(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := time.Parse(time.RFC3339Nano, "2026-05-12T10:47:37.24+09:00")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	retrieved := time.Date(2026, 4, 28, 22, 4, 7, 0, time.UTC)
+	status := auth.Status{
+		Active:          true,
+		Provider:        "playwright-storage-state",
+		SessionFile:     "/tmp/session.json",
+		RetrievedAt:     &retrieved,
+		ServerExpiresAt: &parsed,
+	}
+
+	var buf bytes.Buffer
+	if err := writeAuthStatus(&buf, output.FormatTable, status); err != nil {
+		t.Fatalf("writeAuthStatus: %v", err)
+	}
+	got := buf.String()
+
+	if !strings.Contains(got, "Server Expiry: 2026-05-12 10:47 KST") {
+		t.Fatalf("expected KST server expiry, got %q", got)
+	}
+	persistenceIdx := strings.Index(got, "Persistence:")
+	serverIdx := strings.Index(got, "Server Expiry:")
+	liveIdx := strings.Index(got, "Live Check:")
+	if persistenceIdx < 0 || serverIdx < 0 || liveIdx < 0 {
+		t.Fatalf("missing expected lines: %q", got)
+	}
+	if !(persistenceIdx < serverIdx && serverIdx < liveIdx) {
+		t.Fatalf("expected Persistence < Server Expiry < Live Check, got %d / %d / %d", persistenceIdx, serverIdx, liveIdx)
+	}
+}
+
+func TestWriteAuthStatusOmitsServerExpiryWhenNil(t *testing.T) {
+	t.Parallel()
+
+	retrieved := time.Date(2026, 4, 28, 22, 4, 7, 0, time.UTC)
+	status := auth.Status{
+		Active:      true,
+		Provider:    "playwright-storage-state",
+		SessionFile: "/tmp/session.json",
+		RetrievedAt: &retrieved,
+	}
+
+	var buf bytes.Buffer
+	if err := writeAuthStatus(&buf, output.FormatTable, status); err != nil {
+		t.Fatalf("writeAuthStatus: %v", err)
+	}
+	if strings.Contains(buf.String(), "Server Expiry") {
+		t.Fatalf("expected no server expiry line, got %q", buf.String())
+	}
+}
+
+func TestRunAuthExtendSucceeds(t *testing.T) {
+	t.Parallel()
+
+	expiry := time.Date(2026, 5, 13, 7, 3, 20, 0, time.FixedZone("KST", 9*3600))
+	result := &auth.ExtendResult{
+		UUID:            "abc",
+		ServerExpiresAt: expiry,
+		Elapsed:         3 * time.Second,
+	}
+
+	var out bytes.Buffer
+	if err := writeExtendResult(&out, result); err != nil {
+		t.Fatalf("writeExtendResult: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Extension complete") {
+		t.Fatalf("expected success line, got %q", got)
+	}
+	if !strings.Contains(got, "2026-05-13 07:03 KST") {
+		t.Fatalf("expected formatted KST expiry, got %q", got)
+	}
+}
+
+func TestRunAuthExtendTimeoutMessage(t *testing.T) {
+	t.Parallel()
+
+	got := userFacingCommandError(auth.ErrExtensionTimeout).Error()
+	if !strings.Contains(got, "rerun") {
+		t.Fatalf("expected retry hint, got %q", got)
+	}
+	if !strings.Contains(got, "tossctl auth extend") {
+		t.Fatalf("expected extend command hint, got %q", got)
+	}
+}
+
+func TestRunAuthExtendRejectionMessage(t *testing.T) {
+	t.Parallel()
+
+	got := userFacingCommandError(auth.ErrExtensionRejected).Error()
+	if !strings.Contains(got, "denied") && !strings.Contains(got, "canceled") {
+		t.Fatalf("expected rejection wording, got %q", got)
+	}
+}
+
+func TestWriteExtendResultRendersKSTForRFC3339ParsedInput(t *testing.T) {
+	t.Parallel()
+
+	// Simulate the production path: server returns RFC3339Nano with numeric
+	// offset, parsed via time.Parse — the resulting Location is an anonymous
+	// FixedZone with empty name. writeExtendResult must still display "KST".
+	parsed, err := time.Parse(time.RFC3339Nano, "2026-05-13T07:03:20.24+09:00")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	result := &auth.ExtendResult{
+		UUID:            "abc",
+		ServerExpiresAt: parsed,
+		Elapsed:         3 * time.Second,
+	}
+
+	var out bytes.Buffer
+	if err := writeExtendResult(&out, result); err != nil {
+		t.Fatalf("writeExtendResult: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "2026-05-13 07:03 KST") {
+		t.Fatalf("expected KST label even for RFC3339-parsed input, got %q", got)
+	}
+}
+
+// Sanity check: spinner runs without crashing when stdout is not a TTY.
+func TestSpinnerSilentInNonTTY(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	stop := startSpinner(&out, "test", false)
+	time.Sleep(20 * time.Millisecond)
+	stop()
+	if out.Len() != 0 {
+		t.Fatalf("expected no output in non-TTY mode, got %q", out.String())
+	}
+}

--- a/cmd/tossctl/errors.go
+++ b/cmd/tossctl/errors.go
@@ -1,15 +1,18 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
 
+	"github.com/junghoonkye/tossinvest-cli/internal/auth"
 	tossclient "github.com/junghoonkye/tossinvest-cli/internal/client"
 	"github.com/junghoonkye/tossinvest-cli/internal/config"
 	"github.com/junghoonkye/tossinvest-cli/internal/permissions"
+	"github.com/junghoonkye/tossinvest-cli/internal/session"
 	"github.com/junghoonkye/tossinvest-cli/internal/trading"
 )
 
@@ -18,12 +21,26 @@ func userFacingCommandError(err error) error {
 		return nil
 	}
 
-	if errors.Is(err, tossclient.ErrNoSession) {
+	if errors.Is(err, context.Canceled) {
+		return fmt.Errorf("canceled")
+	}
+
+	if errors.Is(err, session.ErrNoSession) || errors.Is(err, tossclient.ErrNoSession) {
 		return fmt.Errorf("no active session; run `tossctl auth login`")
 	}
 
 	if tossclient.IsAuthError(err) {
-		return fmt.Errorf("stored session is no longer valid; run `tossctl auth login`")
+		return fmt.Errorf("stored session is no longer valid; run `tossctl auth extend` to renew, or `tossctl auth login` to re-authenticate")
+	}
+	if errors.Is(err, auth.ErrExtensionTimeout) {
+		// Surface the elapsed-time detail that Service.Extend wrapped into the error.
+		return fmt.Errorf("phone approval did not complete (%s); rerun `tossctl auth extend` to retry", extractParenDetail(err))
+	}
+	if errors.Is(err, auth.ErrExtensionRejected) {
+		return fmt.Errorf("phone approval was denied or canceled; rerun `tossctl auth extend` to retry")
+	}
+	if errors.Is(err, auth.ErrExtensionNotConfigured) {
+		return fmt.Errorf("internal error: ExtensionRunner is not configured")
 	}
 	if errors.Is(err, permissions.ErrNoGrant) || errors.Is(err, permissions.ErrExpiredGrant) {
 		return fmt.Errorf("no active trading permission grant; run `tossctl order permissions grant --ttl 300`")
@@ -202,6 +219,19 @@ func buildPlaceCommand(kind string, flags *placeFlags, confirm string) string {
 		args = append(args, "--execute", "--dangerously-skip-permissions", "--confirm", confirm)
 	}
 	return strings.Join(args, " ")
+}
+
+// extractParenDetail returns the parenthetical detail wrapped into a sentinel
+// error by Service.Extend (e.g. "(대기 120s)"). Returns "시간 초과" if no
+// detail is found, so the user-facing message is always a complete sentence.
+func extractParenDetail(err error) string {
+	msg := err.Error()
+	if i := strings.LastIndex(msg, "("); i != -1 {
+		if j := strings.LastIndex(msg, ")"); j > i {
+			return msg[i+1 : j]
+		}
+	}
+	return "시간 초과"
 }
 
 func formatCommandFloat(value float64) string {

--- a/cmd/tossctl/errors_test.go
+++ b/cmd/tossctl/errors_test.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/junghoonkye/tossinvest-cli/internal/auth"
+	tossclient "github.com/junghoonkye/tossinvest-cli/internal/client"
 	"github.com/junghoonkye/tossinvest-cli/internal/config"
+	"github.com/junghoonkye/tossinvest-cli/internal/session"
 	"github.com/junghoonkye/tossinvest-cli/internal/trading"
 )
 
@@ -119,4 +124,65 @@ func TestUserFacingPlaceErrorFormatsPostPrepareFXGuidance(t *testing.T) {
 
 func rootPathsForTest() config.Paths {
 	return config.Paths{}
+}
+
+func TestUserFacingCommandErrorAuthErrorMentionsExtend(t *testing.T) {
+	t.Parallel()
+
+	authErr := &tossclient.AuthError{StatusCode: 401, Endpoint: "/api/v1/account/list"}
+	got := userFacingCommandError(authErr).Error()
+	if !strings.Contains(got, "tossctl auth extend") {
+		t.Fatalf("expected auth extend hint, got %q", got)
+	}
+	if !strings.Contains(got, "tossctl auth login") {
+		t.Fatalf("expected auth login hint, got %q", got)
+	}
+}
+
+func TestUserFacingCommandErrorExtensionTimeout(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("%w (waited 120s)", auth.ErrExtensionTimeout)
+	got := userFacingCommandError(wrapped).Error()
+	if !strings.Contains(got, "waited 120s") {
+		t.Fatalf("expected timeout detail, got %q", got)
+	}
+	if !strings.Contains(got, "rerun") {
+		t.Fatalf("expected retry hint, got %q", got)
+	}
+	if !strings.Contains(got, "tossctl auth extend") {
+		t.Fatalf("expected extend command hint, got %q", got)
+	}
+}
+
+func TestUserFacingCommandErrorContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	got := userFacingCommandError(context.Canceled).Error()
+	if !strings.Contains(got, "canceled") {
+		t.Fatalf("expected cancellation message, got %q", got)
+	}
+}
+
+func TestUserFacingCommandErrorExtensionRejected(t *testing.T) {
+	t.Parallel()
+
+	got := userFacingCommandError(auth.ErrExtensionRejected).Error()
+	if !strings.Contains(got, "denied") && !strings.Contains(got, "canceled") {
+		t.Fatalf("expected rejection wording, got %q", got)
+	}
+}
+
+func TestUserFacingCommandErrorSessionErrNoSessionMentionsLogin(t *testing.T) {
+	t.Parallel()
+
+	for _, err := range []error{session.ErrNoSession, tossclient.ErrNoSession} {
+		got := userFacingCommandError(err).Error()
+		if !strings.Contains(got, "tossctl auth login") {
+			t.Fatalf("for %v: expected login hint, got %q", err, got)
+		}
+		if !strings.Contains(got, "no active session") {
+			t.Fatalf("for %v: expected friendly message, got %q", err, got)
+		}
+	}
 }

--- a/cmd/tossctl/root.go
+++ b/cmd/tossctl/root.go
@@ -3,7 +3,10 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"path/filepath"
+	"time"
 
 	"github.com/junghoonkye/tossinvest-cli/internal/auth"
 	tossclient "github.com/junghoonkye/tossinvest-cli/internal/client"
@@ -46,8 +49,14 @@ func newRootCmd() *cobra.Command {
 			"web client with browser-assisted login and a narrow trading beta surface.",
 		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			_, err := output.ParseFormat(opts.outputFormat)
-			return err
+			format, err := output.ParseFormat(opts.outputFormat)
+			if err != nil {
+				return err
+			}
+			store := session.NewFileStore(resolveSessionFile(opts))
+			sess, _ := store.Load(cmd.Context())
+			writeExpiryWarningIfNeeded(cmd.ErrOrStderr(), sess, deepestCommandName(cmd), format, time.Now())
+			return nil
 		},
 	}
 
@@ -87,6 +96,76 @@ func newRootCmd() *cobra.Command {
 	)
 
 	return cmd
+}
+
+// resolveSessionFile mirrors the resolution done in newAppContext but without
+// requiring the full app context — PersistentPreRunE runs before subcommands
+// have built theirs.
+func resolveSessionFile(opts *rootOptions) string {
+	if opts.sessionFile != "" {
+		return opts.sessionFile
+	}
+	if opts.configDir != "" {
+		return filepath.Join(opts.configDir, "session.json")
+	}
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		return ""
+	}
+	return paths.SessionFile
+}
+
+func deepestCommandName(cmd *cobra.Command) string {
+	if cmd == nil {
+		return ""
+	}
+	return cmd.Name()
+}
+
+var expiryWarningSkipCommands = map[string]struct{}{
+	"extend":                  {},
+	"login":                   {},
+	"logout":                  {},
+	"status":                  {},
+	"import-playwright-state": {},
+	"version":                 {},
+	"help":                    {},
+}
+
+func writeExpiryWarningIfNeeded(w io.Writer, sess *session.Session, cmdName string, format output.Format, now time.Time) {
+	if sess == nil || sess.ServerExpiresAt == nil {
+		return
+	}
+	if format == output.FormatJSON {
+		return
+	}
+	if _, skip := expiryWarningSkipCommands[cmdName]; skip {
+		return
+	}
+	remaining := sess.ServerExpiresAt.Sub(now)
+	if remaining <= 0 || remaining >= 24*time.Hour {
+		return
+	}
+	fmt.Fprintf(w, "⚠ session expires in ~%s; run `tossctl auth extend` to renew\n", humanizeDuration(remaining))
+}
+
+func humanizeDuration(d time.Duration) string {
+	if d <= 0 {
+		return "0s"
+	}
+	hours := int(d.Hours())
+	if hours >= 1 {
+		minutes := int(d.Minutes()) % 60
+		if minutes == 0 {
+			return fmt.Sprintf("%dh", hours)
+		}
+		return fmt.Sprintf("%dh %dm", hours, minutes)
+	}
+	minutes := int(d.Minutes())
+	if minutes >= 1 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	return fmt.Sprintf("%ds", int(d.Seconds()))
 }
 
 func newAppContext(opts *rootOptions) (*appContext, error) {
@@ -137,8 +216,9 @@ func newAppContext(opts *rootOptions) (*appContext, error) {
 		configService: configService,
 		loginConfig:   loginConfig,
 		authService: auth.NewService(store, paths.SessionFile, auth.Options{
-			LoginConfig: loginConfig,
-			Validator:   client,
+			LoginConfig:     loginConfig,
+			Validator:       client,
+			ExtensionRunner: client,
 		}),
 		client:            client,
 		session:           sess,

--- a/cmd/tossctl/root_test.go
+++ b/cmd/tossctl/root_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/output"
+	"github.com/junghoonkye/tossinvest-cli/internal/session"
+)
+
+func TestExpiryWarningWithin24Hours(t *testing.T) {
+	t.Parallel()
+
+	exp := time.Now().Add(18 * time.Hour)
+	sess := &session.Session{ServerExpiresAt: &exp}
+
+	var buf bytes.Buffer
+	writeExpiryWarningIfNeeded(&buf, sess, "portfolio", output.FormatTable, time.Now())
+	got := buf.String()
+	if !strings.Contains(got, "session expires") {
+		t.Fatalf("expected warning, got %q", got)
+	}
+	if !strings.Contains(got, "tossctl auth extend") {
+		t.Fatalf("expected hint about auth extend, got %q", got)
+	}
+}
+
+func TestExpiryWarningSilentBeyond24Hours(t *testing.T) {
+	t.Parallel()
+
+	exp := time.Now().Add(48 * time.Hour)
+	sess := &session.Session{ServerExpiresAt: &exp}
+
+	var buf bytes.Buffer
+	writeExpiryWarningIfNeeded(&buf, sess, "portfolio", output.FormatTable, time.Now())
+	if buf.Len() != 0 {
+		t.Fatalf("expected silence, got %q", buf.String())
+	}
+}
+
+func TestExpiryWarningSilentInJSONMode(t *testing.T) {
+	t.Parallel()
+
+	exp := time.Now().Add(2 * time.Hour)
+	sess := &session.Session{ServerExpiresAt: &exp}
+
+	var buf bytes.Buffer
+	writeExpiryWarningIfNeeded(&buf, sess, "portfolio", output.FormatJSON, time.Now())
+	if buf.Len() != 0 {
+		t.Fatalf("expected silence in JSON mode, got %q", buf.String())
+	}
+}
+
+func TestExpiryWarningSilentForExtendCommand(t *testing.T) {
+	t.Parallel()
+
+	exp := time.Now().Add(2 * time.Hour)
+	sess := &session.Session{ServerExpiresAt: &exp}
+
+	for _, name := range []string{"extend", "login", "logout", "status", "import-playwright-state", "version", "help"} {
+		var buf bytes.Buffer
+		writeExpiryWarningIfNeeded(&buf, sess, name, output.FormatTable, time.Now())
+		if buf.Len() != 0 {
+			t.Fatalf("expected silence for %q, got %q", name, buf.String())
+		}
+	}
+}
+
+func TestExpiryWarningSilentWhenAlreadyExpired(t *testing.T) {
+	t.Parallel()
+
+	exp := time.Now().Add(-1 * time.Hour)
+	sess := &session.Session{ServerExpiresAt: &exp}
+
+	var buf bytes.Buffer
+	writeExpiryWarningIfNeeded(&buf, sess, "portfolio", output.FormatTable, time.Now())
+	// Already expired — let the 401 path handle it; don't add noise.
+	if buf.Len() != 0 {
+		t.Fatalf("expected silence when already expired, got %q", buf.String())
+	}
+}

--- a/docs/reverse-engineering/auth-notes.md
+++ b/docs/reverse-engineering/auth-notes.md
@@ -84,6 +84,25 @@ Consequences:
 - No "silent re-auth via long-lived token" exists. Without a valid SESSION the server's `/api/v3/init` issues a fresh guest SESSION and the page redirects to `/signin`. `UTK/LTK/FTK/BTK` alone do not prove identity.
 - Browser tabs appear to "persist for days" only because (a) the dashboard polls authenticated APIs every 3–30 seconds while the tab is open (≈460 calls observed over 18 min of user idle), keeping the idle timer warm, or (b) the browser has a persistent SESSION from having confirmed "이 기기 로그인 유지".
 
+### Server-side activity expiry (~7 days)
+
+Despite the 1-year cookie `Max-Age`, the server runs a separate ~7-day activity-expiry clock per session. `GET /api/v1/session/expired-at` returns the current value as KST RFC3339. When < 24h remain, the web app displays a `로그인이 곧 풀릴 수 있어요` tooltip and a `로그인 유지하기` button inside the profile popover.
+
+Full extension flow (captured live 2026-05-05):
+
+```
+POST /api/v1/wts-login-extend/doc/request           → {result:{txId:"<uuid>"}}      // also sends phone push
+GET  /api/v1/wts-login-extend/doc/{txId}/status     → {result:"REQUESTED"}          // poll ~1s while pending
+                                                    → {result:"COMPLETED"}          // after phone approval
+POST /api/v1/wts-login-extend/{txId}/state          → 200 {}                        // ★ required finalize — without this, expired-at does NOT advance
+GET  /api/v1/session/expired-at                     → {result:"<new ISO8601 KST>"}  // ~7 days further out
+GET  /api/v1/wts-login-extend/doc/{txId}/status     → {result:"EXPIRED"}            // doc consumed
+```
+
+The `POST /state` step is the easy thing to miss: status `COMPLETED` looks like success but the server activity clock only advances after `/state` is called. tossctl mirrors this full chain in `tossctl auth extend`.
+
+The **"Exempt"** entry in the table above therefore applies only to the cookie-level idle timeout (the ≈1-hour sliding window). It does **not** exempt the persistent SESSION from this server-side activity-expiry clock. In practice, a long-running CLI automation that never idles more than 1 hour can still hit a hard wall after ~7 days without explicit extension.
+
 ## Logout Behavior (Set-Cookie on 2xx)
 
 Several `wts-cert-api.tossinvest.com` endpoints respond to 2xx requests with `Set-Cookie: SESSION=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=Lax` — an instruction to **delete** the client-side SESSION cookie. Observed at least on:

--- a/internal/auth/extend.go
+++ b/internal/auth/extend.go
@@ -1,0 +1,94 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/session"
+)
+
+var (
+	ErrExtensionTimeout       = errors.New("auth extend: phone approval timed out")
+	ErrExtensionRejected      = errors.New("auth extend: phone approval was rejected or canceled")
+	ErrExtensionNotConfigured = errors.New("auth extend: ExtensionRunner not configured")
+)
+
+type ExtendResult struct {
+	UUID            string
+	ServerExpiresAt time.Time
+	Elapsed         time.Duration
+}
+
+func (s *Service) Extend(ctx context.Context, timeout time.Duration) (*ExtendResult, error) {
+	if s.extensionRunner == nil {
+		return nil, ErrExtensionNotConfigured
+	}
+
+	sess, err := s.store.Load(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if sess == nil || len(sess.Cookies) == 0 {
+		return nil, session.ErrNoSession
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	start := time.Now()
+	uuid, err := s.extensionRunner.RequestExtension(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("request extension: %w", err)
+	}
+
+	ticker := time.NewTicker(s.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		status, err := s.extensionRunner.GetExtensionStatus(ctx, uuid)
+		if err == nil {
+			if status.Approved() {
+				break
+			}
+			if status.Rejected() {
+				return nil, ErrExtensionRejected
+			}
+		} else if !isContextErr(err) {
+			return nil, fmt.Errorf("poll extension status: %w", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return nil, fmt.Errorf("%w (waited %s)", ErrExtensionTimeout, time.Since(start).Round(time.Second))
+			}
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+
+	if err := s.extensionRunner.FinalizeExtension(ctx, uuid); err != nil {
+		return nil, fmt.Errorf("finalize extension: %w", err)
+	}
+
+	expiredAt, err := s.extensionRunner.GetServerExpiredAt(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read new expiry: %w", err)
+	}
+	sess.ServerExpiresAt = &expiredAt
+	if err := s.store.Save(ctx, sess); err != nil {
+		return nil, fmt.Errorf("persist new expiry: %w", err)
+	}
+
+	return &ExtendResult{
+		UUID:            uuid,
+		ServerExpiresAt: expiredAt,
+		Elapsed:         time.Since(start),
+	}, nil
+}
+
+func isContextErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}

--- a/internal/auth/extend_test.go
+++ b/internal/auth/extend_test.go
@@ -1,0 +1,285 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/client"
+	"github.com/junghoonkye/tossinvest-cli/internal/session"
+)
+
+type fakeExtensionRunner struct {
+	requestErr     error
+	statusSequence []client.ExtensionStatus
+	statusErr      error
+	finalizeErr    error
+	expiredAt      time.Time
+	expiredErr     error
+	requestCalls   atomic.Int32
+	statusCalls    atomic.Int32
+	finalizeCalls  atomic.Int32
+	expiredAtCalls atomic.Int32
+}
+
+func (r *fakeExtensionRunner) RequestExtension(context.Context) (string, error) {
+	r.requestCalls.Add(1)
+	return "uuid-1", r.requestErr
+}
+
+func (r *fakeExtensionRunner) GetExtensionStatus(context.Context, string) (client.ExtensionStatus, error) {
+	idx := int(r.statusCalls.Add(1)) - 1
+	if r.statusErr != nil {
+		return client.ExtensionStatus{}, r.statusErr
+	}
+	if idx >= len(r.statusSequence) {
+		return r.statusSequence[len(r.statusSequence)-1], nil
+	}
+	return r.statusSequence[idx], nil
+}
+
+func (r *fakeExtensionRunner) FinalizeExtension(context.Context, string) error {
+	r.finalizeCalls.Add(1)
+	return r.finalizeErr
+}
+
+func (r *fakeExtensionRunner) GetServerExpiredAt(context.Context) (time.Time, error) {
+	r.expiredAtCalls.Add(1)
+	return r.expiredAt, r.expiredErr
+}
+
+func newExtendService(t *testing.T, runner ExtensionRunner) (*Service, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "session.json")
+	if err := session.NewFileStore(path).Save(context.Background(), &session.Session{
+		Provider:    "playwright-storage-state",
+		Cookies:     map[string]string{"SESSION": "s"},
+		Headers:     map[string]string{"X-XSRF-TOKEN": "x"},
+		RetrievedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	svc := NewService(
+		session.NewFileStore(path),
+		path,
+		Options{ExtensionRunner: runner, PollInterval: time.Millisecond},
+	)
+	return svc, path
+}
+
+func TestExtendApprovesAfterPolling(t *testing.T) {
+	t.Parallel()
+
+	want := time.Date(2026, 5, 13, 7, 3, 20, 0, time.FixedZone("KST", 9*3600))
+	runner := &fakeExtensionRunner{
+		statusSequence: []client.ExtensionStatus{
+			{Status: "REQUESTED"},
+			{Status: "REQUESTED"},
+			{Status: "COMPLETED"},
+		},
+		expiredAt: want,
+	}
+	svc, path := newExtendService(t, runner)
+
+	result, err := svc.Extend(context.Background(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("Extend: %v", err)
+	}
+	if result.UUID != "uuid-1" {
+		t.Fatalf("UUID = %q", result.UUID)
+	}
+	if !result.ServerExpiresAt.Equal(want) {
+		t.Fatalf("ServerExpiresAt = %s, want %s", result.ServerExpiresAt, want)
+	}
+	if runner.statusCalls.Load() != 3 {
+		t.Fatalf("expected 3 status polls, got %d", runner.statusCalls.Load())
+	}
+	if runner.finalizeCalls.Load() != 1 {
+		t.Fatalf("expected 1 finalize call, got %d", runner.finalizeCalls.Load())
+	}
+
+	stored, err := session.NewFileStore(path).Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if stored.ServerExpiresAt == nil || !stored.ServerExpiresAt.Equal(want) {
+		t.Fatalf("ServerExpiresAt not persisted")
+	}
+}
+
+func TestExtendReturnsRejectionEarly(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeExtensionRunner{
+		statusSequence: []client.ExtensionStatus{
+			{Status: "REQUESTED"},
+			{Status: "EXPIRED"},
+		},
+	}
+	svc, _ := newExtendService(t, runner)
+
+	_, err := svc.Extend(context.Background(), 5*time.Second)
+	if !errors.Is(err, ErrExtensionRejected) {
+		t.Fatalf("expected ErrExtensionRejected, got %v", err)
+	}
+	if runner.expiredAtCalls.Load() != 0 {
+		t.Fatal("should not call GetServerExpiredAt on rejection")
+	}
+	if runner.finalizeCalls.Load() != 0 {
+		t.Fatal("should not call FinalizeExtension on rejection")
+	}
+}
+
+func TestExtendWrapsFinalizeError(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeExtensionRunner{
+		statusSequence: []client.ExtensionStatus{{Status: "COMPLETED"}},
+		finalizeErr:    errors.New("400 invalid-access"),
+	}
+	svc, _ := newExtendService(t, runner)
+
+	_, err := svc.Extend(context.Background(), 5*time.Second)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "finalize extension") {
+		t.Fatalf("expected wrap prefix 'finalize extension', got %q", err.Error())
+	}
+	if runner.expiredAtCalls.Load() != 0 {
+		t.Fatal("should not call GetServerExpiredAt when finalize fails")
+	}
+}
+
+func TestExtendTimesOut(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeExtensionRunner{
+		statusSequence: []client.ExtensionStatus{{Status: "REQUESTED"}},
+	}
+	svc, _ := newExtendService(t, runner)
+
+	_, err := svc.Extend(context.Background(), 10*time.Millisecond)
+	if !errors.Is(err, ErrExtensionTimeout) {
+		t.Fatalf("expected ErrExtensionTimeout, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "waited") {
+		t.Fatalf("expected wrapped 'waited' detail, got %q", err.Error())
+	}
+}
+
+func TestExtendRespectsContextCancel(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeExtensionRunner{
+		statusSequence: []client.ExtensionStatus{{Status: "REQUESTED"}},
+	}
+	svc, _ := newExtendService(t, runner)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := svc.Extend(ctx, 5*time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestExtendRequiresStoredSession(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "session.json")
+	svc := NewService(
+		session.NewFileStore(path),
+		path,
+		Options{ExtensionRunner: &fakeExtensionRunner{}, PollInterval: time.Millisecond},
+	)
+
+	_, err := svc.Extend(context.Background(), time.Second)
+	if !errors.Is(err, session.ErrNoSession) {
+		t.Fatalf("expected ErrNoSession, got %v", err)
+	}
+}
+
+func TestExtendWrapsRequestError(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeExtensionRunner{requestErr: errors.New("dial tcp: connection refused")}
+	svc, _ := newExtendService(t, runner)
+
+	_, err := svc.Extend(context.Background(), 5*time.Second)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "request extension") {
+		t.Fatalf("expected wrap prefix 'request extension', got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("expected underlying error to be retained, got %q", err.Error())
+	}
+}
+
+func TestExtendWrapsPollingError(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeExtensionRunner{statusErr: errors.New("503 service unavailable")}
+	svc, _ := newExtendService(t, runner)
+
+	_, err := svc.Extend(context.Background(), 5*time.Second)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "poll extension status") {
+		t.Fatalf("expected wrap prefix 'poll extension status', got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "503 service unavailable") {
+		t.Fatalf("expected underlying error to be retained, got %q", err.Error())
+	}
+}
+
+func TestExtendWrapsExpiryRefreshError(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeExtensionRunner{
+		statusSequence: []client.ExtensionStatus{{Status: "COMPLETED"}},
+		expiredErr:     errors.New("502 bad gateway"),
+	}
+	svc, _ := newExtendService(t, runner)
+
+	_, err := svc.Extend(context.Background(), 5*time.Second)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "read new expiry") {
+		t.Fatalf("expected wrap prefix 'read new expiry', got %q", err.Error())
+	}
+}
+
+func TestExtendRequiresExtensionRunner(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "session.json")
+	if err := session.NewFileStore(path).Save(context.Background(), &session.Session{
+		Provider:    "playwright-storage-state",
+		Cookies:     map[string]string{"SESSION": "s"},
+		RetrievedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	svc := NewService(
+		session.NewFileStore(path),
+		path,
+		Options{PollInterval: time.Millisecond},
+	)
+
+	_, err := svc.Extend(context.Background(), time.Second)
+	if !errors.Is(err, ErrExtensionNotConfigured) {
+		t.Fatalf("expected ErrExtensionNotConfigured, got %v", err)
+	}
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/junghoonkye/tossinvest-cli/internal/client"
 	"github.com/junghoonkye/tossinvest-cli/internal/session"
 )
 
@@ -20,17 +21,21 @@ type LoginConfig struct {
 }
 
 type Options struct {
-	LoginConfig LoginConfig
-	Runner      LoginRunner
-	Validator   SessionValidator
+	LoginConfig     LoginConfig
+	Runner          LoginRunner
+	Validator       SessionValidator
+	ExtensionRunner ExtensionRunner
+	PollInterval    time.Duration // defaults to 1s when zero
 }
 
 type Service struct {
-	store       session.Store
-	sessionFile string
-	loginConfig LoginConfig
-	runner      LoginRunner
-	validator   SessionValidator
+	store           session.Store
+	sessionFile     string
+	loginConfig     LoginConfig
+	runner          LoginRunner
+	validator       SessionValidator
+	extensionRunner ExtensionRunner
+	pollInterval    time.Duration
 }
 
 type Status struct {
@@ -41,6 +46,7 @@ type Status struct {
 	StorageKeys     int        `json:"storage_keys,omitempty"`
 	RetrievedAt     *time.Time `json:"retrieved_at,omitempty"`
 	ExpiresAt       *time.Time `json:"expires_at,omitempty"`
+	ServerExpiresAt *time.Time `json:"server_expires_at,omitempty"`
 	SessionFile     string     `json:"session_file"`
 	Validated       bool       `json:"validated"`
 	Valid           bool       `json:"valid"`
@@ -50,6 +56,14 @@ type Status struct {
 
 type SessionValidator interface {
 	ValidateSession(context.Context) error
+	GetServerExpiredAt(context.Context) (time.Time, error)
+}
+
+type ExtensionRunner interface {
+	RequestExtension(context.Context) (string, error)
+	GetExtensionStatus(context.Context, string) (client.ExtensionStatus, error)
+	FinalizeExtension(context.Context, string) error
+	GetServerExpiredAt(context.Context) (time.Time, error)
 }
 
 func DefaultLoginConfig(cacheDir string) LoginConfig {
@@ -157,12 +171,19 @@ func NewService(store session.Store, sessionFile string, opts Options) *Service 
 		runner = PythonLoginRunner{}
 	}
 
+	pollInterval := opts.PollInterval
+	if pollInterval <= 0 {
+		pollInterval = time.Second
+	}
+
 	return &Service{
-		store:       store,
-		sessionFile: sessionFile,
-		loginConfig: opts.LoginConfig,
-		runner:      runner,
-		validator:   opts.Validator,
+		store:           store,
+		sessionFile:     sessionFile,
+		loginConfig:     opts.LoginConfig,
+		runner:          runner,
+		validator:       opts.Validator,
+		extensionRunner: opts.ExtensionRunner,
+		pollInterval:    pollInterval,
 	}
 }
 
@@ -207,14 +228,15 @@ func (s *Service) Status(ctx context.Context) (Status, error) {
 	}
 
 	status := Status{
-		Active:      true,
-		Expired:     sess.IsExpired(time.Now()),
-		Provider:    sess.Provider,
-		CookieCount: len(sess.Cookies),
-		StorageKeys: len(sess.Storage),
-		RetrievedAt: &sess.RetrievedAt,
-		ExpiresAt:   sess.ExpiresAt,
-		SessionFile: s.sessionFile,
+		Active:          true,
+		Expired:         sess.IsExpired(time.Now()),
+		Provider:        sess.Provider,
+		CookieCount:     len(sess.Cookies),
+		StorageKeys:     len(sess.Storage),
+		RetrievedAt:     &sess.RetrievedAt,
+		ExpiresAt:       sess.ExpiresAt,
+		ServerExpiresAt: sess.ServerExpiresAt,
+		SessionFile:     s.sessionFile,
 	}
 
 	if s.validator != nil {
@@ -227,6 +249,12 @@ func (s *Service) Status(ctx context.Context) (Status, error) {
 			return status, nil
 		}
 		status.Valid = true
+
+		if expiredAt, err := s.validator.GetServerExpiredAt(ctx); err == nil {
+			status.ServerExpiresAt = &expiredAt
+			sess.ServerExpiresAt = &expiredAt
+			_ = s.store.Save(ctx, sess) // best-effort persist; non-fatal on save error
+		}
 	}
 
 	return status, nil

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -29,6 +29,10 @@ func (v fakeSessionValidator) ValidateSession(context.Context) error {
 	return v.err
 }
 
+func (v fakeSessionValidator) GetServerExpiredAt(context.Context) (time.Time, error) {
+	return time.Time{}, errors.New("not implemented in fake")
+}
+
 func TestLoginImportsHelperStorageState(t *testing.T) {
 	t.Parallel()
 
@@ -168,6 +172,58 @@ func TestStatusCapturesValidationError(t *testing.T) {
 	}
 	if status.ValidationError != "session rejected" {
 		t.Fatalf("unexpected validation error: %q", status.ValidationError)
+	}
+}
+
+type fakeServerExpiredAtValidator struct {
+	validateErr error
+	expiredAt   time.Time
+	expiredErr  error
+}
+
+func (v fakeServerExpiredAtValidator) ValidateSession(context.Context) error {
+	return v.validateErr
+}
+
+func (v fakeServerExpiredAtValidator) GetServerExpiredAt(context.Context) (time.Time, error) {
+	return v.expiredAt, v.expiredErr
+}
+
+func TestStatusRefreshesServerExpiresAt(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "session.json")
+	if err := session.NewFileStore(path).Save(context.Background(), &session.Session{
+		Provider:    "playwright-storage-state",
+		Cookies:     map[string]string{"SESSION": "s"},
+		RetrievedAt: mustTime(t, "2026-05-04T13:00:00Z"),
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	want := mustTime(t, "2026-05-13T07:03:20+09:00")
+	svc := NewService(
+		session.NewFileStore(path),
+		path,
+		Options{Validator: fakeServerExpiredAtValidator{expiredAt: want}},
+	)
+
+	status, err := svc.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.ServerExpiresAt == nil || !status.ServerExpiresAt.Equal(want) {
+		t.Fatalf("ServerExpiresAt = %v, want %v", status.ServerExpiresAt, &want)
+	}
+
+	// And the value should be persisted back to disk.
+	stored, err := session.NewFileStore(path).Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if stored.ServerExpiresAt == nil || !stored.ServerExpiresAt.Equal(want) {
+		t.Fatalf("disk ServerExpiresAt not persisted")
 	}
 }
 

--- a/internal/client/auth_extend.go
+++ b/internal/client/auth_extend.go
@@ -1,0 +1,169 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type ExtensionStatus struct {
+	Status string
+}
+
+// Captured live on 2026-05-05 against wts-api.tossinvest.com:
+//
+//	REQUESTED → COMPLETED → EXPIRED
+//	pending     phone OK    finalized (POST /state) or doc TTL elapsed
+//
+// Service.Extend polls up to COMPLETED, then calls FinalizeExtension and
+// returns — so it never observes EXPIRED for its own successful doc. If
+// EXPIRED shows up DURING polling it means the doc was invalidated before
+// approval (idle TTL or superseded by a newer request); we surface that as
+// rejection so the user gets a clear retry hint instead of waiting for the
+// outer timeout.
+//
+// Phone-rejection / user-cancel enums were not observed live; if Toss adds a
+// distinct rejection string we'll polling-loop until --timeout (still safe,
+// just less crisp UX). Add it here when captured.
+var (
+	extensionApprovedStates = map[string]struct{}{
+		"COMPLETED": {},
+	}
+	extensionRejectedStates = map[string]struct{}{
+		"EXPIRED": {},
+	}
+)
+
+func (s ExtensionStatus) Approved() bool {
+	_, ok := extensionApprovedStates[strings.ToUpper(strings.TrimSpace(s.Status))]
+	return ok
+}
+
+func (s ExtensionStatus) Rejected() bool {
+	_, ok := extensionRejectedStates[strings.ToUpper(strings.TrimSpace(s.Status))]
+	return ok
+}
+
+type extensionRequestEnvelope struct {
+	Result struct {
+		TxID string `json:"txId"`
+	} `json:"result"`
+}
+
+// /doc/{uuid}/status returns the status string directly under "result" (not
+// nested under a struct). Captured live on 2026-05-05 — pending state is
+// "REQUESTED"; approved/rejected enums are still being mapped.
+type extensionStatusEnvelope struct {
+	Result string `json:"result"`
+}
+
+type serverExpiredAtEnvelope struct {
+	Result string `json:"result"`
+}
+
+// RequestExtension creates a session-extension document and returns the UUID
+// the user must approve from the Toss phone app. The server fans out a push
+// notification as a side effect.
+func (c *Client) RequestExtension(ctx context.Context) (string, error) {
+	if err := c.requireSession(); err != nil {
+		return "", err
+	}
+	endpoint := c.apiBaseURL + "/api/v1/wts-login-extend/doc/request"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.applySession(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", newStatusError(resp.StatusCode, endpoint, body)
+	}
+
+	var env extensionRequestEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return "", fmt.Errorf("decode extension request: %w", err)
+	}
+	id := strings.TrimSpace(env.Result.TxID)
+	if id == "" {
+		return "", fmt.Errorf("extension request returned empty txId")
+	}
+	return id, nil
+}
+
+// GetExtensionStatus polls a previously-issued extension document.
+func (c *Client) GetExtensionStatus(ctx context.Context, uuid string) (ExtensionStatus, error) {
+	if err := c.requireSession(); err != nil {
+		return ExtensionStatus{}, err
+	}
+	endpoint := c.apiBaseURL + "/api/v1/wts-login-extend/doc/" + uuid + "/status"
+	var env extensionStatusEnvelope
+	if err := c.getJSON(ctx, endpoint, &env); err != nil {
+		return ExtensionStatus{}, err
+	}
+	return ExtensionStatus{Status: env.Result}, nil
+}
+
+// FinalizeExtension consumes an approved extension document. Without this
+// step the server-side expiry clock does NOT advance even though
+// /doc/{uuid}/status reports "COMPLETED" — the web UI calls this immediately
+// after the status transition and only then does /session/expired-at return a
+// new value.
+func (c *Client) FinalizeExtension(ctx context.Context, uuid string) error {
+	if err := c.requireSession(); err != nil {
+		return err
+	}
+	endpoint := c.apiBaseURL + "/api/v1/wts-login-extend/" + uuid + "/state"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.applySession(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return newStatusError(resp.StatusCode, endpoint, body)
+	}
+	return nil
+}
+
+// GetServerExpiredAt returns the current server-side session expiry time as a
+// time.Time preserving its original offset (KST in observed responses).
+func (c *Client) GetServerExpiredAt(ctx context.Context) (time.Time, error) {
+	if err := c.requireSession(); err != nil {
+		return time.Time{}, err
+	}
+	endpoint := c.apiBaseURL + "/api/v1/session/expired-at"
+	var env serverExpiredAtEnvelope
+	if err := c.getJSON(ctx, endpoint, &env); err != nil {
+		return time.Time{}, err
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, env.Result)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse server expired-at %q: %w", env.Result, err)
+	}
+	return parsed, nil
+}

--- a/internal/client/auth_extend_test.go
+++ b/internal/client/auth_extend_test.go
@@ -1,0 +1,171 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/session"
+)
+
+func TestRequestExtensionReturnsDocID(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/wts-login-extend/doc/request" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if got := r.Header.Get("X-XSRF-TOKEN"); got != "xsrf-test" {
+			t.Fatalf("missing XSRF header: %q", got)
+		}
+		_, _ = w.Write([]byte(`{"result":{"txId":"abc-123"}}`))
+	}))
+	defer server.Close()
+
+	c := New(Config{
+		HTTPClient: server.Client(),
+		APIBaseURL: server.URL,
+		Session: &session.Session{
+			Cookies: map[string]string{"SESSION": "s"},
+			Headers: map[string]string{"X-XSRF-TOKEN": "xsrf-test"},
+		},
+	})
+
+	uuid, err := c.RequestExtension(context.Background())
+	if err != nil {
+		t.Fatalf("RequestExtension: %v", err)
+	}
+	if uuid != "abc-123" {
+		t.Fatalf("uuid = %q, want abc-123", uuid)
+	}
+}
+
+func TestGetExtensionStatusReportsApproval(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/api/v1/wts-login-extend/doc/abc-123/status") {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		calls++
+		if calls < 2 {
+			_, _ = w.Write([]byte(`{"result":"REQUESTED"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"result":"COMPLETED"}`))
+	}))
+	defer server.Close()
+
+	c := New(Config{
+		HTTPClient: server.Client(),
+		APIBaseURL: server.URL,
+		Session:    &session.Session{Cookies: map[string]string{"SESSION": "s"}},
+	})
+
+	st1, err := c.GetExtensionStatus(context.Background(), "abc-123")
+	if err != nil {
+		t.Fatalf("GetExtensionStatus #1: %v", err)
+	}
+	if st1.Approved() || st1.Rejected() {
+		t.Fatalf("expected pending, got %+v", st1)
+	}
+
+	st2, err := c.GetExtensionStatus(context.Background(), "abc-123")
+	if err != nil {
+		t.Fatalf("GetExtensionStatus #2: %v", err)
+	}
+	if !st2.Approved() {
+		t.Fatalf("expected approved, got %+v", st2)
+	}
+}
+
+func TestGetServerExpiredAtParsesKST(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/session/expired-at" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"result": "2026-05-13T07:03:20.24+09:00"})
+	}))
+	defer server.Close()
+
+	c := New(Config{
+		HTTPClient: server.Client(),
+		APIBaseURL: server.URL,
+		Session:    &session.Session{Cookies: map[string]string{"SESSION": "s"}},
+	})
+
+	got, err := c.GetServerExpiredAt(context.Background())
+	if err != nil {
+		t.Fatalf("GetServerExpiredAt: %v", err)
+	}
+	want := time.Date(2026, 5, 13, 7, 3, 20, 240_000_000, time.FixedZone("KST", 9*3600))
+	if !got.Equal(want) {
+		t.Fatalf("expiry = %s, want %s", got, want)
+	}
+}
+
+func TestRequestExtensionWithoutSessionReturnsAuthError(t *testing.T) {
+	t.Parallel()
+
+	c := New(Config{})
+	_, err := c.RequestExtension(context.Background())
+	if !IsAuthError(err) {
+		t.Fatalf("expected auth error, got %v", err)
+	}
+}
+
+func TestFinalizeExtensionPostsState(t *testing.T) {
+	t.Parallel()
+
+	var captured struct {
+		path   string
+		method string
+		ctype  string
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.path = r.URL.Path
+		captured.method = r.Method
+		captured.ctype = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	c := New(Config{
+		HTTPClient: server.Client(),
+		APIBaseURL: server.URL,
+		Session:    &session.Session{Cookies: map[string]string{"SESSION": "s"}},
+	})
+
+	if err := c.FinalizeExtension(context.Background(), "abc-123"); err != nil {
+		t.Fatalf("FinalizeExtension: %v", err)
+	}
+	if captured.path != "/api/v1/wts-login-extend/abc-123/state" {
+		t.Fatalf("path = %s", captured.path)
+	}
+	if captured.method != http.MethodPost {
+		t.Fatalf("method = %s", captured.method)
+	}
+	if captured.ctype != "application/json" {
+		t.Fatalf("content-type = %s", captured.ctype)
+	}
+}
+
+func TestFinalizeExtensionWithoutSessionReturnsAuthError(t *testing.T) {
+	t.Parallel()
+
+	c := New(Config{})
+	if err := c.FinalizeExtension(context.Background(), "abc-123"); !IsAuthError(err) {
+		t.Fatalf("expected auth error, got %v", err)
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -12,12 +12,13 @@ import (
 var ErrNoSession = errors.New("no stored session")
 
 type Session struct {
-	Provider    string            `json:"provider"`
-	Cookies     map[string]string `json:"cookies,omitempty"`
-	Headers     map[string]string `json:"headers,omitempty"`
-	Storage     map[string]string `json:"storage,omitempty"`
-	RetrievedAt time.Time         `json:"retrieved_at"`
-	ExpiresAt   *time.Time        `json:"expires_at,omitempty"`
+	Provider        string            `json:"provider"`
+	Cookies         map[string]string `json:"cookies,omitempty"`
+	Headers         map[string]string `json:"headers,omitempty"`
+	Storage         map[string]string `json:"storage,omitempty"`
+	RetrievedAt     time.Time         `json:"retrieved_at"`
+	ExpiresAt       *time.Time        `json:"expires_at,omitempty"`
+	ServerExpiresAt *time.Time        `json:"server_expires_at,omitempty"`
 }
 
 type Store interface {

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -1,0 +1,41 @@
+package session
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSessionServerExpiresAtRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "session.json")
+	store := NewFileStore(path)
+
+	cookie := time.Date(2027, 4, 28, 22, 3, 53, 0, time.UTC)
+	server := time.Date(2026, 5, 13, 7, 3, 20, 0, time.FixedZone("KST", 9*3600))
+
+	in := &Session{
+		Provider:        "playwright-storage-state",
+		Cookies:         map[string]string{"SESSION": "x"},
+		RetrievedAt:     time.Now().UTC(),
+		ExpiresAt:       &cookie,
+		ServerExpiresAt: &server,
+	}
+	if err := store.Save(context.Background(), in); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	out, err := store.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if out.ServerExpiresAt == nil || !out.ServerExpiresAt.Equal(server) {
+		t.Fatalf("ServerExpiresAt mismatch: got %v, want %v", out.ServerExpiresAt, &server)
+	}
+	if out.ExpiresAt == nil || !out.ExpiresAt.Equal(cookie) {
+		t.Fatalf("ExpiresAt mismatch")
+	}
+}


### PR DESCRIPTION
## Summary

- **`tossctl auth extend`** 신규 — SESSION 쿠키(1년)와 별개로 토스 서버가 운영하는 ~7일 활성 만료 시계를 폰 토스 앱 푸시 승인으로 갱신합니다. 블로킹 + Braille 스피너 UX, `--timeout` (기본 120초), `Ctrl+C` 처리.
- **24h 만료 경고** — 모든 명령 시작 시 cached server expiry 가 24h 미만이면 stderr 한 줄 경고 (`⚠ session expires in ~18h; run \`tossctl auth extend\` to renew`). `--output json` 모드 침묵.
- **`auth status`** — table 출력에 `Server Expiry: 2026-MM-DD HH:MM KST` 줄 추가, JSON 출력에 `server_expires_at` 필드 추가.

## Endpoint chain (live captured 2026-05-05)

agent-browser 로 토스 웹앱 '로그인 유지하기' 흐름을 실측한 결과:

\`\`\`
POST /api/v1/wts-login-extend/doc/request           → {result:{txId}}              (also fans out phone push)
GET  /api/v1/wts-login-extend/doc/{txId}/status     → {result:\"REQUESTED\"|\"COMPLETED\"|\"EXPIRED\"}  (poll ~1s)
POST /api/v1/wts-login-extend/{txId}/state          → 200 {}                       (★ required finalize)
GET  /api/v1/session/expired-at                     → {result:\"<KST RFC3339>\"}     (~7d further out)
\`\`\`

`POST /state` 단계가 핵심: 빠지면 status 가 `COMPLETED` 여도 server expired-at 이 갱신되지 않습니다.

## Tone

- **CLI 출력 (intro/spinner/success/warnings/errors)**: 영어로 통일, 다른 운영 에러 톤과 일치.
- **README 본문, commit messages**: 한국어 유지.

## Test plan

- [x] 단위 테스트: 12 패키지 모두 PASS (httptest 로 4 endpoint mock + Service.Extend 흐름 9 케이스 + PreRunE 경고 5 케이스 + errors 분기 5 케이스 + writeAuthStatus KST 표시 2 케이스)
- [x] End-to-end smoke (실제 토스 backend, 폰 승인): `tossctl auth extend --timeout 60s` 실행 → 6 초 만에 `✓ Extension complete. New expiry: 2026-05-12 10:47 KST (took 9s)` + `auth status` 가 새 server_expires_at 반영
- [x] PreRunE 경고: 만료 24h 미만 시 stderr 한 줄, JSON 모드 침묵, auth/version/help 등 skip-list 명령 침묵, 이미 만료된 세션은 침묵 (401 path 가 처리)
- [x] Ctrl+C: signal.NotifyContext 로 cancel → "canceled" 메시지

## Out of scope (follow-up backlog)

- `Service.Status` 의 best-effort `store.Save` 에러 observability (debug log)
- Spinner remaining-time countdown
- Exit code 차별화 (Ctrl+C → 130, no-session/401 → 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)