### PR TITLE
docs(readme): 후원 문구 계정 기준 정정

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -54,7 +54,7 @@
   <a href="https://github.com/sponsors/JungHoonGhae"><img src="docs/assets/sponsors/anonymous.svg" width="52" height="52" alt="Anonymous sponsor" title="Anonymous sponsor" /></a>
 </p>
 
-<p align="center"><sub><strong>1</strong> person sponsors tossinvest-cli (one-time included). Sponsor the project and you'll be featured right here.</sub></p>
+<p align="center"><sub><strong>1</strong> person backs my open-source work (one-time included). Sponsorship funds my projects, tossinvest-cli included.</sub></p>
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@
   <a href="https://github.com/sponsors/JungHoonGhae"><img src="docs/assets/sponsors/anonymous.svg" width="52" height="52" alt="익명 후원자" title="익명 후원자" /></a>
 </p>
 
-<p align="center"><sub>현재 <strong>1</strong>분이 tossinvest-cli 를 후원하고 있습니다 (일회성 포함). 후원해 주시면 이 자리에 모셔두겠습니다.</sub></p>
+<p align="center"><sub>현재 <strong>1</strong>분이 제 오픈소스 작업을 후원하고 있습니다 (일회성 포함). 후원은 tossinvest-cli 를 포함한 제 작업 전반에 쓰입니다.</sub></p>
 
 ## 하이브리드 공식 Open API <!--since:2026-06-27-->
 


### PR DESCRIPTION
GitHub Sponsors는 계정 단위 후원 → 'tossinvest-cli를 후원'은 프로젝트 한정 펀딩으로 오해 소지. '제 오픈소스 작업 후원(tossinvest-cli 포함)'으로 정정.