### PR TITLE
feat(quote): batch --live 모드 추가 및 출력 품질 개선

### DIFF
--- a/cmd/tossctl/quote.go
+++ b/cmd/tossctl/quote.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/junghoonkye/tossinvest-cli/internal/domain"
 	"github.com/junghoonkye/tossinvest-cli/internal/output"
@@ -35,10 +41,14 @@ func newQuoteCmd(opts *rootOptions) *cobra.Command {
 		},
 	}
 
-	var batchChart bool
+	var (
+		batchChart    bool
+		batchLive     bool
+		batchInterval int
+	)
 	batchCmd := &cobra.Command{
-		Use:   "batch <symbol> [symbol...]",
-		Short: "Fetch quotes for multiple symbols at once",
+		Use:   "batch <symbol>[,symbol,...] [...]",
+		Short: "Fetch quotes for multiple symbols at once (comma-separated supported)",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app, err := newAppContext(opts)
@@ -46,33 +56,89 @@ func newQuoteCmd(opts *rootOptions) *cobra.Command {
 				return err
 			}
 
-			var quotes []domain.Quote
-			for _, symbol := range args {
-				quote, err := app.client.GetQuote(cmd.Context(), symbol)
-				if err != nil {
-					return err
+			symbols := parseBatchSymbols(args)
+
+			fetchAndRender := func(ctx context.Context, w io.Writer) error {
+				var quotes []domain.Quote
+				for _, symbol := range symbols {
+					quote, err := app.client.GetQuote(ctx, symbol)
+					if err != nil {
+						return err
+					}
+					quotes = append(quotes, quote)
 				}
-				quotes = append(quotes, quote)
+
+				if !batchChart {
+					return output.WriteQuotes(w, app.format, quotes)
+				}
+
+				warnW := io.Writer(cmd.ErrOrStderr())
+				if batchLive {
+					warnW = w
+				}
+				var charts []domain.Chart
+				for _, q := range quotes {
+					chart, err := app.client.GetChart(ctx, q.ProductCode, "3m", 30)
+					if err != nil {
+						fmt.Fprintf(warnW, "warning: chart unavailable for %s: %v\n", q.Symbol, err)
+						charts = append(charts, domain.Chart{})
+						continue
+					}
+					charts = append(charts, chart)
+				}
+				return output.WriteQuotesWithCharts(w, app.format, quotes, charts)
 			}
 
-			if !batchChart {
-				return output.WriteQuotes(cmd.OutOrStdout(), app.format, quotes)
+			if !batchLive {
+				return fetchAndRender(cmd.Context(), cmd.OutOrStdout())
 			}
 
-			var charts []domain.Chart
-			for _, q := range quotes {
-				chart, err := app.client.GetChart(cmd.Context(), q.ProductCode, "3m", 30)
-				if err != nil {
-					fmt.Fprintf(cmd.ErrOrStderr(), "warning: chart unavailable for %s: %v\n", q.Symbol, err)
-					charts = append(charts, domain.Chart{})
-					continue
-				}
-				charts = append(charts, chart)
+			if !isTerminal(cmd.OutOrStdout()) {
+				return fmt.Errorf("--live requires an interactive terminal")
 			}
-			return output.WriteQuotesWithCharts(cmd.OutOrStdout(), app.format, quotes, charts)
+
+			if batchInterval < 1 {
+				batchInterval = 1
+			}
+
+			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer cancel()
+
+			w := cmd.OutOrStdout()
+			fmt.Fprint(w, "\033[?1049h\033[?25l")
+			defer fmt.Fprint(w, "\033[?25h\033[?1049l")
+
+			fmt.Fprintf(w, "\033[H\033[JEvery %ds | Fetching...\n", batchInterval)
+
+			var lastGood string
+			interval := time.Duration(batchInterval) * time.Second
+			for {
+				var buf strings.Builder
+				fmt.Fprintf(&buf, "Every %ds | %s\n\n",
+					batchInterval, time.Now().Local().Format("2006-01-02 15:04:05"))
+
+				if err := fetchAndRender(ctx, &buf); err != nil {
+					if ctx.Err() != nil {
+						return nil
+					}
+					fmt.Fprintf(&buf, "%s\n\033[31merror: %v\033[0m\n", lastGood, err)
+				} else {
+					lastGood = buf.String()
+				}
+
+				fmt.Fprint(w, "\033[H"+buf.String()+"\033[J")
+
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-time.After(interval):
+				}
+			}
 		},
 	}
 	batchCmd.Flags().BoolVar(&batchChart, "chart", false, "show sparkline chart for each symbol")
+	batchCmd.Flags().BoolVar(&batchLive, "live", false, "continuously refresh (like watch/viddy)")
+	batchCmd.Flags().IntVar(&batchInterval, "interval", 2, "refresh interval in seconds (used with --live)")
 
 	var (
 		chartInterval string
@@ -103,4 +169,17 @@ func newQuoteCmd(opts *rootOptions) *cobra.Command {
 	cmd.AddCommand(getCmd, batchCmd, chartCmd)
 
 	return cmd
+}
+
+func parseBatchSymbols(args []string) []string {
+	var symbols []string
+	for _, arg := range args {
+		for _, s := range strings.Split(arg, ",") {
+			s = strings.TrimSpace(s)
+			if s != "" {
+				symbols = append(symbols, s)
+			}
+		}
+	}
+	return symbols
 }


### PR DESCRIPTION
## Summary
- `--live` 플래그: watch/viddy 대체, alternate screen buffer로 깔끔한 화면 전환
- `--interval` 플래그: 갱신 주기 설정 (기본 2초, 최소 1초 클램핑)
- 더블버퍼링으로 깜빡임 방지
- 첫 프레임 "Fetching..." 로딩 표시
- 에러 시 마지막 성공 결과 보존 + 빨간 에러 메시지
- Ctrl+C 시 "context canceled" 노출 방지 (ctx.Err 가드)
- non-TTY 환경에서 `--live` 거부 (ANSI escape 오염 방지)
- chart warning을 `--live` 모드에서 버퍼로 리디렉트

<img width="479" height="100" alt="스크린샷 2026-05-27 14 41 45" src="https://github.com/user-attachments/assets/51c37b20-2c49-4204-8115-ea045facd343" />

## Background
`viddy tossctl quote batch ... --chart` 실행 시 stdout이 파이프로 캡처되어 TTY 감지가 실패, 색상/차트가 깨지는 문제. 프로그램이 직접 터미널을 소유하는 `--live` 모드로 해결.

## Test plan
- [ ] `tossctl quote batch 삼성전자 KB금융 "KODEX 인버스" --chart --live` 실행 → 2초마다 갱신 확인
- [ ] `--interval 1` → 1초 갱신 확인
- [ ] `--interval 0` → 1초로 클램핑 확인
- [ ] Ctrl+C → "context canceled" 없이 깨끗한 종료, 원래 터미널 복원
- [ ] 네트워크 끊김 시 이전 결과 유지 + 빨간 에러 표시
- [ ] `tossctl quote batch ... --live | cat` → "--live requires an interactive terminal" 에러
- [ ] `--live` 없이 기존 `batch` 동작 변경 없음