### PR TITLE
feat(quote): add candle chart and batch sparkline

### DIFF
--- a/cmd/tossctl/quote.go
+++ b/cmd/tossctl/quote.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/junghoonkye/tossinvest-cli/internal/domain"
 	"github.com/junghoonkye/tossinvest-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -13,16 +16,17 @@ func newQuoteCmd(opts *rootOptions) *cobra.Command {
 	}
 
 	getCmd := &cobra.Command{
-		Use:   "get <symbol>",
-		Short: "Fetch quote data for a symbol",
-		Args:  cobra.ExactArgs(1),
+		Use:   "get <symbol or name>",
+		Short: "Fetch quote data for a symbol or stock name",
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app, err := newAppContext(opts)
 			if err != nil {
 				return err
 			}
 
-			quote, err := app.client.GetQuote(cmd.Context(), args[0])
+			symbol := strings.Join(args, " ")
+			quote, err := app.client.GetQuote(cmd.Context(), symbol)
 			if err != nil {
 				return err
 			}
@@ -31,6 +35,7 @@ func newQuoteCmd(opts *rootOptions) *cobra.Command {
 		},
 	}
 
+	var batchChart bool
 	batchCmd := &cobra.Command{
 		Use:   "batch <symbol> [symbol...]",
 		Short: "Fetch quotes for multiple symbols at once",
@@ -50,11 +55,52 @@ func newQuoteCmd(opts *rootOptions) *cobra.Command {
 				quotes = append(quotes, quote)
 			}
 
-			return output.WriteQuotes(cmd.OutOrStdout(), app.format, quotes)
+			if !batchChart {
+				return output.WriteQuotes(cmd.OutOrStdout(), app.format, quotes)
+			}
+
+			var charts []domain.Chart
+			for _, q := range quotes {
+				chart, err := app.client.GetChart(cmd.Context(), q.ProductCode, "3m", 30)
+				if err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "warning: chart unavailable for %s: %v\n", q.Symbol, err)
+					charts = append(charts, domain.Chart{})
+					continue
+				}
+				charts = append(charts, chart)
+			}
+			return output.WriteQuotesWithCharts(cmd.OutOrStdout(), app.format, quotes, charts)
 		},
 	}
+	batchCmd.Flags().BoolVar(&batchChart, "chart", false, "show sparkline chart for each symbol")
 
-	cmd.AddCommand(getCmd, batchCmd)
+	var (
+		chartInterval string
+		chartCount    int
+	)
+	chartCmd := &cobra.Command{
+		Use:   "chart <symbol or name>",
+		Short: "Fetch candle chart for a symbol or stock name",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := newAppContext(opts)
+			if err != nil {
+				return err
+			}
+
+			symbol := strings.Join(args, " ")
+			chart, err := app.client.GetChart(cmd.Context(), symbol, chartInterval, chartCount)
+			if err != nil {
+				return err
+			}
+
+			return output.WriteChart(cmd.OutOrStdout(), app.format, chart)
+		},
+	}
+	chartCmd.Flags().StringVar(&chartInterval, "interval", "3m", "candle interval: 1m, 3m, 5m, 10m, 15m, 30m, 60m")
+	chartCmd.Flags().IntVar(&chartCount, "count", 30, "number of candles to fetch")
+
+	cmd.AddCommand(getCmd, batchCmd, chartCmd)
 
 	return cmd
 }

--- a/internal/client/chart.go
+++ b/internal/client/chart.go
@@ -1,0 +1,132 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/domain"
+)
+
+type chartCandleRaw struct {
+	DT     string  `json:"dt"`
+	Base   float64 `json:"base"`
+	Open   float64 `json:"open"`
+	High   float64 `json:"high"`
+	Low    float64 `json:"low"`
+	Close  float64 `json:"close"`
+	Volume float64 `json:"volume"`
+}
+
+type chartResult struct {
+	Code     string           `json:"code"`
+	Exchange string           `json:"exchange"`
+	Candles  []chartCandleRaw `json:"candles"`
+}
+
+func (c *Client) GetChart(ctx context.Context, symbol, interval string, count int) (domain.Chart, error) {
+	productCode, err := c.resolveProductCode(ctx, symbol)
+	if err != nil {
+		return domain.Chart{}, err
+	}
+
+	info, err := c.getStockInfo(ctx, productCode)
+	if err != nil {
+		return domain.Chart{}, err
+	}
+
+	rangeParam, err := normalizeChartInterval(interval)
+	if err != nil {
+		return domain.Chart{}, err
+	}
+
+	if count <= 0 {
+		count = 30
+	}
+
+	sType := deriveSecurityType(productCode)
+	endpoint, err := url.Parse(fmt.Sprintf("%s/api/v1/c-chart/%s/%s/%s", c.infoBaseURL, sType, productCode, rangeParam))
+	if err != nil {
+		return domain.Chart{}, err
+	}
+	query := endpoint.Query()
+	query.Set("count", strconv.Itoa(count))
+	query.Set("useAdjustedRate", "true")
+	query.Set("session", "main")
+	endpoint.RawQuery = query.Encode()
+
+	var envelope quoteEnvelope[chartResult]
+	if err := c.getJSON(ctx, endpoint.String(), &envelope); err != nil {
+		return domain.Chart{}, err
+	}
+
+	chart := domain.Chart{
+		ProductCode: envelope.Result.Code,
+		Symbol:      info.Symbol,
+		Name:        info.Name,
+		Interval:    interval,
+		FetchedAt:   time.Now().UTC(),
+	}
+	if chart.ProductCode == "" {
+		chart.ProductCode = productCode
+	}
+
+	chart.Candles = make([]domain.Candle, 0, len(envelope.Result.Candles))
+	for _, raw := range envelope.Result.Candles {
+		t, parseErr := time.Parse(time.RFC3339, raw.DT)
+		if parseErr != nil {
+			t = time.Time{}
+		}
+		chart.Candles = append(chart.Candles, domain.Candle{
+			Time:   t,
+			Open:   raw.Open,
+			High:   raw.High,
+			Low:    raw.Low,
+			Close:  raw.Close,
+			Volume: raw.Volume,
+		})
+		if chart.Base == 0 && raw.Base != 0 {
+			chart.Base = raw.Base
+		}
+	}
+
+	for i, j := 0, len(chart.Candles)-1; i < j; i, j = i+1, j-1 {
+		chart.Candles[i], chart.Candles[j] = chart.Candles[j], chart.Candles[i]
+	}
+
+	return chart, nil
+}
+
+func deriveSecurityType(productCode string) string {
+	if len(productCode) >= 7 && productCode[0] == 'A' {
+		for i := 1; i < len(productCode); i++ {
+			if productCode[i] < '0' || productCode[i] > '9' {
+				return "us-s"
+			}
+		}
+		return "kr-s"
+	}
+	return "us-s"
+}
+
+func normalizeChartInterval(interval string) (string, error) {
+	s := strings.ToLower(strings.TrimSpace(interval))
+	if s == "" {
+		return "", fmt.Errorf("interval is required")
+	}
+	s = strings.TrimSuffix(s, "min")
+	s = strings.TrimSuffix(s, "m")
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		n = 0
+	}
+	switch n {
+	case 1, 3, 5, 10, 15, 30, 60:
+		return fmt.Sprintf("min:%d", n), nil
+	default:
+		return "", fmt.Errorf("unsupported interval %q; expected one of: 1m, 3m, 5m, 10m, 15m, 30m, 60m", interval)
+	}
+}

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -80,6 +80,25 @@ type WatchlistItem struct {
 	Last     float64 `json:"last,omitempty"`
 }
 
+type Candle struct {
+	Time   time.Time `json:"time"`
+	Open   float64   `json:"open"`
+	High   float64   `json:"high"`
+	Low    float64   `json:"low"`
+	Close  float64   `json:"close"`
+	Volume float64   `json:"volume,omitempty"`
+}
+
+type Chart struct {
+	ProductCode string    `json:"product_code"`
+	Symbol      string    `json:"symbol,omitempty"`
+	Name        string    `json:"name,omitempty"`
+	Interval    string    `json:"interval"`
+	Base        float64   `json:"base,omitempty"`
+	Candles     []Candle  `json:"candles"`
+	FetchedAt   time.Time `json:"fetched_at"`
+}
+
 type Quote struct {
 	ProductCode    string    `json:"product_code,omitempty"`
 	Symbol         string    `json:"symbol"`

--- a/internal/output/chart.go
+++ b/internal/output/chart.go
@@ -1,0 +1,350 @@
+package output
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/domain"
+)
+
+const (
+	chartColorReset = "\033[0m"
+	chartColorRed   = "\033[31m"
+	chartColorBlue  = "\033[34m"
+	chartColorBold  = "\033[1m"
+	chartColorDim   = "\033[2m"
+)
+
+func WriteChart(w io.Writer, format Format, chart domain.Chart) error {
+	switch format {
+	case FormatTable:
+		return writeChartTable(w, chart)
+	case FormatJSON:
+		return writeChartJSON(w, chart)
+	case FormatCSV:
+		return writeChartCSV(w, chart)
+	default:
+		return fmt.Errorf("unsupported output format: %s", format)
+	}
+}
+
+func writeChartJSON(w io.Writer, chart domain.Chart) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(chart)
+}
+
+func writeChartCSV(w io.Writer, chart domain.Chart) error {
+	writer := csv.NewWriter(w)
+	if err := writer.Write([]string{"time", "open", "high", "low", "close", "volume"}); err != nil {
+		return err
+	}
+	for _, c := range chart.Candles {
+		if err := writer.Write([]string{
+			c.Time.Format("2006-01-02T15:04:05Z07:00"),
+			formatFloat(c.Open),
+			formatFloat(c.High),
+			formatFloat(c.Low),
+			formatFloat(c.Close),
+			formatFloat(c.Volume),
+		}); err != nil {
+			return err
+		}
+	}
+	writer.Flush()
+	return writer.Error()
+}
+
+func writeChartTable(w io.Writer, chart domain.Chart) error {
+	if len(chart.Candles) == 0 {
+		_, err := fmt.Fprintln(w, "no candle data")
+		return err
+	}
+
+	last := chart.Candles[len(chart.Candles)-1].Close
+	base := chart.Base
+	change := last - base
+	var changeRate float64
+	if base != 0 {
+		changeRate = change / base * 100
+	}
+
+	changeColor := chartColorBlue
+	changeSign := ""
+	if change > 0 {
+		changeColor = chartColorRed
+		changeSign = "+"
+	}
+
+	name := chart.Name
+	if name == "" {
+		name = chart.Symbol
+	}
+	fmt.Fprintf(w, "%s%s (%s)%s  %s  %s%s%s (%s%.2f%%)  %s · %d candles\n\n",
+		chartColorBold, name, chart.ProductCode, chartColorReset,
+		formatPriceKR(last),
+		changeColor, changeSign+formatPriceKR(change), chartColorReset,
+		changeSign, changeRate,
+		chart.Interval, len(chart.Candles),
+	)
+
+	return renderCandleChart(w, chart.Candles, 12)
+}
+
+func tickSizeKR(price float64) float64 {
+	switch {
+	case price < 2000:
+		return 1
+	case price < 5000:
+		return 5
+	case price < 20000:
+		return 10
+	case price < 50000:
+		return 50
+	case price < 200000:
+		return 100
+	case price < 500000:
+		return 500
+	default:
+		return 1000
+	}
+}
+
+func renderCandleChart(w io.Writer, candles []domain.Candle, desiredRows int) error {
+	if len(candles) == 0 {
+		return nil
+	}
+
+	rawMin, rawMax := candles[0].Low, candles[0].High
+	for _, c := range candles {
+		if c.Low < rawMin {
+			rawMin = c.Low
+		}
+		if c.High > rawMax {
+			rawMax = c.High
+		}
+	}
+
+	mid := (rawMin + rawMax) / 2
+	tick := tickSizeKR(mid)
+	rawRange := rawMax - rawMin
+	if rawRange == 0 {
+		rawRange = tick
+	}
+
+	rawStep := rawRange / float64(desiredRows)
+	ticksPerRow := int(math.Ceil(rawStep / tick))
+	if ticksPerRow < 1 {
+		ticksPerRow = 1
+	}
+	stepPrice := float64(ticksPerRow) * tick
+
+	minPrice := math.Floor(rawMin/stepPrice)*stepPrice - stepPrice
+	maxPrice := math.Ceil(rawMax/stepPrice)*stepPrice + stepPrice
+	rows := int(math.Round((maxPrice - minPrice) / stepPrice))
+	if rows < 1 {
+		rows = 1
+	}
+	priceRange := maxPrice - minPrice
+	totalSubrows := 2 * rows
+
+	const eps = 1e-9
+	toUpperSr := func(price float64) int {
+		x := (maxPrice - price) / priceRange * float64(totalSubrows)
+		sr := int(math.Floor(x + eps))
+		if sr < 0 {
+			sr = 0
+		}
+		if sr >= totalSubrows {
+			sr = totalSubrows - 1
+		}
+		return sr
+	}
+	toLowerSr := func(price float64) int {
+		x := (maxPrice - price) / priceRange * float64(totalSubrows)
+		sr := int(math.Ceil(x-eps)) - 1
+		if sr < 0 {
+			sr = 0
+		}
+		if sr >= totalSubrows {
+			sr = totalSubrows - 1
+		}
+		return sr
+	}
+
+	type metric struct {
+		highSr, lowSr, bodyTopSr, bodyBotSr int
+		up                                  bool
+	}
+	metrics := make([]metric, len(candles))
+	for i, c := range candles {
+		bodyTop, bodyBot := c.Open, c.Close
+		if c.Close >= c.Open {
+			bodyTop, bodyBot = c.Close, c.Open
+		}
+		metrics[i] = metric{
+			highSr:    toUpperSr(c.High),
+			lowSr:     toLowerSr(c.Low),
+			bodyTopSr: toUpperSr(bodyTop),
+			bodyBotSr: toLowerSr(bodyBot),
+			up:        c.Close >= c.Open,
+		}
+	}
+
+	var sb strings.Builder
+	labelWidth := 9
+	for r := 0; r < rows; r++ {
+		rowTopPrice := maxPrice - float64(r)*stepPrice
+		sb.WriteString(fmt.Sprintf("%*s ┤", labelWidth, formatPriceKR(rowTopPrice)))
+
+		upperSub := 2 * r
+		lowerSub := 2*r + 1
+
+		for _, m := range metrics {
+			color := chartColorBlue
+			if m.up {
+				color = chartColorRed
+			}
+
+			upperInBody := upperSub >= m.bodyTopSr && upperSub <= m.bodyBotSr
+			lowerInBody := lowerSub >= m.bodyTopSr && lowerSub <= m.bodyBotSr
+			upperInWick := upperSub >= m.highSr && upperSub <= m.lowSr
+			lowerInWick := lowerSub >= m.highSr && lowerSub <= m.lowSr
+
+			var ch string
+			switch {
+			case upperInBody && lowerInBody:
+				ch = "█"
+			case upperInBody:
+				ch = "▀"
+			case lowerInBody:
+				ch = "▄"
+			case upperInWick || lowerInWick:
+				ch = "│"
+			default:
+				ch = " "
+			}
+
+			if ch == " " {
+				sb.WriteString("   ")
+			} else {
+				sb.WriteString(" " + color + ch + chartColorReset + " ")
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString(strings.Repeat(" ", labelWidth+1))
+	sb.WriteString("└")
+	sb.WriteString(strings.Repeat("─", len(candles)*3))
+	sb.WriteString("\n")
+
+	labelStep := 1
+	if len(candles) > 12 {
+		labelStep = len(candles) / 6
+		if labelStep < 1 {
+			labelStep = 1
+		}
+	}
+	sb.WriteString(strings.Repeat(" ", labelWidth+2))
+	for i := 0; i < len(candles); i += labelStep {
+		label := "     "
+		if !candles[i].Time.IsZero() {
+			label = candles[i].Time.Local().Format("15:04")
+		}
+		span := labelStep
+		if i+labelStep > len(candles) {
+			span = len(candles) - i
+		}
+		sb.WriteString(fmt.Sprintf("%-*s", 3*span, label))
+	}
+	sb.WriteString("\n")
+
+	_, err := io.WriteString(w, sb.String())
+	return err
+}
+
+func renderSparkline(candles []domain.Candle, width int) string {
+	if len(candles) == 0 {
+		return ""
+	}
+
+	closes := make([]float64, len(candles))
+	min, max := candles[0].Close, candles[0].Close
+	for i, c := range candles {
+		closes[i] = c.Close
+		if c.Close < min {
+			min = c.Close
+		}
+		if c.Close > max {
+			max = c.Close
+		}
+	}
+
+	if width > 1 && len(closes) > width {
+		sampled := make([]float64, width)
+		for i := 0; i < width; i++ {
+			idx := i * (len(closes) - 1) / (width - 1)
+			sampled[i] = closes[idx]
+		}
+		closes = sampled
+	}
+
+	blocks := []rune{'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
+	spread := max - min
+	var sb strings.Builder
+	for _, v := range closes {
+		level := 0
+		if spread > 0 {
+			level = int((v - min) / spread * 7)
+			if level > 7 {
+				level = 7
+			}
+		}
+		sb.WriteRune(blocks[level])
+	}
+
+	last := candles[len(candles)-1].Close
+	first := candles[0].Close
+	color := chartColorBlue
+	if last >= first {
+		color = chartColorRed
+	}
+	return color + sb.String() + chartColorReset
+}
+
+func formatPriceKR(p float64) string {
+	negative := p < 0
+	if negative {
+		p = -p
+	}
+	intPart := int64(p + 0.5)
+	s := fmt.Sprintf("%d", intPart)
+	n := len(s)
+	var out strings.Builder
+	if negative {
+		out.WriteString("-")
+	}
+	if n <= 3 {
+		out.WriteString(s)
+		return out.String()
+	}
+	pre := n % 3
+	if pre > 0 {
+		out.WriteString(s[:pre])
+		if n > pre {
+			out.WriteString(",")
+		}
+	}
+	for i := pre; i < n; i += 3 {
+		out.WriteString(s[i : i+3])
+		if i+3 < n {
+			out.WriteString(",")
+		}
+	}
+	return out.String()
+}

--- a/internal/output/quote.go
+++ b/internal/output/quote.go
@@ -99,6 +99,10 @@ func writeQuoteTable(w io.Writer, quote domain.Quote) error {
 }
 
 func WriteQuotes(w io.Writer, format Format, quotes []domain.Quote) error {
+	return WriteQuotesWithCharts(w, format, quotes, nil)
+}
+
+func WriteQuotesWithCharts(w io.Writer, format Format, quotes []domain.Quote, charts []domain.Chart) error {
 	switch format {
 	case FormatJSON:
 		encoder := json.NewEncoder(w)
@@ -122,13 +126,17 @@ func WriteQuotes(w io.Writer, format Format, quotes []domain.Quote) error {
 		writer.Flush()
 		return writer.Error()
 	case FormatTable:
-		for _, q := range quotes {
+		for i, q := range quotes {
 			changeStr := fmt.Sprintf("%.2f", q.Change)
 			if q.Change > 0 {
 				changeStr = "+" + changeStr
 			}
-			if _, err := fmt.Fprintf(w, "%-8s %-20s %12s %s (%.2f%%)\n",
-				q.Symbol, q.Name, formatFloat(q.Last), changeStr, q.ChangeRate*100,
+			sparkline := ""
+			if charts != nil && i < len(charts) && len(charts[i].Candles) > 0 {
+				sparkline = "  " + renderSparkline(charts[i].Candles, 20)
+			}
+			if _, err := fmt.Fprintf(w, "%-8s %-20s %12s %s (%.2f%%)%s\n",
+				q.Symbol, q.Name, formatFloat(q.Last), changeStr, q.ChangeRate*100, sparkline,
 			); err != nil {
 				return err
 			}


### PR DESCRIPTION
## 변경 사항

터미널에서 분봉 캔들 차트를 볼 수 있는 `tossctl quote chart` 서브커맨드와, `tossctl quote batch --chart`로 여러 종목의 스파크라인을 한눈에 볼 수 있는 기능을 추가합니다.

### 주요 기능

- **`tossctl quote chart <종목>`** — ASCII 캔들 차트 (1/3/5/10/15/30/60분봉)
  - 반블록 문자(`▀▄█│`)로 세로 해상도 2배
  - 한국 호가단위 자동 적용 (`tickSizeKR()`: 가격대별 1/5/10/50/100/500/1000원)
  - ANSI 색상: 양봉 빨강, 음봉 파랑
  - `--interval 5m`, `--count 50` 등 옵션
  - table / json / csv 출력 지원

<img width="620" height="205" alt="image" src="https://github.com/user-attachments/assets/2838608e-b9c0-4ea3-acad-9962364c09dc" />

- **`tossctl quote batch ... --chart`** — 종목별 스파크라인 표시
  - 3분봉 30개 기준 미니 차트(`▁▂▃▄▅▆▇█`)를 테이블 우측에 표시
  - 차트 API 실패 시 경고만 출력하고 나머지 종목은 정상 표시
  
<img width="568" height="48" alt="스크린샷 2026-05-19 17 04 14" src="https://github.com/user-attachments/assets/fe9890c6-fbf3-4b55-ad4d-e69a500b8451" />

### 사용 예시

```bash
# 캔들 차트
tossctl quote chart 삼성전자
tossctl quote chart 삼성전자 --interval 5m --count 50
tossctl quote chart "KODEX 인버스" --interval 15m

# 스파크라인 배치
tossctl quote batch 삼성전자 KB금융 "KODEX 인버스" --chart

# JSON/CSV 출력
tossctl quote chart 삼성전자 -o json
tossctl quote chart 삼성전자 -o csv
```

### 변경 파일

| 파일 | 내용 |
|------|------|
| `internal/domain/models.go` | `Candle`, `Chart` 도메인 타입 추가 |
| `internal/client/chart.go` (신규) | 토스증권 c-chart API 클라이언트 |
| `internal/output/chart.go` (신규) | ASCII 캔들 차트 + 스파크라인 렌더링 |
| `internal/output/quote.go` | `WriteQuotesWithCharts()` 추가 (배치+스파크라인) |
| `cmd/tossctl/quote.go` | `chart` 서브커맨드, `batch --chart` 플래그 |

### 기술 세부사항

- 토스증권 비공개 차트 API (`wts-info-api.tossinvest.com/api/v1/c-chart/{sType}/{productCode}/min:{N}`) 활용
- 기존 `quoteEnvelope[T]` 제네릭 패턴 재사용 (코드 일관성)
- API는 최신순 반환 → 시간순 역정렬 처리
- 복수 단어 종목명 지원 (`"KODEX 인버스"` 등)

## 테스트

- [x] `make test` 통과
- [x] 실제 데이터로 수동 확인 (삼성전자, KODEX 인버스, KB금융)
- [x] 다양한 인터벌 검증 (3m, 5m, 15m, 30m)
- [x] table / json / csv 출력 포맷 확인
- [x] 차트 API 실패 시 graceful degradation 확인
- [ ] US 주식 차트 미검증 (코드는 작성됨)

---

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>