### PR TITLE
feat(market): market themes — 테마 등락 랭킹 (v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ tossctl 사용자 관점의 변경 이력입니다. 각 버전에서 "무엇을 
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-06-29
+
+### 새 기능
+- **`market themes`** — 테마 등락 랭킹. 오늘 가장 많이 오른 토스 테마(예: 배터리·연예기획사)를 등락률·상승종목수와 함께 보여줍니다. `--size N` 으로 개수 조정(0=전체). 공식 Open API 에는 없는 토스 WTS 고유 기능입니다. `--output json|csv` 지원.
+
 ### 개선
 - 라우팅 백엔드 값 명칭 정리 — `--backend` 플래그와 `openapi.prefer` 의 `official` 값을 `openapi` 로 바꿨습니다(`tossctl openapi` 서브커맨드·`openapi.*` 설정과 일관). 기존 `official` 은 deprecated 별칭으로 계속 동작하므로 기존 설정·스크립트는 그대로 작동합니다.
 

--- a/README.en.md
+++ b/README.en.md
@@ -163,6 +163,7 @@ The Toss Securities official Open API is currently **rolling out in stages to pr
 | **🆕 Dividend report** | `portfolio dividends` (annual total · region · monthly, `--by-payment-date` tax) | ❌ | ✅ |
 | **🆕 Community rankings** | `community rankings --type influencer\|profit\|followers` | ❌ | ✅ |
 | **🆕 Sector movements** | `market sectors [id]` (industry tree, 1d·1m·1y returns) | ❌ | ✅ |
+| **🆕 Theme fluctuation ranking** | `market themes` (today's top-moving themes, rising-stock counts) | ❌ | ✅ |
 | **🆕 Personalized news briefing** | `market briefing` (headlines grouped by theme) | ❌ | ✅ |
 | **🆕 Toss AI signals** | `market signals` (per-symbol AI signal · keywords · move) | ❌ | ✅ |
 | **🆕 Stock screener** | `market screener [id]` (preset) · `--filter '<json>'` (custom) `--nation kr\|us` | ❌ | ✅ |
@@ -402,7 +403,7 @@ tossctl account summary
 tossctl portfolio positions
 tossctl portfolio allocation
 tossctl portfolio dividends [--year YYYY] [--by-payment-date]
-tossctl market investors|earnings|briefing|sectors|index|ranking|signals
+tossctl market investors|earnings|briefing|sectors|themes|index|ranking|signals
 tossctl community rankings --type influencer|profit|followers
 tossctl orders list
 tossctl orders completed --market us|kr|all

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Waiting for approval in the Toss app on your phone...
 | **🆕 배당 내역** | `portfolio dividends` (연간 총액·지역·월별, `--by-payment-date` 세금) | ❌ | ✅ |
 | **🆕 커뮤니티 랭킹** | `community rankings --type influencer\|profit\|followers` | ❌ | ✅ |
 | **🆕 업종별 등락** | `market sectors [id]` (대분류·하위 업종, 1일·1개월·1년) | ❌ | ✅ |
+| **🆕 테마 등락 랭킹** | `market themes` (오늘 가장 많이 오른 테마, 상승종목 수) | ❌ | ✅ |
 | **🆕 개인화 뉴스 브리핑** | `market briefing` (테마별 뉴스 묶음) | ❌ | ✅ |
 | **🆕 토스 AI 시그널** | `market signals` (종목별 AI 시그널·키워드·등락) | ❌ | ✅ |
 | **🆕 조건 검색 (스크리너)** | `market screener [id]` (프리셋) · `--filter '<json>'` (커스텀 조건) `--nation kr\|us` | ❌ | ✅ |
@@ -473,7 +474,7 @@ tossctl account summary
 tossctl portfolio positions
 tossctl portfolio allocation
 tossctl portfolio dividends [--year YYYY] [--by-payment-date]
-tossctl market investors|earnings|briefing|sectors|index|ranking|signals
+tossctl market investors|earnings|briefing|sectors|themes|index|ranking|signals
 tossctl community rankings --type influencer|profit|followers
 tossctl orders list
 tossctl orders completed --market us|kr|all

--- a/cmd/tossctl/market.go
+++ b/cmd/tossctl/market.go
@@ -249,6 +249,24 @@ func newMarketCmd(opts *rootOptions) *cobra.Command {
 	screenerCmd.Flags().IntVar(&screenerSize, "size", 30, "max stocks to return")
 	screenerCmd.Flags().StringVar(&screenerFilter, "filter", "", "custom raw filter JSON array (preset 대신)")
 
-	cmd.AddCommand(hoursCmd, fxCmd, indexCmd, rankingCmd, signalsCmd, investorsCmd, earningsCmd, briefingCmd, sectorsCmd, screenerCmd)
+	var themesSize int
+	themesCmd := &cobra.Command{
+		Use:   "themes",
+		Short: "Theme/sector fluctuation ranking (테마 등락 랭킹, 오늘 가장 많이 오른 테마). 공식 API 에 없음",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			app, err := newAppContext(opts)
+			if err != nil {
+				return err
+			}
+			tr, err := app.client.GetThemeRankings(cmd.Context(), themesSize)
+			if err != nil {
+				return err
+			}
+			return output.WriteThemeRankings(cmd.OutOrStdout(), app.format, tr)
+		},
+	}
+	themesCmd.Flags().IntVar(&themesSize, "size", 20, "number of ranked themes (0 = all)")
+
+	cmd.AddCommand(hoursCmd, fxCmd, indexCmd, rankingCmd, signalsCmd, investorsCmd, earningsCmd, briefingCmd, sectorsCmd, themesCmd, screenerCmd)
 	return cmd
 }

--- a/docs/reverse-engineering/wts-endpoints.json
+++ b/docs/reverse-engineering/wts-endpoints.json
@@ -4,10 +4,10 @@
   "chunk_count": 26,
   "total": 934,
   "counts": {
-    "implemented": 69,
-    "candidate": 373,
+    "implemented": 70,
+    "candidate": 372,
     "excluded": 492,
-    "candidate_next": 25,
+    "candidate_next": 24,
     "meaningful": 442
   },
   "overrides": {},
@@ -2708,9 +2708,7 @@
       "first_seen": "2026-06-19"
     },
     "/api/v1/tics/rankings": {
-      "status": "candidate",
-      "priority": "next",
-      "note": "TICS 랭킹",
+      "status": "implemented",
       "first_seen": "2026-06-29"
     },
     "/api/v1/time": {

--- a/internal/client/marketdata.go
+++ b/internal/client/marketdata.go
@@ -749,6 +749,63 @@ type ticsItemRaw struct {
 	SubItems []ticsItemRaw `json:"subItems"`
 }
 
+type ticsRankItemRaw struct {
+	TicsID           string `json:"ticsId"`
+	Title            string `json:"title"`
+	PreciseValue     string `json:"preciseValue"`
+	Ranking          int    `json:"ranking"`
+	TotalCount       int    `json:"totalCount"`
+	RiseCompanyCount int    `json:"riseCompanyCount"`
+	PriceValue       string `json:"priceValue"`
+}
+
+type ticsRankingRaw struct {
+	Name     string            `json:"name"`
+	DateTime string            `json:"dateTime"`
+	Data     []ticsRankItemRaw `json:"data"`
+}
+
+// GetThemeRankings returns TICS themes ranked by today's fluctuation
+// (오늘의 테마 등락 순위). Maps to GET /api/v1/tics/rankings (wts-info-api).
+// size <= 0 returns the full list; otherwise the top `size` by ranking.
+func (c *Client) GetThemeRankings(ctx context.Context, size int) (domain.ThemeRankings, error) {
+	var env quoteEnvelope[ticsRankingRaw]
+	if err := c.getJSON(ctx, c.infoBaseURL+"/api/v1/tics/rankings", &env); err != nil {
+		return domain.ThemeRankings{}, err
+	}
+	out := domain.ThemeRankings{
+		Name:      env.Result.Name,
+		DateTime:  env.Result.DateTime,
+		FetchedAt: time.Now().UTC(),
+	}
+	for _, it := range env.Result.Data {
+		out.Items = append(out.Items, domain.ThemeRanking{
+			Ranking:          it.Ranking,
+			TicsID:           it.TicsID,
+			Title:            it.Title,
+			ChangeRate:       parsePercent(it.PreciseValue),
+			RiseCompanyCount: it.RiseCompanyCount,
+			TotalCount:       it.TotalCount,
+			Summary:          it.PriceValue,
+		})
+	}
+	if size > 0 && len(out.Items) > size {
+		out.Items = out.Items[:size]
+	}
+	return out, nil
+}
+
+// parsePercent parses a Toss percent string like "+11.18%", "-3.2%", "0.0%"
+// into a float (11.18, -3.2, 0). Returns 0 for unparseable input.
+func parsePercent(s string) float64 {
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, "%")
+	s = strings.ReplaceAll(s, ",", "")
+	s = strings.TrimPrefix(s, "+")
+	v, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	return v
+}
+
 func ticsToSector(t ticsItemRaw) domain.Sector {
 	s := domain.Sector{
 		ID:             t.ID,

--- a/internal/client/theme_rankings_test.go
+++ b/internal/client/theme_rankings_test.go
@@ -1,0 +1,85 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGetThemeRankings(t *testing.T) {
+	const body = `{"result":{"type":"tics","name":"tics_fluctuation_v2","dateTime":"2026-06-29T12:30:35","data":[
+		{"productCode":null,"ticsId":"685","title":"배터리제조","value":"+11.1%","preciseValue":"+11.18%","ranking":1,"totalCount":21,"riseCompanyCount":13,"priceValue":"21개 중 13개 종목 상승"},
+		{"productCode":null,"ticsId":"100","title":"조선","value":"-3.2%","preciseValue":"-3.20%","ranking":2,"totalCount":10,"riseCompanyCount":1,"priceValue":"10개 중 1개 종목 상승"},
+		{"ticsId":"7","title":"보험","value":"+0.5%","preciseValue":"+0.50%","ranking":3,"totalCount":5,"riseCompanyCount":3}
+	]}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/api/v1/tics/rankings") {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	r, err := testClientFor(srv).GetThemeRankings(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("GetThemeRankings: %v", err)
+	}
+	if r.Name != "tics_fluctuation_v2" {
+		t.Errorf("name = %q", r.Name)
+	}
+	if len(r.Items) != 3 {
+		t.Fatalf("want 3 items, got %d", len(r.Items))
+	}
+	g := r.Items[0]
+	if g.Title != "배터리제조" || g.ChangeRate != 11.18 || g.RiseCompanyCount != 13 || g.TotalCount != 21 || g.Ranking != 1 || g.TicsID != "685" {
+		t.Errorf("item0 mismatch: %+v", g)
+	}
+	if g.Summary != "21개 중 13개 종목 상승" {
+		t.Errorf("summary = %q", g.Summary)
+	}
+	if r.Items[1].ChangeRate != -3.2 {
+		t.Errorf("negative rate parse: got %v", r.Items[1].ChangeRate)
+	}
+}
+
+func TestGetThemeRankingsSizeLimit(t *testing.T) {
+	const body = `{"result":{"data":[
+		{"ranking":1,"title":"a","preciseValue":"+1%"},
+		{"ranking":2,"title":"b","preciseValue":"+2%"},
+		{"ranking":3,"title":"c","preciseValue":"+3%"}
+	]}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	r, err := testClientFor(srv).GetThemeRankings(context.Background(), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Items) != 2 {
+		t.Fatalf("size limit: want 2, got %d", len(r.Items))
+	}
+	if r.Items[0].Title != "a" || r.Items[1].Title != "b" {
+		t.Errorf("expected top-2 by order, got %+v", r.Items)
+	}
+}
+
+func TestParsePercent(t *testing.T) {
+	cases := map[string]float64{
+		"+11.18%":   11.18,
+		"-3.20%":    -3.2,
+		"0.0%":      0,
+		"+1,234.5%": 1234.5,
+		"":          0,
+		"  +5% ":    5,
+	}
+	for in, want := range cases {
+		if got := parsePercent(in); got != want {
+			t.Errorf("parsePercent(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -596,6 +596,26 @@ type Sectors struct {
 	FetchedAt time.Time `json:"fetched_at"`
 }
 
+// ThemeRanking is one TICS theme/sector ranked by today's fluctuation.
+type ThemeRanking struct {
+	Ranking          int     `json:"ranking"`
+	TicsID           string  `json:"tics_id"`
+	Title            string  `json:"title"`
+	ChangeRate       float64 `json:"change_rate"` // daily % change (e.g. 11.18 or -3.2)
+	RiseCompanyCount int     `json:"rise_company_count"`
+	TotalCount       int     `json:"total_count"`
+	Summary          string  `json:"summary"` // e.g. "21개 중 13개 종목 상승"
+}
+
+// ThemeRankings is the TICS theme fluctuation ranking (오늘의 테마 등락 순위),
+// sorted by ranking (1 = biggest gainer). Not in the official Open API.
+type ThemeRankings struct {
+	Name      string         `json:"name"`
+	DateTime  string         `json:"date_time"`
+	Items     []ThemeRanking `json:"items"`
+	FetchedAt time.Time      `json:"fetched_at"`
+}
+
 // BuyingPower is the cash-based buying power for a given currency.
 // Endpoint: GET /api/v1/buying-power (official API).
 // cashBuyingPower (string decimal) is parsed to float64.

--- a/internal/monitor/probes.go
+++ b/internal/monitor/probes.go
@@ -297,6 +297,17 @@ func Probes() []Probe {
 			},
 		},
 		{
+			Name:   "theme-rankings",
+			Method: "GET",
+			URL:    info + "/api/v1/tics/rankings",
+			Check: func(status int, body []byte) error {
+				if err := expectStatus(status, 200); err != nil {
+					return err
+				}
+				return expectPath(body, "result.data", "array")
+			},
+		},
+		{
 			Name:   "community-rankings",
 			Method: "GET",
 			URL:    info + "/api/v1/community/top-rankings/INFLUENCER",

--- a/internal/monitor/probes_test.go
+++ b/internal/monitor/probes_test.go
@@ -26,6 +26,7 @@ func TestProbesRegistryStableNames(t *testing.T) {
 		"community-rankings":       true,
 		"news-briefing":            true,
 		"sectors-tics":             true,
+		"theme-rankings":           true,
 		"trading-flows":            true,
 		"ai-signals":               true,
 		"screener-presets":         true,

--- a/internal/output/marketdata.go
+++ b/internal/output/marketdata.go
@@ -810,6 +810,52 @@ func WriteCommunityRanking(w io.Writer, format Format, r domain.CommunityRanking
 }
 
 // WriteSectors renders an industry (TICS) list with fluctuation rates.
+// WriteThemeRankings renders the TICS theme fluctuation ranking. Table output
+// colours the change rate (KR convention: red up / blue down) only when the
+// colour gate is on; JSON/CSV are byte-identical regardless.
+func WriteThemeRankings(w io.Writer, format Format, r domain.ThemeRankings) error {
+	switch format {
+	case FormatJSON:
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(r)
+	case FormatCSV:
+		cw := csv.NewWriter(w)
+		if err := cw.Write([]string{"ranking", "tics_id", "title", "change_rate", "rise_company_count", "total_count"}); err != nil {
+			return err
+		}
+		for _, t := range r.Items {
+			if err := cw.Write([]string{
+				fmt.Sprintf("%d", t.Ranking), t.TicsID, t.Title,
+				formatFloat(t.ChangeRate), fmt.Sprintf("%d", t.RiseCompanyCount), fmt.Sprintf("%d", t.TotalCount),
+			}); err != nil {
+				return err
+			}
+		}
+		cw.Flush()
+		return cw.Error()
+	case FormatTable:
+		if len(r.Items) == 0 {
+			_, err := fmt.Fprintln(w, "테마 데이터가 없습니다")
+			return err
+		}
+		enabled := colorEnabled(w, format)
+		if _, err := fmt.Fprintf(w, "순위  테마            등락률      상승/전체\n"); err != nil {
+			return err
+		}
+		for _, t := range r.Items {
+			rateStr := fmt.Sprintf("%+8.2f%%", t.ChangeRate)
+			if _, err := fmt.Fprintf(w, "%3d   %-14s  %s  %d/%d\n",
+				t.Ranking, t.Title, profitText(rateStr, t.ChangeRate, enabled), t.RiseCompanyCount, t.TotalCount); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported output format: %s", format)
+	}
+}
+
 func WriteSectors(w io.Writer, format Format, sectors domain.Sectors) error {
 	list := sectors.Items
 	switch format {

--- a/internal/output/marketdata_test.go
+++ b/internal/output/marketdata_test.go
@@ -143,3 +143,71 @@ func TestWriteTradesCSVHeader(t *testing.T) {
 		t.Errorf("expected price in CSV, got %q", out)
 	}
 }
+
+func TestWriteThemeRankingsTable(t *testing.T) {
+	var buf bytes.Buffer
+	r := domain.ThemeRankings{
+		Name: "tics_fluctuation_v2", DateTime: "2026-06-29T12:30:35",
+		Items: []domain.ThemeRanking{
+			{Ranking: 1, TicsID: "685", Title: "배터리제조", ChangeRate: 11.18, RiseCompanyCount: 13, TotalCount: 21, Summary: "21개 중 13개 종목 상승"},
+			{Ranking: 96, TicsID: "100", Title: "조선", ChangeRate: -3.2, RiseCompanyCount: 1, TotalCount: 10},
+		},
+	}
+	if err := WriteThemeRankings(&buf, FormatTable, r); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "배터리제조") || !strings.Contains(out, "+11.18%") {
+		t.Errorf("expected gainer row: %q", out)
+	}
+	if !strings.Contains(out, "-3.20%") {
+		t.Errorf("expected negative theme rate: %q", out)
+	}
+	if !strings.Contains(out, "13/21") {
+		t.Errorf("expected rise/total counts: %q", out)
+	}
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("table to non-TTY must be plain (no ANSI): %q", out)
+	}
+}
+
+func TestWriteThemeRankingsCSV(t *testing.T) {
+	var buf bytes.Buffer
+	r := domain.ThemeRankings{Items: []domain.ThemeRanking{
+		{Ranking: 1, TicsID: "685", Title: "배터리제조", ChangeRate: 11.18, RiseCompanyCount: 13, TotalCount: 21},
+	}}
+	if err := WriteThemeRankings(&buf, FormatCSV, r); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.HasPrefix(out, "ranking,tics_id,title,change_rate,rise_company_count,total_count") {
+		t.Errorf("unexpected CSV header: %q", out)
+	}
+	if !strings.Contains(out, "배터리제조") {
+		t.Errorf("expected theme in CSV: %q", out)
+	}
+}
+
+func TestWriteThemeRankingsJSON(t *testing.T) {
+	var buf bytes.Buffer
+	r := domain.ThemeRankings{Name: "tics_fluctuation_v2", Items: []domain.ThemeRanking{
+		{Ranking: 1, Title: "배터리제조", ChangeRate: 11.18},
+	}}
+	if err := WriteThemeRankings(&buf, FormatJSON, r); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"change_rate": 11.18`) || !strings.Contains(out, `"name": "tics_fluctuation_v2"`) {
+		t.Errorf("unexpected JSON: %q", out)
+	}
+}
+
+func TestWriteThemeRankingsEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteThemeRankings(&buf, FormatTable, domain.ThemeRankings{}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "테마 데이터가 없습니다") {
+		t.Errorf("expected empty notice: %q", buf.String())
+	}
+}

--- a/tools/update_new_markers.py
+++ b/tools/update_new_markers.py
@@ -28,6 +28,7 @@ FEATURE_DATES = {
     "portfolio dividends": "2026-06-19",
     "community rankings": "2026-06-19",
     "market sectors": "2026-06-19",
+    "market themes": "2026-06-29",
     "market briefing": "2026-06-19",
     "market investors": "2026-06-19",
     "market earnings": "2026-06-19",

--- a/tools/wts_endpoints.py
+++ b/tools/wts_endpoints.py
@@ -67,6 +67,7 @@ IMPLEMENTED = [
     r"^/api/v1/dashboard/wts/overview/ai-signals/personalized$", # market briefing
     r"^/api/v1/dividends/accounts/annual/history",               # portfolio dividends
     r"^/api/v1/tics/all$",                                        # market sectors
+    r"^/api/v1/tics/rankings$",                                   # market themes
     r"^/api/v1/index-prices$",                                    # market index <code> (지수 상세)
 ]
 
@@ -80,7 +81,6 @@ RECOMMENDED = [
     (r"^/api/v\d+/dashboard/wts/overview/ai-signals", "AI 시그널 확장"),
     (r"^/api/v\d+/dashboard/wts/overview/rankings/by-investors", "투자자별 랭킹(수급 discovery)"),
     (r"^/api/v1/companies/tics/rankings", "업종(TICS) 랭킹"),
-    (r"^/api/v1/tics/rankings", "TICS 랭킹"),
     (r"^/api/v\d+/dashboard/wts/overview/tics", "업종(TICS) 개요·랭킹"),
     (r"^/api/v1/community/top-rankings", "커뮤니티 랭킹(인플루언서/수익률)"),
     (r"^/api/v1/r-chart", "실시간 차트"),


### PR DESCRIPTION
GET /api/v1/tics/rankings → 오늘 가장 많이 오른 토스 테마 랭킹(등락률·상승종목수). 공식 Open API 에 없는 WTS 고유 기능.

- domain/client/output/cmd + probe + 계약테스트(더미)·단위·출력 테스트
- 카탈로그 implemented 승격, README(+🆕)·CHANGELOG
- 라이브 table/json/csv 검증 완료