### PR TITLE
feat(windows): PowerShell installer + Windows Python resolution

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -56,10 +56,21 @@ Always run `tossctl order preview` before any trading mutation.
 
 ### For Humans
 
-```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/JungHoonGhae/tossinvest-cli/main/install.sh | sh
+macOS / Linux:
 
+```bash
+curl -fsSL https://raw.githubusercontent.com/JungHoonGhae/tossinvest-cli/main/install.sh | sh
+```
+
+Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/JungHoonGhae/tossinvest-cli/main/install.ps1 | iex
+```
+
+Verify:
+
+```bash
 tossctl version
 tossctl doctor
 tossctl auth login
@@ -301,9 +312,13 @@ brew install tossctl
 #### Windows (PowerShell)
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/JungHoonGhae/tossinvest-cli/releases/latest/download/tossctl-windows-amd64.zip -OutFile tossctl.zip
-Expand-Archive tossctl.zip -DestinationPath .
+irm https://raw.githubusercontent.com/JungHoonGhae/tossinvest-cli/main/install.ps1 | iex
 ```
+
+Installs to `%LOCALAPPDATA%\tossctl` and adds it to the user PATH automatically.
+Open a new terminal window and `tossctl` is ready to use.
+
+For a manual install, download `tossctl-windows-amd64.zip` from [Releases](https://github.com/JungHoonGhae/tossinvest-cli/releases/latest).
 
 #### From source
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,21 @@ Always run `tossctl order preview` before any trading mutation.
 
 ### For Human
 
-```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/JungHoonGhae/tossinvest-cli/main/install.sh | sh
+macOS / Linux:
 
-# 설치 확인
+```bash
+curl -fsSL https://raw.githubusercontent.com/JungHoonGhae/tossinvest-cli/main/install.sh | sh
+```
+
+Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/JungHoonGhae/tossinvest-cli/main/install.ps1 | iex
+```
+
+설치 확인:
+
+```bash
 tossctl version
 tossctl doctor
 tossctl auth login
@@ -353,9 +363,13 @@ brew install tossctl
 #### Windows (PowerShell)
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/JungHoonGhae/tossinvest-cli/releases/latest/download/tossctl-windows-amd64.zip -OutFile tossctl.zip
-Expand-Archive tossctl.zip -DestinationPath .
+irm https://raw.githubusercontent.com/JungHoonGhae/tossinvest-cli/main/install.ps1 | iex
 ```
+
+스크립트는 `%LOCALAPPDATA%\tossctl`에 설치하고, 사용자 PATH에 자동으로 추가합니다.
+새 터미널을 열면 `tossctl` 명령을 바로 사용할 수 있습니다.
+
+수동 설치가 필요한 경우 [Releases](https://github.com/JungHoonGhae/tossinvest-cli/releases/latest)에서 `tossctl-windows-amd64.zip`을 직접 다운로드하세요.
 
 #### From source
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,165 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    tossinvest-cli (tossctl) Windows installer
+.DESCRIPTION
+    Downloads the latest tossctl release from GitHub, verifies the SHA256
+    checksum, extracts it to %LOCALAPPDATA%\tossctl, and adds that directory
+    to the current user's PATH.
+.EXAMPLE
+    irm https://raw.githubusercontent.com/JungHoonGhae/tossinvest-cli/main/install.ps1 | iex
+#>
+
+function Install-Tossctl {
+    $ErrorActionPreference = "Stop"
+
+    $REPO        = "JungHoonGhae/tossinvest-cli"
+    $BINARY      = "tossctl.exe"
+    $ASSET       = "tossctl-windows-amd64"
+    $INSTALL_DIR = Join-Path $env:LOCALAPPDATA "tossctl"
+
+    function Write-Step([string]$msg) { Write-Host $msg -ForegroundColor Cyan }
+    function Write-Ok([string]$msg)   { Write-Host $msg -ForegroundColor Green }
+    function Write-Warn([string]$msg) { Write-Host "Warning: $msg" -ForegroundColor Yellow }
+
+    Write-Step "tossinvest-cli installer for Windows"
+    Write-Host ""
+
+    # ── Architecture notice ───────────────────────────────────────────────────
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    # PROCESSOR_ARCHITEW6432 is set to the native arch when running under WOW64
+    if ($env:PROCESSOR_ARCHITEW6432) { $arch = $env:PROCESSOR_ARCHITEW6432 }
+    if ($arch -eq "ARM64") {
+        Write-Warn "ARM64 detected. No native arm64 build is available yet."
+        Write-Warn "The amd64 binary runs under x64 emulation on Windows 11 ARM."
+        Write-Host ""
+    }
+
+    # ── Resolve download URLs ─────────────────────────────────────────────────
+    $zipUrl    = "https://github.com/$REPO/releases/latest/download/$ASSET.zip"
+    $sha256Url = "https://github.com/$REPO/releases/latest/download/$ASSET.zip.sha256"
+
+    # ── Temporary directory ───────────────────────────────────────────────────
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Path $tmpDir | Out-Null
+
+    try {
+        # ── Download ──────────────────────────────────────────────────────────
+        Write-Step "Downloading $ASSET.zip..."
+        $zipPath    = Join-Path $tmpDir "$ASSET.zip"
+        $sha256Path = Join-Path $tmpDir "$ASSET.zip.sha256"
+
+        Invoke-WebRequest -Uri $zipUrl    -OutFile $zipPath    -UseBasicParsing
+        Invoke-WebRequest -Uri $sha256Url -OutFile $sha256Path -UseBasicParsing
+
+        # ── Verify checksum ───────────────────────────────────────────────────
+        Write-Step "Verifying checksum..."
+        $expectedLine = (Get-Content $sha256Path -Raw).Trim()
+        $expected = ($expectedLine -split '\s+')[0].ToLower()
+        if ($expected -notmatch '^[0-9a-f]{64}$') {
+            throw "Could not parse SHA256 from checksum file (got: '$expected'). The asset download may have failed."
+        }
+        $actual = (Get-FileHash $zipPath -Algorithm SHA256).Hash.ToLower()
+        if ($expected -ne $actual) {
+            throw "Checksum mismatch!`n  expected: $expected`n  actual:   $actual"
+        }
+
+        # ── Extract ───────────────────────────────────────────────────────────
+        Write-Step "Extracting..."
+        $extractDir = Join-Path $tmpDir "extracted"
+        Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+        # ── Install ───────────────────────────────────────────────────────────
+        Write-Step "Installing to $INSTALL_DIR..."
+        if (-not (Test-Path $INSTALL_DIR)) {
+            New-Item -ItemType Directory -Path $INSTALL_DIR | Out-Null
+        }
+
+        $destBin = Join-Path $INSTALL_DIR $BINARY
+        if (Get-Process -Name "tossctl" -ErrorAction SilentlyContinue) {
+            Write-Warn "tossctl is currently running. Close it before upgrading or the file copy may fail."
+        }
+        Copy-Item (Join-Path $extractDir $BINARY) $destBin -Force
+
+        $srcHelper = Join-Path $extractDir "auth-helper"
+        if (Test-Path $srcHelper) {
+            $dstHelper = Join-Path $INSTALL_DIR "auth-helper"
+            if (Test-Path $dstHelper) {
+                Remove-Item $dstHelper -Recurse -Force
+            }
+            Copy-Item $srcHelper $dstHelper -Recurse -Force
+        }
+
+        # ── PATH (exact-segment, null-safe) ───────────────────────────────────
+        $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+        if ([string]::IsNullOrEmpty($userPath)) {
+            $newPath = $INSTALL_DIR
+        } else {
+            $segments = $userPath -split ';' | Where-Object { $_ -ne '' }
+            if ($segments -notcontains $INSTALL_DIR) {
+                $newPath = ($segments + $INSTALL_DIR) -join ';'
+            } else {
+                $newPath = $userPath
+            }
+        }
+        if ($newPath -ne $userPath) {
+            [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+            $env:PATH = "$env:PATH;$INSTALL_DIR"
+            Write-Ok "Added $INSTALL_DIR to PATH (user scope)."
+        }
+
+        # ── Google Chrome check ───────────────────────────────────────────────
+        Write-Host ""
+        Write-Step "Checking for Google Chrome (required for auth login)..."
+        $chromePaths = @(
+            (Join-Path $env:ProgramFiles       "Google\Chrome\Application\chrome.exe"),
+            (Join-Path ${env:ProgramFiles(x86)} "Google\Chrome\Application\chrome.exe"),
+            (Join-Path $env:LOCALAPPDATA       "Google\Chrome\Application\chrome.exe")
+        )
+        $chromeFound = $chromePaths | Where-Object { Test-Path $_ }
+        if ($chromeFound) {
+            Write-Ok "Google Chrome found."
+        } else {
+            Write-Warn "Google Chrome was NOT found. tossctl auth login requires Chrome."
+            Write-Host "  Install from: https://www.google.com/chrome/" -ForegroundColor Yellow
+        }
+
+        # ── Python / playwright ───────────────────────────────────────────────
+        Write-Host ""
+        Write-Step "Installing Python dependencies for auth-helper..."
+        $pyCmd = $null
+        foreach ($candidate in @("python", "python3", "py")) {
+            if (Get-Command $candidate -ErrorAction SilentlyContinue) {
+                $pyCmd = $candidate
+                break
+            }
+        }
+        if ($pyCmd) {
+            $pipOut = & $pyCmd -m pip install --quiet playwright 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warn "Failed to install playwright. Run '$pyCmd -m pip install playwright' manually."
+                Write-Host $pipOut -ForegroundColor DarkGray
+            } else {
+                Write-Ok "playwright installed via $pyCmd."
+            }
+        } else {
+            Write-Warn "Python not found. Install Python 3.11+ from https://python.org"
+            Write-Host "  Then run: python -m pip install playwright" -ForegroundColor Yellow
+        }
+
+        # ── Done ──────────────────────────────────────────────────────────────
+        Write-Host ""
+        Write-Ok "Installed tossctl to $destBin"
+        Write-Host ""
+        Write-Host "NOTE: Open a new terminal window so PATH changes take effect." -ForegroundColor Yellow
+        Write-Host ""
+        Write-Host "Next steps:"
+        Write-Host "  tossctl doctor"
+        Write-Host "  tossctl auth login"
+
+    } finally {
+        Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Install-Tossctl

--- a/install.ps1
+++ b/install.ps1
@@ -13,6 +13,13 @@
 function Install-Tossctl {
     $ErrorActionPreference = "Stop"
 
+    # Windows PowerShell 5.1 on older hosts may negotiate TLS 1.0/1.1, which
+    # GitHub rejects. Ensure TLS 1.2 is enabled before any HTTPS request.
+    try {
+        [Net.ServicePointManager]::SecurityProtocol =
+            [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+    } catch {}
+
     $REPO        = "JungHoonGhae/tossinvest-cli"
     $BINARY      = "tossctl.exe"
     $ASSET       = "tossctl-windows-amd64"

--- a/install.ps1
+++ b/install.ps1
@@ -118,11 +118,13 @@ function Install-Tossctl {
         # ── Google Chrome check ───────────────────────────────────────────────
         Write-Host ""
         Write-Step "Checking for Google Chrome (required for auth login)..."
-        $chromePaths = @(
-            (Join-Path $env:ProgramFiles       "Google\Chrome\Application\chrome.exe"),
-            (Join-Path ${env:ProgramFiles(x86)} "Google\Chrome\Application\chrome.exe"),
-            (Join-Path $env:LOCALAPPDATA       "Google\Chrome\Application\chrome.exe")
-        )
+        # Some roots can be undefined (e.g. ProgramFiles(x86) on 32-bit Windows);
+        # filter nulls first so Join-Path never throws under -ErrorAction Stop.
+        $chromeRoots = @($env:ProgramFiles, ${env:ProgramFiles(x86)}, $env:LOCALAPPDATA) |
+            Where-Object { $_ }
+        $chromePaths = $chromeRoots | ForEach-Object {
+            Join-Path $_ "Google\Chrome\Application\chrome.exe"
+        }
         $chromeFound = $chromePaths | Where-Object { Test-Path $_ }
         if ($chromeFound) {
             Write-Ok "Google Chrome found."

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/junghoonkye/tossinvest-cli/internal/client"
@@ -98,6 +99,9 @@ func resolveDefaultPythonBin() string {
 			return candidate
 		}
 	}
+	if runtime.GOOS == "windows" {
+		return "python"
+	}
 	return "python3"
 }
 
@@ -111,6 +115,9 @@ func defaultPythonCandidates() []string {
 				filepath.Join(toolDir, tool, "Scripts", "python.exe"),
 			)
 		}
+	}
+	if runtime.GOOS == "windows" {
+		return append(candidates, "python", "python.exe", "python3")
 	}
 	return append(candidates, "python3")
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -117,7 +117,9 @@ func defaultPythonCandidates() []string {
 		}
 	}
 	if runtime.GOOS == "windows" {
-		return append(candidates, "python", "python.exe", "python3")
+		// `py` (the Windows Python launcher) is frequently present even when
+		// `python` is missing from PATH; install.ps1 falls back to it too.
+		return append(candidates, "python", "python.exe", "python3", "py")
 	}
 	return append(candidates, "python3")
 }

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -265,7 +265,7 @@ func TestDefaultLoginConfigPrefersUvToolPython(t *testing.T) {
 	}
 }
 
-func TestDefaultLoginConfigFallsBackToPython3(t *testing.T) {
+func TestDefaultLoginConfigFallsBackToPlatformPython(t *testing.T) {
 	t.Setenv("TOSSCTL_AUTH_HELPER_PYTHON", "")
 	t.Setenv("UV_TOOL_DIR", filepath.Join(t.TempDir(), "nonexistent"))
 	t.Setenv("XDG_DATA_HOME", filepath.Join(t.TempDir(), "nonexistent"))

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -241,7 +241,14 @@ func TestDefaultLoginConfigHonorsExplicitPythonOverride(t *testing.T) {
 
 func TestDefaultLoginConfigPrefersUvToolPython(t *testing.T) {
 	toolDir := t.TempDir()
-	pythonPath := filepath.Join(toolDir, "tossctl-auth-helper", "bin", "python")
+	// On Windows exec.LookPath only treats files with a PATHEXT extension as
+	// runnable, and uv installs the interpreter under Scripts\python.exe rather
+	// than bin/python, so mirror that layout to match resolveDefaultPythonBin.
+	rel := filepath.Join("tossctl-auth-helper", "bin", "python")
+	if runtime.GOOS == "windows" {
+		rel = filepath.Join("tossctl-auth-helper", "Scripts", "python.exe")
+	}
+	pythonPath := filepath.Join(toolDir, rel)
 	if err := os.MkdirAll(filepath.Dir(pythonPath), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -265,8 +266,13 @@ func TestDefaultLoginConfigFallsBackToPython3(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
 	cfg := DefaultLoginConfig(t.TempDir())
-	if cfg.PythonBin != "python3" {
-		t.Fatalf("expected python3 fallback, got %q", cfg.PythonBin)
+
+	want := "python3"
+	if runtime.GOOS == "windows" {
+		want = "python"
+	}
+	if cfg.PythonBin != want {
+		t.Fatalf("expected %q fallback, got %q", want, cfg.PythonBin)
 	}
 }
 

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -271,6 +271,10 @@ func TestDefaultLoginConfigFallsBackToPython3(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", filepath.Join(t.TempDir(), "nonexistent"))
 	t.Setenv("APPDATA", "")
 	t.Setenv("HOME", t.TempDir())
+	// Clear PATH so no python* candidate resolves via exec.LookPath, forcing
+	// resolveDefaultPythonBin to exercise its final GOOS-based fallback rather
+	// than whatever interpreter happens to be installed on the test machine.
+	t.Setenv("PATH", "")
 
 	cfg := DefaultLoginConfig(t.TempDir())
 


### PR DESCRIPTION
## 변경 사항

Windows에서도 macOS/Linux와 동일하게 한 줄로 `tossctl`을 설치할 수 있게 지원 추가.

## 영향 범위

- [ ] 조회 (읽기 전용)
- [ ] 거래 (mutation)
- [x] 설치 / CI
- [x] 문서

## 테스트

- [x] `make test` 통과 -> 윈도우 환경에서는 make가 없어 `go test ./...`를 직접 실행, 통과 확인. `make lint`는 Makefile에 없어 `go vet ./...`로 대체하였음 (`CONTRIBUTING.md`의 최신화가 아직 안된 것으로 보여짐).
- [x] 수동 확인 완료

## 체크리스트

- [x] 기존 동작을 깨뜨리지 않음
  - `install.sh` 미수정, macOS/Linux Python 탐색 경로 동일 (`python3` 폴백 유지)
  - Windows 분기는 `runtime.GOOS == "windows"` 조건으로 격리
  - 기존 테스트는 Linux/macOS CI에서 그대로 통과
- [ ] 거래 관련 변경인 경우 안전장치(config gate, confirm token 등) 유지 확인
  - 해당 없음 (설치/문서 변경만)
