### PR TITLE
docs(readme): 배지 비율 재보정 + 후원 섹션 상단

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -44,6 +44,18 @@
 > [!IMPORTANT]
 > Trading is fully disabled out of the box. Each action must be explicitly enabled in `config.json` before it can run.
 
+## Sponsors
+
+<p align="center">
+  <a href="https://github.com/sponsors/JungHoonGhae"><img src="docs/assets/badges/sponsor.svg" height="46" alt="Become a sponsor" /></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/sponsors/JungHoonGhae"><img src="docs/assets/sponsors/anonymous.svg" width="52" height="52" alt="Anonymous sponsor" title="Anonymous sponsor" /></a>
+</p>
+
+<p align="center"><sub><strong>1</strong> person sponsors tossinvest-cli (one-time included). Sponsor the project and you'll be featured right here.</sub></p>
+
 ## Quick Start
 
 ### For Agents
@@ -492,18 +504,6 @@ We would love your feedback. Suggestions and bug reports:
 - Open an [Issue](https://github.com/JungHoonGhae/tossinvest-cli/issues) or PR on GitHub
 - Connect on LinkedIn [@junghoonghae](https://www.linkedin.com/in/junghoonghae)
 - Email [lucas.ghae@remodule.dev](mailto:lucas.ghae@remodule.dev)
-
-## Sponsors
-
-If tossinvest-cli helps you, consider sponsoring its continued development.
-
-<p align="center">
-  <a href="https://github.com/sponsors/JungHoonGhae"><img src="docs/assets/badges/sponsor.svg" height="46" alt="Become a sponsor" /></a>
-</p>
-
-<p align="center"><sub>Be the first sponsor and your logo lands right here.</sub></p>
-
-<!-- sponsors --><!-- sponsors -->
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@
   </a>
 </p>
 
+## 후원
+
+<p align="center">
+  <a href="https://github.com/sponsors/JungHoonGhae"><img src="docs/assets/badges/sponsor.svg" height="46" alt="Become a sponsor" /></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/sponsors/JungHoonGhae"><img src="docs/assets/sponsors/anonymous.svg" width="52" height="52" alt="익명 후원자" title="익명 후원자" /></a>
+</p>
+
+<p align="center"><sub>현재 <strong>1</strong>분이 tossinvest-cli 를 후원하고 있습니다 (일회성 포함). 후원해 주시면 이 자리에 모셔두겠습니다.</sub></p>
+
 ## 하이브리드 공식 Open API <!--since:2026-06-27-->
 
 tossctl은 웹 세션(WTS)만으로도 전부 동작합니다. 토스 공식 Open API 키를 선택적으로
@@ -580,18 +592,6 @@ US/KR 지정가 매수/매도, US 소수점 매수, 당일 미체결 취소가 l
 - GitHub에서 [이슈](https://github.com/JungHoonGhae/tossinvest-cli/issues)나 PR 열기
 - LinkedIn [@junghoonghae](https://www.linkedin.com/in/junghoonghae)
 - 이메일 [lucas.ghae@remodule.dev](mailto:lucas.ghae@remodule.dev)
-
-## 후원
-
-tossinvest-cli 가 도움이 되었다면 후원으로 지속적인 개발을 응원해 주세요.
-
-<p align="center">
-  <a href="https://github.com/sponsors/JungHoonGhae"><img src="docs/assets/badges/sponsor.svg" height="46" alt="Become a sponsor" /></a>
-</p>
-
-<p align="center"><sub>첫 후원자가 되어주시면 이 자리에 로고를 모셔두겠습니다.</sub></p>
-
-<!-- sponsors --><!-- sponsors -->
 
 ## License
 

--- a/docs/assets/badges/agents.svg
+++ b/docs/assets/badges/agents.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="398" height="64" viewBox="0 0 398 64">
+<svg xmlns="http://www.w3.org/2000/svg" width="863" height="126" viewBox="0 0 863 126">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
+   <stop offset="0" stop-color="#1c1d1f"/><stop offset="0.5" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
-  </radialGradient>
-  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
-   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
-  </filter>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.07"/><stop offset="0.45" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="rim" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.22"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="1" stop-color="#ffffff" stop-opacity="0.05"/>
+  </linearGradient>
  </defs>
- <g filter="url(#sh)"><rect x="7" y="7" width="384.0" height="50" rx="8" fill="url(#bg)"/></g>
- <rect x="7" y="7" width="384.0" height="50" rx="8" fill="url(#gloss)"/>
- <rect x="7.5" y="7.5" width="383.0" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
- <line x1="131.0" y1="22" x2="131.0" y2="42" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>
- <text x="69.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">WORKS WITH</text>
- <text x="261.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">Claude · Codex · Cursor</text>
+ <rect x="3" y="3" width="857.5" height="120" rx="16" fill="url(#bg)"/>
+ <rect x="3" y="3" width="857.5" height="120" rx="16" fill="url(#gloss)"/>
+ <rect x="3.75" y="3.75" width="856.0" height="118.5" rx="15.2" fill="none" stroke="url(#rim)" stroke-width="1.5"/>
+ <line x1="327.0" y1="41.4" x2="327.0" y2="84.6" stroke="#ffffff" stroke-opacity="0.15" stroke-width="2"/>
+ <text x="165.0" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="25" font-weight="500" letter-spacing="4" fill="#8b8d94">WORKS WITH</text>
+ <text x="593.8" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="37" font-weight="600" fill="#fafafa">Claude · Codex · Cursor</text>
 </svg>

--- a/docs/assets/badges/go.svg
+++ b/docs/assets/badges/go.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="262" height="64" viewBox="0 0 262 64">
+<svg xmlns="http://www.w3.org/2000/svg" width="616" height="126" viewBox="0 0 616 126">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
+   <stop offset="0" stop-color="#1c1d1f"/><stop offset="0.5" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
-  </radialGradient>
-  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
-   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
-  </filter>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.07"/><stop offset="0.45" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="rim" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.22"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="1" stop-color="#ffffff" stop-opacity="0.05"/>
+  </linearGradient>
  </defs>
- <g filter="url(#sh)"><rect x="7" y="7" width="248.7" height="50" rx="8" fill="url(#bg)"/></g>
- <rect x="7" y="7" width="248.7" height="50" rx="8" fill="url(#gloss)"/>
- <rect x="7.5" y="7.5" width="247.7" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
- <line x1="131.0" y1="22" x2="131.0" y2="42" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>
- <text x="69.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">BUILT WITH</text>
- <text x="193.3" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">Go 1.25+</text>
+ <rect x="3" y="3" width="610.0" height="120" rx="16" fill="url(#bg)"/>
+ <rect x="3" y="3" width="610.0" height="120" rx="16" fill="url(#gloss)"/>
+ <rect x="3.75" y="3.75" width="608.5" height="118.5" rx="15.2" fill="none" stroke="url(#rim)" stroke-width="1.5"/>
+ <line x1="327.0" y1="41.4" x2="327.0" y2="84.6" stroke="#ffffff" stroke-opacity="0.15" stroke-width="2"/>
+ <text x="165.0" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="25" font-weight="500" letter-spacing="4" fill="#8b8d94">BUILT WITH</text>
+ <text x="470.0" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="37" font-weight="600" fill="#fafafa">Go 1.25+</text>
 </svg>

--- a/docs/assets/badges/hybrid.svg
+++ b/docs/assets/badges/hybrid.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="354" height="64" viewBox="0 0 354 64">
+<svg xmlns="http://www.w3.org/2000/svg" width="782" height="126" viewBox="0 0 782 126">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
+   <stop offset="0" stop-color="#1c1d1f"/><stop offset="0.5" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
-  </radialGradient>
-  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
-   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
-  </filter>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.07"/><stop offset="0.45" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="rim" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.22"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="1" stop-color="#ffffff" stop-opacity="0.05"/>
+  </linearGradient>
  </defs>
- <g filter="url(#sh)"><rect x="7" y="7" width="340.5" height="50" rx="8" fill="url(#bg)"/></g>
- <rect x="7" y="7" width="340.5" height="50" rx="8" fill="url(#gloss)"/>
- <rect x="7.5" y="7.5" width="339.5" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
- <line x1="147.0" y1="22" x2="147.0" y2="42" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>
- <text x="77.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">OFFICIAL API</text>
- <text x="247.2" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">Optional hybrid</text>
+ <rect x="3" y="3" width="776.0" height="120" rx="16" fill="url(#bg)"/>
+ <rect x="3" y="3" width="776.0" height="120" rx="16" fill="url(#gloss)"/>
+ <rect x="3.75" y="3.75" width="774.5" height="118.5" rx="15.2" fill="none" stroke="url(#rim)" stroke-width="1.5"/>
+ <line x1="363.0" y1="41.4" x2="363.0" y2="84.6" stroke="#ffffff" stroke-opacity="0.15" stroke-width="2"/>
+ <text x="183.0" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="25" font-weight="500" letter-spacing="4" fill="#8b8d94">OFFICIAL API</text>
+ <text x="571.0" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="37" font-weight="600" fill="#fafafa">Optional hybrid</text>
 </svg>

--- a/docs/assets/badges/license.svg
+++ b/docs/assets/badges/license.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="202" height="64" viewBox="0 0 202 64">
+<svg xmlns="http://www.w3.org/2000/svg" width="484" height="126" viewBox="0 0 484 126">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
+   <stop offset="0" stop-color="#1c1d1f"/><stop offset="0.5" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
-  </radialGradient>
-  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
-   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
-  </filter>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.07"/><stop offset="0.45" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="rim" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.22"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="1" stop-color="#ffffff" stop-opacity="0.05"/>
+  </linearGradient>
  </defs>
- <g filter="url(#sh)"><rect x="7" y="7" width="188.6" height="50" rx="8" fill="url(#bg)"/></g>
- <rect x="7" y="7" width="188.6" height="50" rx="8" fill="url(#gloss)"/>
- <rect x="7.5" y="7.5" width="187.6" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
- <line x1="107.0" y1="22" x2="107.0" y2="42" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>
- <text x="57.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">LICENSE</text>
- <text x="151.3" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">MIT</text>
+ <rect x="3" y="3" width="478.5" height="120" rx="16" fill="url(#bg)"/>
+ <rect x="3" y="3" width="478.5" height="120" rx="16" fill="url(#gloss)"/>
+ <rect x="3.75" y="3.75" width="477.0" height="118.5" rx="15.2" fill="none" stroke="url(#rim)" stroke-width="1.5"/>
+ <line x1="273.0" y1="41.4" x2="273.0" y2="84.6" stroke="#ffffff" stroke-opacity="0.15" stroke-width="2"/>
+ <text x="138.0" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="25" font-weight="500" letter-spacing="4" fill="#8b8d94">LICENSE</text>
+ <text x="377.2" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="37" font-weight="600" fill="#fafafa">MIT</text>
 </svg>

--- a/docs/assets/badges/output.svg
+++ b/docs/assets/badges/output.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="310" height="64" viewBox="0 0 310 64">
+<svg xmlns="http://www.w3.org/2000/svg" width="683" height="126" viewBox="0 0 683 126">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
+   <stop offset="0" stop-color="#1c1d1f"/><stop offset="0.5" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
-  </radialGradient>
-  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
-   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
-  </filter>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.07"/><stop offset="0.45" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="rim" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.22"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="1" stop-color="#ffffff" stop-opacity="0.05"/>
+  </linearGradient>
  </defs>
- <g filter="url(#sh)"><rect x="7" y="7" width="296.0" height="50" rx="8" fill="url(#bg)"/></g>
- <rect x="7" y="7" width="296.0" height="50" rx="8" fill="url(#gloss)"/>
- <rect x="7.5" y="7.5" width="295.0" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
- <line x1="99.0" y1="22" x2="99.0" y2="42" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>
- <text x="53.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">OUTPUT</text>
- <text x="201.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">JSON · CSV · SSE</text>
+ <rect x="3" y="3" width="677.0" height="120" rx="16" fill="url(#bg)"/>
+ <rect x="3" y="3" width="677.0" height="120" rx="16" fill="url(#gloss)"/>
+ <rect x="3.75" y="3.75" width="675.5" height="118.5" rx="15.2" fill="none" stroke="url(#rim)" stroke-width="1.5"/>
+ <line x1="255.0" y1="41.4" x2="255.0" y2="84.6" stroke="#ffffff" stroke-opacity="0.15" stroke-width="2"/>
+ <text x="129.0" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="25" font-weight="500" letter-spacing="4" fill="#8b8d94">OUTPUT</text>
+ <text x="467.5" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="37" font-weight="600" fill="#fafafa">JSON · CSV · SSE</text>
 </svg>

--- a/docs/assets/badges/spec-checked.svg
+++ b/docs/assets/badges/spec-checked.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="307" height="64" viewBox="0 0 307 64">
+<svg xmlns="http://www.w3.org/2000/svg" width="719" height="126" viewBox="0 0 719 126">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
+   <stop offset="0" stop-color="#1c1d1f"/><stop offset="0.5" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
-  </radialGradient>
-  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
-   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
-  </filter>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.07"/><stop offset="0.45" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="rim" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.22"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="1" stop-color="#ffffff" stop-opacity="0.05"/>
+  </linearGradient>
  </defs>
- <g filter="url(#sh)"><rect x="7" y="7" width="293.0" height="50" rx="8" fill="url(#bg)"/></g>
- <rect x="7" y="7" width="293.0" height="50" rx="8" fill="url(#gloss)"/>
- <rect x="7.5" y="7.5" width="292.0" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
- <line x1="147.0" y1="22" x2="147.0" y2="42" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>
- <text x="77.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">SPEC CHECKED</text>
- <text x="223.5" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">2026-06-27</text>
+ <rect x="3" y="3" width="713.0" height="120" rx="16" fill="url(#bg)"/>
+ <rect x="3" y="3" width="713.0" height="120" rx="16" fill="url(#gloss)"/>
+ <rect x="3.75" y="3.75" width="711.5" height="118.5" rx="15.2" fill="none" stroke="url(#rim)" stroke-width="1.5"/>
+ <line x1="363.0" y1="41.4" x2="363.0" y2="84.6" stroke="#ffffff" stroke-opacity="0.15" stroke-width="2"/>
+ <text x="183.0" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="25" font-weight="500" letter-spacing="4" fill="#8b8d94">SPEC CHECKED</text>
+ <text x="539.5" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="37" font-weight="600" fill="#fafafa">2026-06-27</text>
 </svg>

--- a/docs/assets/badges/sponsor.svg
+++ b/docs/assets/badges/sponsor.svg
@@ -1,17 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="245" height="64" viewBox="0 0 245 64">
+<svg xmlns="http://www.w3.org/2000/svg" width="478" height="126" viewBox="0 0 478 126">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
+   <stop offset="0" stop-color="#1c1d1f"/><stop offset="0.5" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
-  </radialGradient>
-  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
-   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
-  </filter>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.07"/><stop offset="0.45" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="rim" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.22"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="1" stop-color="#ffffff" stop-opacity="0.05"/>
+  </linearGradient>
  </defs>
- <g filter="url(#sh)"><rect x="7" y="7" width="231.5" height="50" rx="8" fill="url(#bg)"/></g>
- <rect x="7" y="7" width="231.5" height="50" rx="8" fill="url(#gloss)"/>
- <rect x="7.5" y="7.5" width="230.5" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
- <text x="122.8" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="18" font-weight="600" fill="#fafafa"><tspan fill="#ec6cb9">♥</tspan>  Become a sponsor</text>
+ <rect x="3" y="3" width="472.0" height="120" rx="16" fill="url(#bg)"/>
+ <rect x="3" y="3" width="472.0" height="120" rx="16" fill="url(#gloss)"/>
+ <rect x="3.75" y="3.75" width="470.5" height="118.5" rx="15.2" fill="none" stroke="url(#rim)" stroke-width="1.5"/>
+ <text x="239.0" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="33" font-weight="600" fill="#fafafa"><tspan fill="#ec6cb9" font-size="37">♥</tspan>  Become a sponsor</text>
 </svg>

--- a/docs/assets/badges/verified-api.svg
+++ b/docs/assets/badges/verified-api.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="366" height="64" viewBox="0 0 366 64">
+<svg xmlns="http://www.w3.org/2000/svg" width="823" height="126" viewBox="0 0 823 126">
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
+   <stop offset="0" stop-color="#1c1d1f"/><stop offset="0.5" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
-  </radialGradient>
-  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
-   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
-  </filter>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.07"/><stop offset="0.45" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="rim" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.22"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="1" stop-color="#ffffff" stop-opacity="0.05"/>
+  </linearGradient>
  </defs>
- <g filter="url(#sh)"><rect x="7" y="7" width="352.2" height="50" rx="8" fill="url(#bg)"/></g>
- <rect x="7" y="7" width="352.2" height="50" rx="8" fill="url(#gloss)"/>
- <rect x="7.5" y="7.5" width="351.2" height="49" rx="7.5" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
- <line x1="171.0" y1="22" x2="171.0" y2="42" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>
- <text x="89.0" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">VS OFFICIAL API</text>
- <text x="265.1" y="32.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">v1.1.5 verified</text>
+ <rect x="3" y="3" width="817.0" height="120" rx="16" fill="url(#bg)"/>
+ <rect x="3" y="3" width="817.0" height="120" rx="16" fill="url(#gloss)"/>
+ <rect x="3.75" y="3.75" width="815.5" height="118.5" rx="15.2" fill="none" stroke="url(#rim)" stroke-width="1.5"/>
+ <line x1="417.0" y1="41.4" x2="417.0" y2="84.6" stroke="#ffffff" stroke-opacity="0.15" stroke-width="2"/>
+ <text x="210.0" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="25" font-weight="500" letter-spacing="4" fill="#8b8d94">VS OFFICIAL API</text>
+ <text x="618.5" y="63.0" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-size="37" font-weight="600" fill="#fafafa">v1.1.5 verified</text>
 </svg>

--- a/docs/assets/sponsors/anonymous.svg
+++ b/docs/assets/sponsors/anonymous.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="52" height="52" viewBox="0 0 52 52">
+ <defs>
+  <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#3a3c47"/><stop offset="1" stop-color="#22242c"/>
+  </linearGradient>
+  <clipPath id="c"><circle cx="26" cy="26" r="25"/></clipPath>
+ </defs>
+ <circle cx="26" cy="26" r="25" fill="url(#g)"/>
+ <g clip-path="url(#c)" fill="#9094a0">
+  <circle cx="26" cy="21" r="8.5"/>
+  <ellipse cx="26" cy="47" rx="15" ry="13"/>
+ </g>
+ <circle cx="26" cy="26" r="25" fill="none" stroke="#ffffff" stroke-opacity="0.14"/>
+</svg>

--- a/tools/make_badges.py
+++ b/tools/make_badges.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 """Generate the README custom badge SVGs (premium dark-glass pill style).
 
-Single source of truth for the bespoke README badges. Style mirrors a high-end
-button set: a near-black pill with a soft top-gloss gradient, rim highlight and
-drop shadow, a centered uppercase gray label and a centered white value split
-by a faint divider. Static badges carry fixed values; the two "verified vs
-official API" / "spec checked" badges read their values from
-docs/migration/.openapi-snapshot.json so they stay fresh — the daily monitor
-re-runs this and commits the result. Also emits a "Become a sponsor" CTA.
+Single source of truth for the bespoke README badges. The geometry is
+reverse-engineered from a high-end button set (taste-skill's webp buttons):
+flat, wide pills (aspect ~4:1) that fill the frame with only a hair of margin,
+a near-black neutral vertical gradient, a faint top sheen and a light rim — no
+external drop shadow (that is what kept ours looking chunky and small). A
+small uppercase gray label and a larger white value are split by a faint
+divider. All sizes are expressed as ratios of the pill height PH so the look
+is resolution-independent.
+
+Static badges carry fixed values; the "vs Official API" / "spec checked"
+badges read their values from docs/migration/.openapi-snapshot.json so they
+stay fresh — the daily monitor re-runs this and commits the result. Also
+emits a "Become a sponsor" CTA.
 
 Usage: python3 tools/make_badges.py   (no args)
 Output: docs/assets/badges/*.svg
@@ -21,28 +27,51 @@ ROOT = Path(__file__).resolve().parent.parent
 OUT = ROOT / "docs" / "assets" / "badges"
 SNAP = ROOT / "docs" / "migration" / ".openapi-snapshot.json"
 
-PH, SP, RX = 50, 7, 8  # pill height, shadow padding, corner radius (rx≈0.16·PH)
+# Pill geometry, in a 120-unit-tall coordinate space (ratios mirror taste:
+# margin ~0.025·PH, radius ~0.13·PH, value cap ~0.22·PH, label cap ~0.15·PH,
+# side padding ~0.60·PH). No drop shadow — the pill fills the frame.
+PH = 120
+SP = 3                       # transparent margin (AA room for the rim)
+RX = 16                      # corner radius (~0.13·PH)
+VALUE_FS = 37                # value font-size (~0.31·PH → cap ~0.22·PH)
+LABEL_FS = 25                # label font-size (~0.21·PH → cap ~0.15·PH)
+LABEL_LS = 4                 # label letter-spacing
+PAD = 72                     # side padding per region (~0.60·PH)
+MIN_LABEL = 190              # minimum label-region width
+SANS = "ui-sans-serif,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif"
 
 
 def _lw(s: str) -> float:
-    return len(s) * 8.0  # uppercase label, font 12 + letter-spacing 2
+    return len(s) * 18.0  # uppercase label advance incl. letter-spacing
 
 
 def _vw(s: str) -> float:
-    return sum(12.2 if c.isupper() else (5.0 if c in " ·." else 10.1) for c in s)
+    w = 0.0
+    for c in s:
+        if c == " ":
+            w += 10.0
+        elif c == "·":
+            w += 13.0
+        elif c == ".":
+            w += 9.0
+        elif c.isupper() or c.isdigit():
+            w += 21.5
+        else:
+            w += 18.5
+    return w
 
 
 _DEFS = '''
  <defs>
   <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-   <stop offset="0" stop-color="#1a1b1d"/><stop offset="0.55" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
+   <stop offset="0" stop-color="#1c1d1f"/><stop offset="0.5" stop-color="#101113"/><stop offset="1" stop-color="#0a0a0b"/>
   </linearGradient>
-  <radialGradient id="gloss" cx="0.5" cy="0" r="0.85">
-   <stop offset="0" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="0.65" stop-color="#ffffff" stop-opacity="0"/>
-  </radialGradient>
-  <filter id="sh" x="-12%" y="-12%" width="124%" height="148%">
-   <feDropShadow dx="0" dy="2.5" stdDeviation="3.5" flood-color="#000000" flood-opacity="0.5"/>
-  </filter>
+  <linearGradient id="gloss" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.07"/><stop offset="0.45" stop-color="#ffffff" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="rim" x1="0" y1="0" x2="0" y2="1">
+   <stop offset="0" stop-color="#ffffff" stop-opacity="0.22"/><stop offset="0.5" stop-color="#ffffff" stop-opacity="0.10"/><stop offset="1" stop-color="#ffffff" stop-opacity="0.05"/>
+  </linearGradient>
  </defs>'''
 
 
@@ -50,25 +79,24 @@ def _shell(pw: float, extra: str) -> str:
     VW, VH = int(pw + 2 * SP), PH + 2 * SP
     return (
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{VW}" height="{VH}" viewBox="0 0 {VW} {VH}">{_DEFS}\n'
-        f' <g filter="url(#sh)"><rect x="{SP}" y="{SP}" width="{pw:.1f}" height="{PH}" rx="{RX}" fill="url(#bg)"/></g>\n'
+        f' <rect x="{SP}" y="{SP}" width="{pw:.1f}" height="{PH}" rx="{RX}" fill="url(#bg)"/>\n'
         f' <rect x="{SP}" y="{SP}" width="{pw:.1f}" height="{PH}" rx="{RX}" fill="url(#gloss)"/>\n'
-        f' <rect x="{SP + 0.5}" y="{SP + 0.5}" width="{pw - 1:.1f}" height="{PH - 1}" rx="{RX - 0.5:.1f}" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>\n'
+        f' <rect x="{SP + 0.75}" y="{SP + 0.75}" width="{pw - 1.5:.1f}" height="{PH - 1.5}" rx="{RX - 0.75:.1f}" fill="none" stroke="url(#rim)" stroke-width="1.5"/>\n'
         f'{extra}\n</svg>\n'
     )
 
 
 def badge(fn: str, label: str, value: str) -> None:
-    lpad, vpad, minlabel = 22, 26, 92
-    lreg = max(_lw(label) + 2 * lpad, minlabel)
-    vreg = _vw(value) + 2 * vpad
+    lreg = max(_lw(label) + 2 * PAD, MIN_LABEL)
+    vreg = _vw(value) + 2 * PAD
     pw = lreg + vreg
     cy = SP + PH / 2
     divx = SP + lreg
     lcx, vcx = SP + lreg / 2, divx + vreg / 2
     extra = (
-        f' <line x1="{divx:.1f}" y1="{SP + 15}" x2="{divx:.1f}" y2="{SP + PH - 15}" stroke="#ffffff" stroke-opacity="0.16" stroke-width="1.2"/>\n'
-        f' <text x="{lcx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="12" font-weight="500" letter-spacing="2" fill="#8b8d94">{label.upper()}</text>\n'
-        f' <text x="{vcx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="21" font-weight="600" fill="#fafafa">{value}</text>'
+        f' <line x1="{divx:.1f}" y1="{SP + 0.32 * PH:.1f}" x2="{divx:.1f}" y2="{SP + 0.68 * PH:.1f}" stroke="#ffffff" stroke-opacity="0.15" stroke-width="2"/>\n'
+        f' <text x="{lcx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="{SANS}" font-size="{LABEL_FS}" font-weight="500" letter-spacing="{LABEL_LS}" fill="#8b8d94">{label.upper()}</text>\n'
+        f' <text x="{vcx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="{SANS}" font-size="{VALUE_FS}" font-weight="600" fill="#fafafa">{value}</text>'
     )
     (OUT / fn).write_text(_shell(pw, extra))
     print(f"  {fn}  {label} | {value}")
@@ -76,12 +104,11 @@ def badge(fn: str, label: str, value: str) -> None:
 
 def cta(fn: str, text: str) -> None:
     """Single-region call-to-action pill with a pink heart (sponsor)."""
-    pad = 28
-    pw = 22 + _vw(text) + 2 * pad  # 22 = heart glyph room
+    pw = 46 + _vw(text) + 2 * PAD  # 46 = heart glyph room
     cy, cx = SP + PH / 2, SP + pw / 2
     extra = (
-        f' <text x="{cx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="ui-sans-serif,-apple-system,Segoe UI,Roboto,sans-serif" font-size="18" font-weight="600" fill="#fafafa">'
-        f'<tspan fill="#ec6cb9">♥</tspan>  {text}</text>'
+        f' <text x="{cx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="central" font-family="{SANS}" font-size="{VALUE_FS - 4}" font-weight="600" fill="#fafafa">'
+        f'<tspan fill="#ec6cb9" font-size="{VALUE_FS}">♥</tspan>  {text}</text>'
     )
     (OUT / fn).write_text(_shell(pw, extra))
     print(f"  {fn}  ♥ {text}")


### PR DESCRIPTION
배지 디자인을 taste-skill 버튼 실측값으로 재보정하고, 후원 섹션을 상단으로 올려 노출을 강화했습니다.

## 배지 재보정 (크기·형태)
- taste 버튼(webp)을 픽셀 측정 → 종횡비 ~4:1(납작·길쭉), 값폰트 0.31·H / 라벨 0.21·H, 좌우여백 0.60·H, radius 0.13·H
- **외부 드롭섀도우 제거**: 섀도우 여백이 펄을 작고 통통하게 만들던 원인 → 펄이 프레임을 꽉 채우도록
- taste 실물과 동일 높이 나란히 렌더로 매칭 검증

## 후원 섹션
- 하단 → **상단**(KR: 스타히스토리 직후 / EN: 경고 직후)으로 이동
- 익명 후원자 실루엣 아바타 + 후원자 수(일회성 포함) 표기
- 현 후원자는 비공개 일회성 후원이라 신원은 비노출(GitHub 공개 위젯과 동일하게 익명)
