### PR TITLE
fix(install): /usr/local/bin 부재 시 설치 실패 수정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ tossctl 사용자 관점의 변경 이력입니다. 각 버전에서 "무엇을 
 
 ## [Unreleased]
 
+### 버그 수정
+- 설치 스크립트(`curl ... install.sh | sh`)가 `/usr/local/bin` 이 없는 환경(주로 새로 설정한 Apple Silicon Mac — Homebrew 가 `/opt/homebrew` 에 있어 `/usr/local/bin` 이 아직 없는 경우)에서 `mv: ... No such file or directory` 로 설치에 실패하던 문제 수정. 설치 디렉터리를 먼저 만들고, 쓰기 권한이 있으면 sudo 없이 설치합니다. `INSTALL_DIR`·`SHARE_DIR` 환경변수로 설치 위치를 바꿀 수도 있습니다.
+
 ## [0.11.1] - 2026-06-25
 
 ### 버그 수정

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,8 @@ set -e
 
 REPO="JungHoonGhae/tossinvest-cli"
 BINARY="tossctl"
-INSTALL_DIR="/usr/local/bin"
-SHARE_DIR="/usr/local/share/tossctl"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+SHARE_DIR="${SHARE_DIR:-/usr/local/share/tossctl}"
 
 main() {
     os=$(detect_os)
@@ -37,22 +37,24 @@ main() {
     tar -xzf "${tmpdir}/${asset}" -C "$tmpdir"
 
     echo "Installing to ${INSTALL_DIR}..."
-    if [ -w "$INSTALL_DIR" ]; then
-        mv "${tmpdir}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
-        chmod +x "${INSTALL_DIR}/${BINARY}"
-        mkdir -p "${SHARE_DIR}"
-        if [ -d "${tmpdir}/auth-helper" ]; then
-            rm -rf "${SHARE_DIR}/auth-helper"
-            mv "${tmpdir}/auth-helper" "${SHARE_DIR}/auth-helper"
-        fi
+
+    # Use sudo only when we can't write the target ourselves. On a fresh
+    # Apple Silicon Mac /usr/local/bin frequently doesn't exist yet (Homebrew
+    # lives in /opt/homebrew), so we must create it before moving the binary —
+    # otherwise mv fails with "No such file or directory" on the destination.
+    if can_write "$INSTALL_DIR" && can_write "$SHARE_DIR"; then
+        SUDO=""
     else
-        sudo mv "${tmpdir}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
-        sudo chmod +x "${INSTALL_DIR}/${BINARY}"
-        sudo mkdir -p "${SHARE_DIR}"
-        if [ -d "${tmpdir}/auth-helper" ]; then
-            sudo rm -rf "${SHARE_DIR}/auth-helper"
-            sudo mv "${tmpdir}/auth-helper" "${SHARE_DIR}/auth-helper"
-        fi
+        SUDO="sudo"
+        echo "Elevated permissions required to write ${INSTALL_DIR}."
+    fi
+
+    $SUDO mkdir -p "${INSTALL_DIR}" "${SHARE_DIR}"
+    $SUDO mv "${tmpdir}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+    $SUDO chmod +x "${INSTALL_DIR}/${BINARY}"
+    if [ -d "${tmpdir}/auth-helper" ]; then
+        $SUDO rm -rf "${SHARE_DIR}/auth-helper"
+        $SUDO mv "${tmpdir}/auth-helper" "${SHARE_DIR}/auth-helper"
     fi
 
     echo ""
@@ -70,6 +72,16 @@ main() {
     echo "Next steps:"
     echo "  tossctl doctor"
     echo "  tossctl auth login"
+}
+
+# True if we can create/write inside dir. When dir doesn't exist yet, walk up
+# to the first existing ancestor and test that (mkdir -p will create the rest).
+can_write() {
+    d="$1"
+    while [ ! -e "$d" ]; do
+        d=$(dirname "$d")
+    done
+    [ -w "$d" ]
 }
 
 detect_os() {


### PR DESCRIPTION
## 문제
`curl … install.sh | sh` 가 `/usr/local/bin` 이 없는 환경(주로 새로 설정한 Apple Silicon Mac — Homebrew 가 `/opt/homebrew` 에 있어 `/usr/local/bin` 부재)에서 `mv: … No such file or directory` 로 설치 실패. 디렉터리가 없어 sudo 분기로 가도 `sudo mv` 역시 목적지 부모 부재로 동일 실패.

## 수정
- 설치 디렉터리를 `mkdir -p` 로 먼저 생성
- `can_write` 헬퍼로 정말 권한이 없을 때만 sudo (있으면 sudo 없이 설치)
- `INSTALL_DIR`/`SHARE_DIR` 환경변수 오버라이드 지원

## 검증
존재하지 않는 설치 경로로 실제 릴리즈를 받아 끝까지 실행 → 디렉터리 생성·설치·바이너리 실행(`tossctl 0.11.1`) 통과. `sh -n` 문법 체크, `can_write` 로직 확인. Windows `install.ps1` 은 이미 디렉터리를 생성하므로 영향 없음.

> `curl … | sh` 는 main 의 raw 파일을 받으므로 머지 즉시 적용됨.