### PR TITLE
docs(readme): 프리미엄 배지 + 스폰서 버튼

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -15,13 +15,17 @@
   <a href="LICENSE"><img src="docs/assets/badges/license.svg" height="44" alt="License: MIT" /></a>&nbsp;
   <a href="https://go.dev/"><img src="docs/assets/badges/go.svg" height="44" alt="Built with Go 1.25+" /></a>&nbsp;
   <img src="docs/assets/badges/agents.svg" height="44" alt="Works with Claude · Codex · Cursor" />&nbsp;
-  <img src="docs/assets/badges/output.svg" height="44" alt="Output: JSON · CSV · SSE" />&nbsp;
-  <a href="https://tossinvest-cli.vercel.app/docs/guide/hybrid-openapi"><img src="docs/assets/badges/hybrid.svg" height="44" alt="Official API: Optional hybrid" /></a>
+  <img src="docs/assets/badges/output.svg" height="44" alt="Output: JSON · CSV · SSE" />
 </p>
 
 <p align="center">
+  <a href="https://tossinvest-cli.vercel.app/docs/guide/hybrid-openapi"><img src="docs/assets/badges/hybrid.svg" height="44" alt="Official API: Optional hybrid" /></a>&nbsp;
   <a href="docs/migration/.openapi-snapshot.json"><img src="docs/assets/badges/verified-api.svg" height="44" alt="Verified vs official Open API" /></a>&nbsp;
   <a href="docs/migration/.openapi-snapshot.json"><img src="docs/assets/badges/spec-checked.svg" height="44" alt="Spec last checked" /></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/sponsors/JungHoonGhae"><img src="docs/assets/badges/sponsor.svg" height="44" alt="Become a sponsor" /></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -16,13 +16,17 @@
   <a href="LICENSE"><img src="docs/assets/badges/license.svg" height="44" alt="License: MIT" /></a>&nbsp;
   <a href="https://go.dev/"><img src="docs/assets/badges/go.svg" height="44" alt="Built with Go 1.25+" /></a>&nbsp;
   <img src="docs/assets/badges/agents.svg" height="44" alt="Works with Claude · Codex · Cursor" />&nbsp;
-  <img src="docs/assets/badges/output.svg" height="44" alt="Output: JSON · CSV · SSE" />&nbsp;
-  <a href="https://tossinvest-cli.vercel.app/docs/guide/hybrid-openapi"><img src="docs/assets/badges/hybrid.svg" height="44" alt="Official API: Optional hybrid" /></a>
+  <img src="docs/assets/badges/output.svg" height="44" alt="Output: JSON · CSV · SSE" />
 </p>
 
 <p align="center">
+  <a href="https://tossinvest-cli.vercel.app/docs/guide/hybrid-openapi"><img src="docs/assets/badges/hybrid.svg" height="44" alt="Official API: Optional hybrid" /></a>&nbsp;
   <a href="docs/migration/.openapi-snapshot.json"><img src="docs/assets/badges/verified-api.svg" height="44" alt="Verified vs official Open API" /></a>&nbsp;
   <a href="docs/migration/.openapi-snapshot.json"><img src="docs/assets/badges/spec-checked.svg" height="44" alt="Spec last checked" /></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/sponsors/JungHoonGhae"><img src="docs/assets/badges/sponsor.svg" height="44" alt="Become a sponsor" /></a>
 </p>
 
 <p align="center">

--- a/docs/assets/badges/agents.svg
+++ b/docs/assets/badges/agents.svg
@@ -1,11 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="267" height="46" viewBox="0 0 267 46" role="img" aria-label="Works with: Claude · Codex · Cursor">
-  <defs><clipPath id="r"><rect width="267" height="46" rx="9"/></clipPath></defs>
-  <g clip-path="url(#r)">
-    <rect width="267" height="46" fill="#15161a"/>
-    <rect x="0" y="0" width="3" height="46" fill="#34D399"/>
-    <line x1="94.0" y1="11" x2="94.0" y2="35" stroke="#2b2d34" stroke-width="1"/>
-  </g>
-  <rect x="0.5" y="0.5" width="266" height="45" rx="9" fill="none" stroke="#2b2d34" stroke-width="1"/>
-  <text x="17.0" y="23.0" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10.5" letter-spacing="0.8" fill="#8b8d98">WORKS WITH</text>
-  <text x="108.0" y="23.0" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="13" font-weight="600" fill="#f2f3f5">Claude · Codex · Cursor</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="56" viewBox="0 0 320 56">
+ <defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+  </linearGradient>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
+   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  </filter>
+ </defs>
+ <g filter="url(#sh)"><rect x="6" y="6" width="308.8" height="44" rx="11" fill="url(#bg)"/></g>
+ <rect x="6" y="6" width="308.8" height="44" rx="11" fill="url(#gloss)"/>
+ <rect x="6.5" y="6.5" width="307.8" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
+ <line x1="114.0" y1="18" x2="114.0" y2="38" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>
+ <text x="60.0" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">WORKS WITH</text>
+ <text x="214.4" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">Claude · Codex · Cursor</text>
 </svg>

--- a/docs/assets/badges/go.svg
+++ b/docs/assets/badges/go.svg
@@ -1,11 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="174" height="46" viewBox="0 0 174 46" role="img" aria-label="Built with: Go 1.25+">
-  <defs><clipPath id="r"><rect width="174" height="46" rx="9"/></clipPath></defs>
-  <g clip-path="url(#r)">
-    <rect width="174" height="46" fill="#15161a"/>
-    <rect x="0" y="0" width="3" height="46" fill="#34D399"/>
-    <line x1="94.0" y1="11" x2="94.0" y2="35" stroke="#2b2d34" stroke-width="1"/>
-  </g>
-  <rect x="0.5" y="0.5" width="173" height="45" rx="9" fill="none" stroke="#2b2d34" stroke-width="1"/>
-  <text x="17.0" y="23.0" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10.5" letter-spacing="0.8" fill="#8b8d98">BUILT WITH</text>
-  <text x="108.0" y="23.0" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="13" font-weight="600" fill="#f2f3f5">Go 1.25+</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="218" height="56" viewBox="0 0 218 56">
+ <defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+  </linearGradient>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
+   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  </filter>
+ </defs>
+ <g filter="url(#sh)"><rect x="6" y="6" width="206.8" height="44" rx="11" fill="url(#bg)"/></g>
+ <rect x="6" y="6" width="206.8" height="44" rx="11" fill="url(#gloss)"/>
+ <rect x="6.5" y="6.5" width="205.8" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
+ <line x1="114.0" y1="18" x2="114.0" y2="38" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>
+ <text x="60.0" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">BUILT WITH</text>
+ <text x="163.4" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">Go 1.25+</text>
 </svg>

--- a/docs/assets/badges/hybrid.svg
+++ b/docs/assets/badges/hybrid.svg
@@ -1,11 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="239" height="46" viewBox="0 0 239 46" role="img" aria-label="Official API: Optional hybrid">
-  <defs><clipPath id="r"><rect width="239" height="46" rx="9"/></clipPath></defs>
-  <g clip-path="url(#r)">
-    <rect width="239" height="46" fill="#15161a"/>
-    <rect x="0" y="0" width="3" height="46" fill="#34D399"/>
-    <line x1="107.0" y1="11" x2="107.0" y2="35" stroke="#2b2d34" stroke-width="1"/>
-  </g>
-  <rect x="0.5" y="0.5" width="238" height="45" rx="9" fill="none" stroke="#2b2d34" stroke-width="1"/>
-  <text x="17.0" y="23.0" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10.5" letter-spacing="0.8" fill="#8b8d98">OFFICIAL API</text>
-  <text x="121.0" y="23.0" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="13" font-weight="600" fill="#f2f3f5">Optional hybrid</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="290" height="56" viewBox="0 0 290 56">
+ <defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+  </linearGradient>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
+   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  </filter>
+ </defs>
+ <g filter="url(#sh)"><rect x="6" y="6" width="278.2" height="44" rx="11" fill="url(#bg)"/></g>
+ <rect x="6" y="6" width="278.2" height="44" rx="11" fill="url(#gloss)"/>
+ <rect x="6.5" y="6.5" width="277.2" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
+ <line x1="128.4" y1="18" x2="128.4" y2="38" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>
+ <text x="67.2" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">OFFICIAL API</text>
+ <text x="206.3" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">Optional hybrid</text>
 </svg>

--- a/docs/assets/badges/license.svg
+++ b/docs/assets/badges/license.svg
@@ -1,11 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="129" height="46" viewBox="0 0 129 46" role="img" aria-label="License: MIT">
-  <defs><clipPath id="r"><rect width="129" height="46" rx="9"/></clipPath></defs>
-  <g clip-path="url(#r)">
-    <rect width="129" height="46" fill="#15161a"/>
-    <rect x="0" y="0" width="3" height="46" fill="#34D399"/>
-    <line x1="74.5" y1="11" x2="74.5" y2="35" stroke="#2b2d34" stroke-width="1"/>
-  </g>
-  <rect x="0.5" y="0.5" width="128" height="45" rx="9" fill="none" stroke="#2b2d34" stroke-width="1"/>
-  <text x="17.0" y="23.0" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10.5" letter-spacing="0.8" fill="#8b8d98">LICENSE</text>
-  <text x="88.5" y="23.0" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="13" font-weight="600" fill="#f2f3f5">MIT</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="170" height="56" viewBox="0 0 170 56">
+ <defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+  </linearGradient>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
+   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  </filter>
+ </defs>
+ <g filter="url(#sh)"><rect x="6" y="6" width="158.0" height="44" rx="11" fill="url(#bg)"/></g>
+ <rect x="6" y="6" width="158.0" height="44" rx="11" fill="url(#gloss)"/>
+ <rect x="6.5" y="6.5" width="157.0" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
+ <line x1="92.4" y1="18" x2="92.4" y2="38" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>
+ <text x="49.2" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">LICENSE</text>
+ <text x="128.2" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">MIT</text>
 </svg>

--- a/docs/assets/badges/output.svg
+++ b/docs/assets/badges/output.svg
@@ -1,11 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="202" height="46" viewBox="0 0 202 46" role="img" aria-label="Output: JSON · CSV · SSE">
-  <defs><clipPath id="r"><rect width="202" height="46" rx="9"/></clipPath></defs>
-  <g clip-path="url(#r)">
-    <rect width="202" height="46" fill="#15161a"/>
-    <rect x="0" y="0" width="3" height="46" fill="#34D399"/>
-    <line x1="68.0" y1="11" x2="68.0" y2="35" stroke="#2b2d34" stroke-width="1"/>
-  </g>
-  <rect x="0.5" y="0.5" width="201" height="45" rx="9" fill="none" stroke="#2b2d34" stroke-width="1"/>
-  <text x="17.0" y="23.0" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10.5" letter-spacing="0.8" fill="#8b8d98">OUTPUT</text>
-  <text x="82.0" y="23.0" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="13" font-weight="600" fill="#f2f3f5">JSON · CSV · SSE</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="56" viewBox="0 0 250 56">
+ <defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+  </linearGradient>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
+   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  </filter>
+ </defs>
+ <g filter="url(#sh)"><rect x="6" y="6" width="238.0" height="44" rx="11" fill="url(#bg)"/></g>
+ <rect x="6" y="6" width="238.0" height="44" rx="11" fill="url(#gloss)"/>
+ <rect x="6.5" y="6.5" width="237.0" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
+ <line x1="85.2" y1="18" x2="85.2" y2="38" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>
+ <text x="45.6" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">OUTPUT</text>
+ <text x="164.6" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">JSON · CSV · SSE</text>
 </svg>

--- a/docs/assets/badges/spec-checked.svg
+++ b/docs/assets/badges/spec-checked.svg
@@ -1,11 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="207" height="46" viewBox="0 0 207 46" role="img" aria-label="Spec checked: 2026-06-27">
-  <defs><clipPath id="r"><rect width="207" height="46" rx="9"/></clipPath></defs>
-  <g clip-path="url(#r)">
-    <rect width="207" height="46" fill="#15161a"/>
-    <rect x="0" y="0" width="3" height="46" fill="#34D399"/>
-    <line x1="107.0" y1="11" x2="107.0" y2="35" stroke="#2b2d34" stroke-width="1"/>
-  </g>
-  <rect x="0.5" y="0.5" width="206" height="45" rx="9" fill="none" stroke="#2b2d34" stroke-width="1"/>
-  <text x="17.0" y="23.0" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10.5" letter-spacing="0.8" fill="#8b8d98">SPEC CHECKED</text>
-  <text x="121.0" y="23.0" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="13" font-weight="600" fill="#f2f3f5">2026-06-27</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="254" height="56" viewBox="0 0 254 56">
+ <defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+  </linearGradient>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
+   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  </filter>
+ </defs>
+ <g filter="url(#sh)"><rect x="6" y="6" width="242.4" height="44" rx="11" fill="url(#bg)"/></g>
+ <rect x="6" y="6" width="242.4" height="44" rx="11" fill="url(#gloss)"/>
+ <rect x="6.5" y="6.5" width="241.4" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
+ <line x1="128.4" y1="18" x2="128.4" y2="38" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>
+ <text x="67.2" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">SPEC CHECKED</text>
+ <text x="188.4" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">2026-06-27</text>
 </svg>

--- a/docs/assets/badges/sponsor.svg
+++ b/docs/assets/badges/sponsor.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="187" height="56" viewBox="0 0 187 56">
+ <defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+  </linearGradient>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
+   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  </filter>
+ </defs>
+ <g filter="url(#sh)"><rect x="6" y="6" width="175.6" height="44" rx="11" fill="url(#bg)"/></g>
+ <rect x="6" y="6" width="175.6" height="44" rx="11" fill="url(#gloss)"/>
+ <rect x="6.5" y="6.5" width="174.6" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
+ <text x="93.8" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="14" font-weight="600" fill="#fafafa"><tspan fill="#db61a2">♥</tspan>  Become a sponsor</text>
+</svg>

--- a/docs/assets/badges/verified-api.svg
+++ b/docs/assets/badges/verified-api.svg
@@ -1,11 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="250" height="46" viewBox="0 0 250 46" role="img" aria-label="vs Official API: v1.1.5 verified">
-  <defs><clipPath id="r"><rect width="250" height="46" rx="9"/></clipPath></defs>
-  <g clip-path="url(#r)">
-    <rect width="250" height="46" fill="#15161a"/>
-    <rect x="0" y="0" width="3" height="46" fill="#34D399"/>
-    <line x1="126.5" y1="11" x2="126.5" y2="35" stroke="#2b2d34" stroke-width="1"/>
-  </g>
-  <rect x="0.5" y="0.5" width="249" height="45" rx="9" fill="none" stroke="#2b2d34" stroke-width="1"/>
-  <text x="17.0" y="23.0" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10.5" letter-spacing="0.8" fill="#8b8d98">VS OFFICIAL API</text>
-  <text x="140.5" y="23.0" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="13" font-weight="600" fill="#f2f3f5">v1.1.5 verified</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="302" height="56" viewBox="0 0 302 56">
+ <defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+  </linearGradient>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
+   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  </filter>
+ </defs>
+ <g filter="url(#sh)"><rect x="6" y="6" width="290.6" height="44" rx="11" fill="url(#bg)"/></g>
+ <rect x="6" y="6" width="290.6" height="44" rx="11" fill="url(#gloss)"/>
+ <rect x="6.5" y="6.5" width="289.6" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
+ <line x1="150.0" y1="18" x2="150.0" y2="38" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>
+ <text x="78.0" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">VS OFFICIAL API</text>
+ <text x="223.3" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">v1.1.5 verified</text>
 </svg>

--- a/tools/make_badges.py
+++ b/tools/make_badges.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
-"""Generate the README custom dark-pill badge SVGs.
+"""Generate the README custom badge SVGs (premium dark-glass pill style).
 
-Single source of truth for the bespoke badges in README (taste-skill style:
-dark pill, gray uppercase label + white value, green brand accent). Static
-badges carry fixed values; the two "verified vs official API" / "spec checked"
-badges read their values from docs/migration/.openapi-snapshot.json so they
-stay fresh — the daily monitor re-runs this and commits the result.
+Single source of truth for the bespoke README badges. Style mirrors a high-end
+button set: a near-black pill with a soft top-gloss gradient, rim highlight and
+drop shadow, a centered uppercase gray label and a centered white value split
+by a faint divider. Static badges carry fixed values; the two "verified vs
+official API" / "spec checked" badges read their values from
+docs/migration/.openapi-snapshot.json so they stay fresh — the daily monitor
+re-runs this and commits the result. Also emits a "Become a sponsor" CTA.
 
 Usage: python3 tools/make_badges.py   (no args)
 Output: docs/assets/badges/*.svg
@@ -19,53 +21,81 @@ ROOT = Path(__file__).resolve().parent.parent
 OUT = ROOT / "docs" / "assets" / "badges"
 SNAP = ROOT / "docs" / "migration" / ".openapi-snapshot.json"
 
-ACCENT = "#34D399"  # tossctl brand green
+PH, SP, RX = 44, 6, 11  # pill height, shadow padding, corner radius
 
 
-def _w_label(s: str) -> float:
-    return len(s) * 6.5
+def _lw(s: str) -> float:
+    return len(s) * 7.2  # monospace label (incl. letter-spacing)
 
 
-def _w_value(s: str) -> float:
-    return sum(8.4 if c.isupper() else (3.4 if c in " ·." else 7.0) for c in s)
+def _vw(s: str) -> float:
+    return sum(9.2 if c.isupper() else (3.8 if c in " ·." else 7.6) for c in s)
 
 
-def badge(filename: str, label: str, value: str, accent: str = ACCENT) -> None:
-    H, r, acc = 46, 9, 3
-    pad_l, gap_ld, gap_dv, pad_r = 14, 12, 14, 16
-    lw, vw = _w_label(label), _w_value(value)
-    x_label = acc + pad_l
-    x_div = x_label + lw + gap_ld
-    x_value = x_div + gap_dv
-    W = int(x_value + vw + pad_r)
-    cy = H / 2
-    svg = f'''<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{H}" viewBox="0 0 {W} {H}" role="img" aria-label="{label}: {value}">
-  <defs><clipPath id="r"><rect width="{W}" height="{H}" rx="{r}"/></clipPath></defs>
-  <g clip-path="url(#r)">
-    <rect width="{W}" height="{H}" fill="#15161a"/>
-    <rect x="0" y="0" width="{acc}" height="{H}" fill="{accent}"/>
-    <line x1="{x_div:.1f}" y1="11" x2="{x_div:.1f}" y2="{H - 11}" stroke="#2b2d34" stroke-width="1"/>
-  </g>
-  <rect x="0.5" y="0.5" width="{W - 1}" height="{H - 1}" rx="{r}" fill="none" stroke="#2b2d34" stroke-width="1"/>
-  <text x="{x_label:.1f}" y="{cy:.1f}" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10.5" letter-spacing="0.8" fill="#8b8d98">{label.upper()}</text>
-  <text x="{x_value:.1f}" y="{cy:.1f}" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="13" font-weight="600" fill="#f2f3f5">{value}</text>
-</svg>
-'''
-    (OUT / filename).write_text(svg)
-    print(f"  {filename}  ({W}x{H})  {label} | {value}")
+_DEFS = '''
+ <defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+  </linearGradient>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
+   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  </filter>
+ </defs>'''
+
+
+def _shell(pw: float, extra: str) -> str:
+    VW, VH = int(pw + 2 * SP), PH + 2 * SP
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{VW}" height="{VH}" viewBox="0 0 {VW} {VH}">{_DEFS}\n'
+        f' <g filter="url(#sh)"><rect x="{SP}" y="{SP}" width="{pw:.1f}" height="{PH}" rx="{RX}" fill="url(#bg)"/></g>\n'
+        f' <rect x="{SP}" y="{SP}" width="{pw:.1f}" height="{PH}" rx="{RX}" fill="url(#gloss)"/>\n'
+        f' <rect x="{SP + 0.5}" y="{SP + 0.5}" width="{pw - 1:.1f}" height="{PH - 1}" rx="{RX}" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>\n'
+        f'{extra}\n</svg>\n'
+    )
+
+
+def badge(fn: str, label: str, value: str) -> None:
+    lpad, vpad, minlabel = 18, 22, 78
+    lreg = max(_lw(label) + 2 * lpad, minlabel)
+    vreg = _vw(value) + 2 * vpad
+    pw = lreg + vreg
+    cy = SP + PH / 2
+    divx = SP + lreg
+    lcx, vcx = SP + lreg / 2, divx + vreg / 2
+    extra = (
+        f' <line x1="{divx:.1f}" y1="{SP + 12}" x2="{divx:.1f}" y2="{SP + PH - 12}" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>\n'
+        f' <text x="{lcx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">{label.upper()}</text>\n'
+        f' <text x="{vcx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">{value}</text>'
+    )
+    (OUT / fn).write_text(_shell(pw, extra))
+    print(f"  {fn}  {label} | {value}")
+
+
+def cta(fn: str, text: str) -> None:
+    """Single-region call-to-action pill with a pink heart (sponsor)."""
+    pad = 22
+    pw = 16 + _vw(text) + 2 * pad  # 16 = heart glyph room
+    cy, cx = SP + PH / 2, SP + pw / 2
+    extra = (
+        f' <text x="{cx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="14" font-weight="600" fill="#fafafa">'
+        f'<tspan fill="#db61a2">♥</tspan>  {text}</text>'
+    )
+    (OUT / fn).write_text(_shell(pw, extra))
+    print(f"  {fn}  ♥ {text}")
 
 
 def main() -> None:
     OUT.mkdir(parents=True, exist_ok=True)
 
-    # Static badges
     badge("license.svg", "License", "MIT")
     badge("go.svg", "Built with", "Go 1.25+")
     badge("agents.svg", "Works with", "Claude · Codex · Cursor")
     badge("output.svg", "Output", "JSON · CSV · SSE")
     badge("hybrid.svg", "Official API", "Optional hybrid")
 
-    # Dynamic badges — values from the verified Open API snapshot
     spec_version, last_checked = "?", "?"
     if SNAP.exists():
         snap = json.loads(SNAP.read_text())
@@ -73,6 +103,8 @@ def main() -> None:
         last_checked = str(snap.get("last_checked_at", "?"))
     badge("verified-api.svg", "vs Official API", f"v{spec_version} verified")
     badge("spec-checked.svg", "Spec checked", last_checked)
+
+    cta("sponsor.svg", "Become a sponsor")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
README 상단 배지를 프리미엄 다크-글래스 펄 스타일로 재디자인하고, 줄바꿈 깨짐을 4+3 2줄 레이아웃으로 정리했습니다. ♥ Become a sponsor CTA 추가.

## 변경
- **배지 디자인**: 글로시 세로 그라데이션 + 림 하이라이트 + 드롭섀도우, 라벨(모노 대문자)/값 중앙 분할 + 페인트 디바이더
- **레이아웃**: 5+2 → 4+3 2줄로 재배치 (License·Built with·Works with·Output / Official API·vs Official API·Spec checked)
- **스폰서**: `github.com/sponsors/JungHoonGhae` 링크 CTA 추가
- `tools/make_badges.py` 단일 소스 유지 — `verified-api`/`spec-checked`는 스냅샷에서 값 자동 반영(daily-monitor가 재생성·커밋)

라이트/다크 GitHub 테마 모두에서 렌더 확인.
