### PR TITLE
chore(wts): tics·토스프라임·대주수익 다음후보 지정

### DIFF
--- a/docs/reverse-engineering/wts-endpoints.json
+++ b/docs/reverse-engineering/wts-endpoints.json
@@ -5,10 +5,10 @@
   "total": 934,
   "counts": {
     "implemented": 69,
-    "candidate": 366,
-    "excluded": 499,
-    "candidate_next": 11,
-    "meaningful": 435
+    "candidate": 373,
+    "excluded": 492,
+    "candidate_next": 25,
+    "meaningful": 442
   },
   "overrides": {},
   "endpoints": {
@@ -923,6 +923,8 @@
     },
     "/api/v1/dashboard/wts/overview/tics": {
       "status": "candidate",
+      "priority": "next",
+      "note": "업종(TICS) 개요·랭킹",
       "first_seen": "2026-06-29"
     },
     "/api/v1/dashboard/wts/overview/trading-info": {
@@ -1155,28 +1157,33 @@
       "first_seen": "2026-06-19"
     },
     "/api/v1/lending/revenue/account": {
-      "status": "excluded",
-      "note": "stock lending product",
+      "status": "candidate",
+      "priority": "next",
+      "note": "대주(주식대여) 수익",
       "first_seen": "2026-06-19"
     },
     "/api/v1/lending/revenue/account/expected": {
-      "status": "excluded",
-      "note": "stock lending product",
+      "status": "candidate",
+      "priority": "next",
+      "note": "대주(주식대여) 수익",
       "first_seen": "2026-06-19"
     },
     "/api/v1/lending/revenue/account/payment": {
-      "status": "excluded",
-      "note": "stock lending product",
+      "status": "candidate",
+      "priority": "next",
+      "note": "대주(주식대여) 수익",
       "first_seen": "2026-06-19"
     },
     "/api/v1/lending/revenue/account/summary": {
-      "status": "excluded",
-      "note": "stock lending product",
+      "status": "candidate",
+      "priority": "next",
+      "note": "대주(주식대여) 수익",
       "first_seen": "2026-06-19"
     },
     "/api/v1/lending/revenue/account/top-revenue": {
-      "status": "excluded",
-      "note": "stock lending product",
+      "status": "candidate",
+      "priority": "next",
+      "note": "대주(주식대여) 수익",
       "first_seen": "2026-06-19"
     },
     "/api/v1/lending/setting/agreement": {
@@ -1853,14 +1860,20 @@
     },
     "/api/v1/prime/users/benefits": {
       "status": "candidate",
+      "priority": "next",
+      "note": "토스프라임 혜택·구독 상태",
       "first_seen": "2026-06-29"
     },
     "/api/v1/prime/users/benefits/cumulative": {
       "status": "candidate",
+      "priority": "next",
+      "note": "토스프라임 혜택·구독 상태",
       "first_seen": "2026-06-29"
     },
     "/api/v1/prime/users/info": {
       "status": "candidate",
+      "priority": "next",
+      "note": "토스프라임 혜택·구독 상태",
       "first_seen": "2026-06-29"
     },
     "/api/v1/product-eligibility/domestic-leverage-etp/trading": {
@@ -2696,6 +2709,8 @@
     },
     "/api/v1/tics/rankings": {
       "status": "candidate",
+      "priority": "next",
+      "note": "TICS 랭킹",
       "first_seen": "2026-06-29"
     },
     "/api/v1/time": {
@@ -3307,10 +3322,14 @@
     },
     "/api/v2/dashboard/wts/overview/tics": {
       "status": "candidate",
+      "priority": "next",
+      "note": "업종(TICS) 개요·랭킹",
       "first_seen": "2026-06-29"
     },
     "/api/v2/dashboard/wts/overview/tics/ranking": {
       "status": "candidate",
+      "priority": "next",
+      "note": "업종(TICS) 개요·랭킹",
       "first_seen": "2026-06-29"
     },
     "/api/v2/feed/subscription/followings": {
@@ -3357,13 +3376,15 @@
       "first_seen": "2026-06-19"
     },
     "/api/v2/lending/revenue/account/payment": {
-      "status": "excluded",
-      "note": "stock lending product",
+      "status": "candidate",
+      "priority": "next",
+      "note": "대주(주식대여) 수익",
       "first_seen": "2026-06-29"
     },
     "/api/v2/lending/revenue/account/summary": {
-      "status": "excluded",
-      "note": "stock lending product",
+      "status": "candidate",
+      "priority": "next",
+      "note": "대주(주식대여) 수익",
       "first_seen": "2026-06-29"
     },
     "/api/v2/lens/issues": {

--- a/tools/wts_endpoints.py
+++ b/tools/wts_endpoints.py
@@ -80,8 +80,12 @@ RECOMMENDED = [
     (r"^/api/v\d+/dashboard/wts/overview/ai-signals", "AI 시그널 확장"),
     (r"^/api/v\d+/dashboard/wts/overview/rankings/by-investors", "투자자별 랭킹(수급 discovery)"),
     (r"^/api/v1/companies/tics/rankings", "업종(TICS) 랭킹"),
+    (r"^/api/v1/tics/rankings", "TICS 랭킹"),
+    (r"^/api/v\d+/dashboard/wts/overview/tics", "업종(TICS) 개요·랭킹"),
     (r"^/api/v1/community/top-rankings", "커뮤니티 랭킹(인플루언서/수익률)"),
     (r"^/api/v1/r-chart", "실시간 차트"),
+    (r"^/api/v\d+/prime/users/(benefits|info)", "토스프라임 혜택·구독 상태"),
+    (r"^/api/v\d+/lending/revenue", "대주(주식대여) 수익"),
 ]
 
 # excluded: out of scope. (pattern, reason)
@@ -94,7 +98,7 @@ EXCLUDED = [
     (r"^/api/v\d+/promotion", "marketing/promotion"),
     (r"^/api/v\d+/minor", "minor-account flow"),
     (r"^/api/v\d+/pension", "pension account flow"),
-    (r"^/api/v\d+/lending", "stock lending product"),
+    (r"^/api/v\d+/lending/(?!revenue)", "stock lending product"),
     (r"^/api/v\d+/(auto-transfer|transfer-income|rename-documents)", "transfer/document admin"),
     (r"^/api/v\d+/terms", "legal terms"),
     (r"^/api/v\d+/login", "login flow (handled by auth-helper)"),


### PR DESCRIPTION
주간 모니터 신규 표면 중 tossctl 범위에 맞는 것을 candidate_next 로 승격 (RECOMMENDED/EXCLUDED 패턴 수정 → 자동 갱신에도 유지).
- tics(TICS) 랭킹·개요
- 토스프라임 혜택·구독(prime/users/benefits·info)
- 대주(주식대여) 수익(lending/revenue/*; lending 제외 패턴에서 revenue 만 negative-lookahead 로 해제)

candidate_next 11→25, meaningful 435→442.