### PR TITLE
docs(readme): 배지 비율 보정 + 후원/연락처 섹션

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -25,14 +25,11 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/sponsors/JungHoonGhae"><img src="docs/assets/badges/sponsor.svg" height="44" alt="Become a sponsor" /></a>
-</p>
-
-<p align="center">
   <a href="#quick-start"><strong>Quick Start</strong></a> ·
   <a href="#support-scope"><strong>Support Scope</strong></a> ·
   <a href="#command-reference"><strong>Command Reference</strong></a> ·
-  <a href="#faq"><strong>FAQ</strong></a>
+  <a href="#faq"><strong>FAQ</strong></a> ·
+  <a href="#sponsors"><strong>Sponsors</strong></a>
 </p>
 
 <p align="center">
@@ -490,7 +487,23 @@ Override paths with `--config-dir` and `--session-file`.
 
 ## Contributing
 
-Bug reports and PRs welcome.
+We would love your feedback. Suggestions and bug reports:
+
+- Open an [Issue](https://github.com/JungHoonGhae/tossinvest-cli/issues) or PR on GitHub
+- Connect on LinkedIn [@junghoonghae](https://www.linkedin.com/in/junghoonghae)
+- Email [lucas.ghae@remodule.dev](mailto:lucas.ghae@remodule.dev)
+
+## Sponsors
+
+If tossinvest-cli helps you, consider sponsoring its continued development.
+
+<p align="center">
+  <a href="https://github.com/sponsors/JungHoonGhae"><img src="docs/assets/badges/sponsor.svg" height="46" alt="Become a sponsor" /></a>
+</p>
+
+<p align="center"><sub>Be the first sponsor and your logo lands right here.</sub></p>
+
+<!-- sponsors --><!-- sponsors -->
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -26,15 +26,12 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/sponsors/JungHoonGhae"><img src="docs/assets/badges/sponsor.svg" height="44" alt="Become a sponsor" /></a>
-</p>
-
-<p align="center">
   <a href="#quick-start"><strong>Quick Start</strong></a> ·
   <a href="#지원-범위"><strong>지원 범위</strong></a> ·
   <a href="#명령-목록"><strong>명령 목록</strong></a> ·
   <a href="#faq"><strong>FAQ</strong></a> ·
-  <a href="#문서"><strong>문서</strong></a>
+  <a href="#문서"><strong>문서</strong></a> ·
+  <a href="#후원"><strong>후원</strong></a>
 </p>
 
 <p align="center">
@@ -578,7 +575,23 @@ US/KR 지정가 매수/매도, US 소수점 매수, 당일 미체결 취소가 l
 
 ## Contributing
 
-버그 제보와 PR은 환영합니다.
+피드백을 환영합니다. 제안·버그 제보:
+
+- GitHub에서 [이슈](https://github.com/JungHoonGhae/tossinvest-cli/issues)나 PR 열기
+- LinkedIn [@junghoonghae](https://www.linkedin.com/in/junghoonghae)
+- 이메일 [lucas.ghae@remodule.dev](mailto:lucas.ghae@remodule.dev)
+
+## 후원
+
+tossinvest-cli 가 도움이 되었다면 후원으로 지속적인 개발을 응원해 주세요.
+
+<p align="center">
+  <a href="https://github.com/sponsors/JungHoonGhae"><img src="docs/assets/badges/sponsor.svg" height="46" alt="Become a sponsor" /></a>
+</p>
+
+<p align="center"><sub>첫 후원자가 되어주시면 이 자리에 로고를 모셔두겠습니다.</sub></p>
+
+<!-- sponsors --><!-- sponsors -->
 
 ## License
 

--- a/docs/assets/badges/agents.svg
+++ b/docs/assets/badges/agents.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="320" height="56" viewBox="0 0 320 56">
+<svg xmlns="http://www.w3.org/2000/svg" width="398" height="64" viewBox="0 0 398 64">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
-  </linearGradient>
-  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
-   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
+  </radialGradient>
+  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
+   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
   </filter>
  </defs>
- <g filter="url(#sh)"><rect x="6" y="6" width="308.8" height="44" rx="11" fill="url(#bg)"/></g>
- <rect x="6" y="6" width="308.8" height="44" rx="11" fill="url(#gloss)"/>
- <rect x="6.5" y="6.5" width="307.8" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
- <line x1="114.0" y1="18" x2="114.0" y2="38" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>
- <text x="60.0" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">WORKS WITH</text>
- <text x="214.4" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">Claude · Codex · Cursor</text>
+ <g filter="url(#sh)"><rect x="7" y="7" width="384.0" height="50" rx="8" fill="url(#bg)"/></g>
+ <rect x="7" y="7" width="384.0" height="50" rx="8" fill="url(#gloss)"/>
+ <rect x="7.5" y="7.5" width="383.0" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
+ <line x1="131.0" y1="22" x2="131.0" y2="42" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>
+ <text x="69.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">WORKS WITH</text>
+ <text x="261.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">Claude · Codex · Cursor</text>
 </svg>

--- a/docs/assets/badges/go.svg
+++ b/docs/assets/badges/go.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="218" height="56" viewBox="0 0 218 56">
+<svg xmlns="http://www.w3.org/2000/svg" width="262" height="64" viewBox="0 0 262 64">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
-  </linearGradient>
-  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
-   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
+  </radialGradient>
+  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
+   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
   </filter>
  </defs>
- <g filter="url(#sh)"><rect x="6" y="6" width="206.8" height="44" rx="11" fill="url(#bg)"/></g>
- <rect x="6" y="6" width="206.8" height="44" rx="11" fill="url(#gloss)"/>
- <rect x="6.5" y="6.5" width="205.8" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
- <line x1="114.0" y1="18" x2="114.0" y2="38" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>
- <text x="60.0" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">BUILT WITH</text>
- <text x="163.4" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">Go 1.25+</text>
+ <g filter="url(#sh)"><rect x="7" y="7" width="248.7" height="50" rx="8" fill="url(#bg)"/></g>
+ <rect x="7" y="7" width="248.7" height="50" rx="8" fill="url(#gloss)"/>
+ <rect x="7.5" y="7.5" width="247.7" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
+ <line x1="131.0" y1="22" x2="131.0" y2="42" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>
+ <text x="69.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">BUILT WITH</text>
+ <text x="193.3" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">Go 1.25+</text>
 </svg>

--- a/docs/assets/badges/hybrid.svg
+++ b/docs/assets/badges/hybrid.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="290" height="56" viewBox="0 0 290 56">
+<svg xmlns="http://www.w3.org/2000/svg" width="354" height="64" viewBox="0 0 354 64">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
-  </linearGradient>
-  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
-   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
+  </radialGradient>
+  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
+   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
   </filter>
  </defs>
- <g filter="url(#sh)"><rect x="6" y="6" width="278.2" height="44" rx="11" fill="url(#bg)"/></g>
- <rect x="6" y="6" width="278.2" height="44" rx="11" fill="url(#gloss)"/>
- <rect x="6.5" y="6.5" width="277.2" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
- <line x1="128.4" y1="18" x2="128.4" y2="38" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>
- <text x="67.2" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">OFFICIAL API</text>
- <text x="206.3" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">Optional hybrid</text>
+ <g filter="url(#sh)"><rect x="7" y="7" width="340.5" height="50" rx="8" fill="url(#bg)"/></g>
+ <rect x="7" y="7" width="340.5" height="50" rx="8" fill="url(#gloss)"/>
+ <rect x="7.5" y="7.5" width="339.5" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
+ <line x1="147.0" y1="22" x2="147.0" y2="42" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>
+ <text x="77.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">OFFICIAL API</text>
+ <text x="247.2" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">Optional hybrid</text>
 </svg>

--- a/docs/assets/badges/license.svg
+++ b/docs/assets/badges/license.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="170" height="56" viewBox="0 0 170 56">
+<svg xmlns="http://www.w3.org/2000/svg" width="202" height="64" viewBox="0 0 202 64">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
-  </linearGradient>
-  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
-   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
+  </radialGradient>
+  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
+   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
   </filter>
  </defs>
- <g filter="url(#sh)"><rect x="6" y="6" width="158.0" height="44" rx="11" fill="url(#bg)"/></g>
- <rect x="6" y="6" width="158.0" height="44" rx="11" fill="url(#gloss)"/>
- <rect x="6.5" y="6.5" width="157.0" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
- <line x1="92.4" y1="18" x2="92.4" y2="38" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>
- <text x="49.2" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">LICENSE</text>
- <text x="128.2" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">MIT</text>
+ <g filter="url(#sh)"><rect x="7" y="7" width="188.6" height="50" rx="8" fill="url(#bg)"/></g>
+ <rect x="7" y="7" width="188.6" height="50" rx="8" fill="url(#gloss)"/>
+ <rect x="7.5" y="7.5" width="187.6" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
+ <line x1="107.0" y1="22" x2="107.0" y2="42" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>
+ <text x="57.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">LICENSE</text>
+ <text x="151.3" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">MIT</text>
 </svg>

--- a/docs/assets/badges/output.svg
+++ b/docs/assets/badges/output.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="250" height="56" viewBox="0 0 250 56">
+<svg xmlns="http://www.w3.org/2000/svg" width="310" height="64" viewBox="0 0 310 64">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
-  </linearGradient>
-  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
-   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
+  </radialGradient>
+  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
+   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
   </filter>
  </defs>
- <g filter="url(#sh)"><rect x="6" y="6" width="238.0" height="44" rx="11" fill="url(#bg)"/></g>
- <rect x="6" y="6" width="238.0" height="44" rx="11" fill="url(#gloss)"/>
- <rect x="6.5" y="6.5" width="237.0" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
- <line x1="85.2" y1="18" x2="85.2" y2="38" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>
- <text x="45.6" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">OUTPUT</text>
- <text x="164.6" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">JSON · CSV · SSE</text>
+ <g filter="url(#sh)"><rect x="7" y="7" width="296.0" height="50" rx="8" fill="url(#bg)"/></g>
+ <rect x="7" y="7" width="296.0" height="50" rx="8" fill="url(#gloss)"/>
+ <rect x="7.5" y="7.5" width="295.0" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
+ <line x1="99.0" y1="22" x2="99.0" y2="42" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>
+ <text x="53.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">OUTPUT</text>
+ <text x="201.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">JSON · CSV · SSE</text>
 </svg>

--- a/docs/assets/badges/spec-checked.svg
+++ b/docs/assets/badges/spec-checked.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="254" height="56" viewBox="0 0 254 56">
+<svg xmlns="http://www.w3.org/2000/svg" width="307" height="64" viewBox="0 0 307 64">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
-  </linearGradient>
-  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
-   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
+  </radialGradient>
+  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
+   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
   </filter>
  </defs>
- <g filter="url(#sh)"><rect x="6" y="6" width="242.4" height="44" rx="11" fill="url(#bg)"/></g>
- <rect x="6" y="6" width="242.4" height="44" rx="11" fill="url(#gloss)"/>
- <rect x="6.5" y="6.5" width="241.4" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
- <line x1="128.4" y1="18" x2="128.4" y2="38" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>
- <text x="67.2" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">SPEC CHECKED</text>
- <text x="188.4" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">2026-06-27</text>
+ <g filter="url(#sh)"><rect x="7" y="7" width="293.0" height="50" rx="8" fill="url(#bg)"/></g>
+ <rect x="7" y="7" width="293.0" height="50" rx="8" fill="url(#gloss)"/>
+ <rect x="7.5" y="7.5" width="292.0" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
+ <line x1="147.0" y1="22" x2="147.0" y2="42" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>
+ <text x="77.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">SPEC CHECKED</text>
+ <text x="223.5" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">2026-06-27</text>
 </svg>

--- a/docs/assets/badges/sponsor.svg
+++ b/docs/assets/badges/sponsor.svg
@@ -1,17 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="187" height="56" viewBox="0 0 187 56">
+<svg xmlns="http://www.w3.org/2000/svg" width="245" height="64" viewBox="0 0 245 64">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
-  </linearGradient>
-  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
-   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
+  </radialGradient>
+  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
+   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
   </filter>
  </defs>
- <g filter="url(#sh)"><rect x="6" y="6" width="175.6" height="44" rx="11" fill="url(#bg)"/></g>
- <rect x="6" y="6" width="175.6" height="44" rx="11" fill="url(#gloss)"/>
- <rect x="6.5" y="6.5" width="174.6" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
- <text x="93.8" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="14" font-weight="600" fill="#fafafa"><tspan fill="#db61a2">♥</tspan>  Become a sponsor</text>
+ <g filter="url(#sh)"><rect x="7" y="7" width="231.5" height="50" rx="8" fill="url(#bg)"/></g>
+ <rect x="7" y="7" width="231.5" height="50" rx="8" fill="url(#gloss)"/>
+ <rect x="7.5" y="7.5" width="230.5" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
+ <text x="122.8" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="18" font-weight="600" fill="#fafafa"><tspan fill="#ec6cb9">♥</tspan>  Become a sponsor</text>
 </svg>

--- a/docs/assets/badges/verified-api.svg
+++ b/docs/assets/badges/verified-api.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="302" height="56" viewBox="0 0 302 56">
+<svg xmlns="http://www.w3.org/2000/svg" width="366" height="64" viewBox="0 0 366 64">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
-  </linearGradient>
-  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
-   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
+  </radialGradient>
+  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
+   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
   </filter>
  </defs>
- <g filter="url(#sh)"><rect x="6" y="6" width="290.6" height="44" rx="11" fill="url(#bg)"/></g>
- <rect x="6" y="6" width="290.6" height="44" rx="11" fill="url(#gloss)"/>
- <rect x="6.5" y="6.5" width="289.6" height="43" rx="11" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>
- <line x1="150.0" y1="18" x2="150.0" y2="38" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>
- <text x="78.0" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">VS OFFICIAL API</text>
- <text x="223.3" y="28.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">v1.1.5 verified</text>
+ <g filter="url(#sh)"><rect x="7" y="7" width="352.2" height="50" rx="8" fill="url(#bg)"/></g>
+ <rect x="7" y="7" width="352.2" height="50" rx="8" fill="url(#gloss)"/>
+ <rect x="7.5" y="7.5" width="351.2" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
+ <line x1="171.0" y1="22" x2="171.0" y2="42" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>
+ <text x="89.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">VS OFFICIAL API</text>
+ <text x="265.1" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">v1.1.5 verified</text>
 </svg>

--- a/tools/make_badges.py
+++ b/tools/make_badges.py
@@ -21,27 +21,27 @@ ROOT = Path(__file__).resolve().parent.parent
 OUT = ROOT / "docs" / "assets" / "badges"
 SNAP = ROOT / "docs" / "migration" / ".openapi-snapshot.json"
 
-PH, SP, RX = 44, 6, 11  # pill height, shadow padding, corner radius
+PH, SP, RX = 50, 7, 8  # pill height, shadow padding, corner radius (rx≈0.16·PH)
 
 
 def _lw(s: str) -> float:
-    return len(s) * 7.2  # monospace label (incl. letter-spacing)
+    return len(s) * 8.0  # uppercase label, font 12 + letter-spacing 2
 
 
 def _vw(s: str) -> float:
-    return sum(9.2 if c.isupper() else (3.8 if c in " ·." else 7.6) for c in s)
+    return sum(12.2 if c.isupper() else (5.0 if c in " ·." else 10.1) for c in s)
 
 
 _DEFS = '''
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#2a2c37"/><stop offset="0.5" stop-color="#16171d"/><stop offset="1" stop-color="#0c0d11"/>
+   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0"/>
-  </linearGradient>
-  <filter id="sh" x="-15%" y="-15%" width="130%" height="150%">
-   <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.45"/>
+  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
+  </radialGradient>
+  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
+   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
   </filter>
  </defs>'''
 
@@ -52,13 +52,13 @@ def _shell(pw: float, extra: str) -> str:
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{VW}" height="{VH}" viewBox="0 0 {VW} {VH}">{_DEFS}\n'
         f' <g filter="url(#sh)"><rect x="{SP}" y="{SP}" width="{pw:.1f}" height="{PH}" rx="{RX}" fill="url(#bg)"/></g>\n'
         f' <rect x="{SP}" y="{SP}" width="{pw:.1f}" height="{PH}" rx="{RX}" fill="url(#gloss)"/>\n'
-        f' <rect x="{SP + 0.5}" y="{SP + 0.5}" width="{pw - 1:.1f}" height="{PH - 1}" rx="{RX}" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1"/>\n'
+        f' <rect x="{SP + 0.5}" y="{SP + 0.5}" width="{pw - 1:.1f}" height="{PH - 1}" rx="{RX - 0.5:.1f}" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>\n'
         f'{extra}\n</svg>\n'
     )
 
 
 def badge(fn: str, label: str, value: str) -> None:
-    lpad, vpad, minlabel = 18, 22, 78
+    lpad, vpad, minlabel = 22, 26, 92
     lreg = max(_lw(label) + 2 * lpad, minlabel)
     vreg = _vw(value) + 2 * vpad
     pw = lreg + vreg
@@ -66,9 +66,9 @@ def badge(fn: str, label: str, value: str) -> None:
     divx = SP + lreg
     lcx, vcx = SP + lreg / 2, divx + vreg / 2
     extra = (
-        f' <line x1="{divx:.1f}" y1="{SP + 12}" x2="{divx:.1f}" y2="{SP + PH - 12}" stroke="#ffffff" stroke-opacity="0.22" stroke-width="1.2"/>\n'
-        f' <text x="{lcx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" letter-spacing="1.5" fill="#9ea0aa">{label.upper()}</text>\n'
-        f' <text x="{vcx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="15" font-weight="600" fill="#fafafa">{value}</text>'
+        f' <line x1="{divx:.1f}" y1="{SP + 15}" x2="{divx:.1f}" y2="{SP + PH - 15}" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>\n'
+        f' <text x="{lcx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">{label.upper()}</text>\n'
+        f' <text x="{vcx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">{value}</text>'
     )
     (OUT / fn).write_text(_shell(pw, extra))
     print(f"  {fn}  {label} | {value}")
@@ -76,12 +76,12 @@ def badge(fn: str, label: str, value: str) -> None:
 
 def cta(fn: str, text: str) -> None:
     """Single-region call-to-action pill with a pink heart (sponsor)."""
-    pad = 22
-    pw = 16 + _vw(text) + 2 * pad  # 16 = heart glyph room
+    pad = 28
+    pw = 22 + _vw(text) + 2 * pad  # 22 = heart glyph room
     cy, cx = SP + PH / 2, SP + pw / 2
     extra = (
-        f' <text x="{cx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="14" font-weight="600" fill="#fafafa">'
-        f'<tspan fill="#db61a2">♥</tspan>  {text}</text>'
+        f' <text x="{cx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="18" font-weight="600" fill="#fafafa">'
+        f'<tspan fill="#ec6cb9">♥</tspan>  {text}</text>'
     )
     (OUT / fn).write_text(_shell(pw, extra))
     print(f"  {fn}  ♥ {text}")


### PR DESCRIPTION
배지 디자인을 taste-skill 버튼 비율에 맞게 보정하고, 스폰서/연락처를 전용 섹션으로 분리했습니다.

## 변경
- **배지 디자인 보정**: 코너 radius 축소(높이의 0.16 — 덜 둥글게), 값 텍스트 확대, 푸른기 제거한 중립 블랙 + 상단 sheen, 여백 확대 → 펄 비율을 taste 버튼에 맞춤
- **스폰서 위치 이동**: 상단 배지 클러스터에 끼어 있던 `Become a sponsor` 펄을 하단 전용 `후원 / Sponsors` 섹션으로 이동 (heading + CTA + 안내 문구), nav 에 링크 추가
- **Contributing 보강**: 이슈/PR · LinkedIn(@junghoonghae) · 이메일(lucas.ghae@remodule.dev)

라이트/다크 양쪽 렌더 확인.
