### PR TITLE
fix(auth): 세션 User-Agent 일치로 비-macOS 인증 거부 해결 (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ tossctl 사용자 관점의 변경 이력입니다. 각 버전에서 "무엇을 
 ## [Unreleased]
 
 ### 버그 수정
+- Windows·Linux 에서 로그인은 성공하는데 `auth status` 와 모든 인증 요청이 거부(400/401/403)되던 문제 수정. tossctl 이 보내는 User-Agent 가 macOS 로 고정돼 있어, 다른 OS 에서 로그인한 세션과 불일치해 토스 서버가 거부하던 것이 원인이었습니다. 이제 로그인한 브라우저의 실제 User-Agent 를 세션에 저장해 그대로 쓰고, 기본값도 실행 OS 에 맞춰 만듭니다. (제보: @1jfollower-lang, #36)
 - Windows 설치 시 playwright 설치 단계에서 실제로는 성공했는데도 빨간 `NativeCommandError` 가 표시되던 문제 수정 (PowerShell이 pip 진행 메시지를 오류로 처리). 이제 종료 코드로만 성공/실패를 판정합니다. (제보: @vvdlife, #35)
 
 ## [0.10.0] - 2026-06-21

--- a/auth-helper/tossctl_auth_helper/cli.py
+++ b/auth-helper/tossctl_auth_helper/cli.py
@@ -377,6 +377,14 @@ def command_login(args: argparse.Namespace) -> int:
                         os.write(fd, payload)
                     finally:
                         os.close(fd)
+                    # Capture the browser's real User-Agent so the CLI sends a
+                    # UA coherent with the session it just established. Toss's
+                    # WTS API rejects fingerprint-incoherent requests (e.g. a
+                    # Windows login replayed with a hardcoded macOS UA → 403).
+                    try:
+                        user_agent = page.evaluate("() => navigator.userAgent")
+                    except Exception:
+                        user_agent = ""
                     browser.close()
                     return emit(
                         {
@@ -388,6 +396,7 @@ def command_login(args: argparse.Namespace) -> int:
                             "storage_state_path": str(storage_state_path),
                             "cookie_count": final_cookie_count,
                             "origin_count": len(storage_state.get("origins", [])),
+                            "user_agent": user_agent or "",
                         }
                     )
 

--- a/internal/auth/helper.go
+++ b/internal/auth/helper.go
@@ -15,6 +15,7 @@ type LoginResult struct {
 	StorageStatePath string `json:"storage_state_path"`
 	CookieCount      int    `json:"cookie_count,omitempty"`
 	OriginCount      int    `json:"origin_count,omitempty"`
+	UserAgent        string `json:"user_agent,omitempty"`
 }
 
 type LoginRunner interface {

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -211,6 +211,17 @@ func (s *Service) LoginWith(ctx context.Context, cfg LoginConfig) (*session.Sess
 		return nil, err
 	}
 
+	// Pin the User-Agent to the exact browser that established this session.
+	// Toss's WTS API rejects fingerprint-incoherent requests, so replaying a
+	// Windows/Linux login with the built-in fallback UA can be refused (403).
+	// applySession lets a session header override the default UA.
+	if result.UserAgent != "" {
+		sess.Headers["User-Agent"] = result.UserAgent
+		if err := s.store.Save(ctx, sess); err != nil {
+			return nil, err
+		}
+	}
+
 	// The helper-managed storage-state file holds a redundant copy of the full
 	// cookie set (SESSION/UTK/LTK/FTK/XSRF-TOKEN) that we have just persisted
 	// into session.json. Remove it so `auth logout` (which only clears

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -73,6 +73,7 @@ func TestLoginImportsHelperStorageState(t *testing.T) {
 				result: &LoginResult{
 					Status:           "ok",
 					StorageStatePath: storageStatePath,
+					UserAgent:        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) HeadlessChrome/149.0.0.0",
 				},
 			},
 		},
@@ -90,6 +91,11 @@ func TestLoginImportsHelperStorageState(t *testing.T) {
 	}
 	if sess.Headers["Browser-Tab-Id"] != "browser-tab-login" {
 		t.Fatalf("unexpected browser-tab-id header: %q", sess.Headers["Browser-Tab-Id"])
+	}
+	// The browser's real UA is pinned so API traffic stays fingerprint-coherent
+	// with the platform the login ran on (else Toss can reject with 403).
+	if sess.Headers["User-Agent"] != "Mozilla/5.0 (Windows NT 10.0; Win64; x64) HeadlessChrome/149.0.0.0" {
+		t.Fatalf("unexpected pinned user-agent: %q", sess.Headers["User-Agent"])
 	}
 	if sess.Storage["localStorage:WTS-DEVICE-ID"] != "device-123" {
 		t.Fatalf("unexpected storage value: %q", sess.Storage["localStorage:WTS-DEVICE-ID"])

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -18,14 +19,28 @@ import (
 const defaultAPIBaseURL = "https://wts-api.tossinvest.com"
 const defaultInfoBaseURL = "https://wts-info-api.tossinvest.com"
 const defaultCertBaseURL = "https://wts-cert-api.tossinvest.com"
+
 // DefaultBrowserUserAgent is the User-Agent that tossctl HTTP traffic uses
 // when the caller does not set one explicitly. Toss servers (wts-api,
 // wts-cert-api, wts-info-api, sse-message) reject the default Go HTTP UA with
-// 403; matching a current Chrome string keeps the fingerprint coherent.
-// Exported so packages outside `client` (e.g. `internal/push` for the SSE
-// listener) can reuse the same string instead of drifting copies — bumping
-// the Chrome version is a single-edit operation.
-const DefaultBrowserUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
+// 403, and reject requests whose UA is incoherent with the session's origin
+// platform — so this is built per-OS to match the machine the login ran on
+// (a hardcoded macOS UA on Windows/Linux was being refused). The normal login
+// path stores the browser's exact UA on the session, which overrides this;
+// this fallback covers manual `import-playwright-state` and the SSE listener.
+// Exported so packages outside `client` (e.g. `internal/push`) reuse one value.
+var DefaultBrowserUserAgent = browserUserAgent(runtime.GOOS)
+
+func browserUserAgent(goos string) string {
+	platform := "X11; Linux x86_64"
+	switch goos {
+	case "darwin":
+		platform = "Macintosh; Intel Mac OS X 10_15_7"
+	case "windows":
+		platform = "Windows NT 10.0; Win64; x64"
+	}
+	return "Mozilla/5.0 (" + platform + ") AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+}
 
 type Config struct {
 	HTTPClient    *http.Client

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBrowserUserAgentMatchesPlatform(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"darwin":  "Macintosh; Intel Mac OS X 10_15_7",
+		"windows": "Windows NT 10.0; Win64; x64",
+		"linux":   "X11; Linux x86_64",
+		"freebsd": "X11; Linux x86_64", // unknown OS falls back to the Linux token
+	}
+
+	for goos, want := range cases {
+		ua := browserUserAgent(goos)
+		if !strings.Contains(ua, want) {
+			t.Errorf("browserUserAgent(%q) = %q, want platform token %q", goos, ua, want)
+		}
+		if !strings.HasPrefix(ua, "Mozilla/5.0 (") || !strings.Contains(ua, "Chrome/") {
+			t.Errorf("browserUserAgent(%q) = %q, not a plausible Chrome UA", goos, ua)
+		}
+	}
+}
+
+func TestDefaultBrowserUserAgentUsesHostPlatform(t *testing.T) {
+	t.Parallel()
+
+	if DefaultBrowserUserAgent != browserUserAgent(runtime.GOOS) {
+		t.Fatalf("DefaultBrowserUserAgent = %q, want host-platform UA %q", DefaultBrowserUserAgent, browserUserAgent(runtime.GOOS))
+	}
+}


### PR DESCRIPTION
## 문제

비-macOS(Windows·Linux)에서 `tossctl auth login`은 성공하는데, `auth status`와 모든 인증 요청이 400/401/403으로 거부됨 (#36). 공개 엔드포인트(`wts-info-api`)는 200으로 정상.

## 원인

`DefaultBrowserUserAgent`가 macOS UA로 하드코딩되어 있어 모든 WTS 요청에 그대로 전송됨. 반면 Playwright 로그인은 실행 OS의 실제 UA(예: `Windows ... HeadlessChrome/149`)로 세션을 생성. 토스 WTS 서버는 세션 origin과 요청 UA가 불일치하면 거부함(코드 주석에도 'UA 불일치 시 403' 명시). macOS 사용자만 우연히 일치해 동작했음.

같은 doctor 실행에서 인증 경로(쿠키+XSRF+Browser-Tab-Id 전송)는 403, probe는 401로 갈린 점이 헤더 의존성을 뒷받침함.

## 수정

- 로그인 시 브라우저의 실제 `navigator.userAgent`를 캡처해 세션 헤더에 저장 → 이후 모든 요청에 동일 UA 사용 (정확 일치)
- `DefaultBrowserUserAgent`를 `runtime.GOOS`에 맞춰 생성 (darwin/windows/linux) — 수동 `import-playwright-state`·SSE 등 캡처 UA가 없는 경로의 폴백
- 플랫폼별 UA 생성 + 로그인 UA 고정 단위 테스트 추가

## 확인

- `go test ./...` 통과, `go build ./...` OK
- 라이브 재현 환경(Windows)이 없어 제보자 검증이 필요합니다. 빌드 후 `tossctl auth status`에서 Live Check: valid 확인 요청.

Closes #36