### PR TITLE
docs: WTS 고유 기능 명시 + 랜딩 "(예정)" 제거

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,9 +6,9 @@
 
 <div align="center">
   <h1>tossinvest-cli</h1>
-  <p><strong>An unofficial Toss Securities CLI that connects AI agents to your brokerage — covers 100% of the official Open API's read &amp; trade scope and goes beyond (auto-routing when you connect an official key).</strong></p>
+  <p><strong>An unofficial Toss Securities CLI that connects AI agents to your brokerage — covers 100% of the official Open API's read &amp; trade scope, plus the Toss WTS features the official API doesn't expose (auto-routing when you connect an official key).</strong></p>
   <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot and any AI agent drive Toss Securities accounts, quotes, and trades through one command interface (<code>tossctl</code>). It works just as well by hand in a terminal.</p>
-  <p><sub>Investor flows · market indices · Toss AI signals · screener · watchlist management · transaction ledger · real-time push · fractional orders · dry-run preview — <strong>tossctl covers areas the official Open API does not.</strong> <a href="#support-scope">Full comparison ↓</a></sub></p>
+  <p><sub>Investor flows · market indices · Toss AI signals · screener · watchlist management · transaction ledger · real-time push · fractional orders · dry-run preview — <strong>Toss WTS features the official Open API doesn't expose.</strong> <a href="#support-scope">Full comparison ↓</a></sub></p>
 </div>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 <div align="center">
   <h1>tossinvest-cli</h1>
-  <p><strong>AI 에이전트를 토스증권에 연결하는 비공식 CLI — 공식 Open API 범위는 100% 포함하고, 공식엔 없는 기능까지 더했습니다(공식 키 연결 시 자동 라우팅).</strong></p>
+  <p><strong>AI 에이전트를 토스증권에 연결하는 비공식 CLI — 공식 Open API 범위는 100% 포함하고, 토스 WTS(웹)엔 있지만 공식 API엔 없는 기능까지 다룹니다(공식 키 연결 시 자동 라우팅).</strong></p>
   <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot 등 어떤 AI 에이전트든 동일한 명령 체계(<code>tossctl</code>)로 토스증권 계좌·시세·거래를 다룰 수 있습니다. 사람이 직접 터미널에서 쓸 수도 있습니다.</p>
-  <p><sub>수급 · 시장지수 · 토스 AI 시그널 · 조건검색(스크리너) · 관심종목 관리 · 거래내역 ledger · 실시간 푸시 · 원화 소수점 주문 · dry-run preview — <strong>공식 Open API에 없는 영역까지</strong> 커버합니다. <a href="#지원-범위">전체 비교표 ↓</a></sub></p>
+  <p><sub>수급 · 시장지수 · 토스 AI 시그널 · 조건검색(스크리너) · 관심종목 관리 · 거래내역 ledger · 실시간 푸시 · 원화 소수점 주문 · dry-run preview — <strong>공식 Open API엔 없는 토스 WTS 고유 영역까지</strong> 커버합니다. <a href="#지원-범위">전체 비교표 ↓</a></sub></p>
   <p><sub><em>An unofficial Toss Securities CLI for AI agents — a superset of the official Open API: 100% of its read &amp; trade coverage, plus more.</em></sub></p>
 </div>
 

--- a/website-fumadocs/app/[lang]/(home)/page.tsx
+++ b/website-fumadocs/app/[lang]/(home)/page.tsx
@@ -69,7 +69,7 @@ const content = {
       note: 'tossctl은 공식이 다루는 약 4%를 100% 포함하고, 공식에 없는 나머지 WTS 기능까지 넓혀갑니다.',
     },
     official: {
-      name: '공식 Open API (예정)',
+      name: '공식 Open API',
       note: 'REST 조회·주문 기본 · 사전 신청 단계 롤아웃',
       items: ['계좌·잔고', '시세·호가·체결', '주문·취소·정정'],
     },
@@ -144,7 +144,7 @@ const content = {
       note: 'tossctl covers 100% of the official ~4% and keeps expanding into the rest of WTS.',
     },
     official: {
-      name: 'Official Open API (planned)',
+      name: 'Official Open API',
       note: 'REST read/order basics · staged rollout',
       items: ['Accounts · balances', 'Quotes · orderbook · ticks', 'Place · cancel · amend'],
     },


### PR DESCRIPTION
- hero/sub: "공식엔 없는 기능" → "토스 WTS엔 있지만 공식 API엔 없는 기능"(WTS 고유 기능임을 명시, 무에서 만든 듯한 뉘앙스 제거)
- 랜딩 비교 라벨에서 "(예정)/(planned)" 제거 (공식 API 가 사전신청 롤아웃 중 — note 에 설명 유지)