### PR TITLE
fix(client): 브라우저 User-Agent 설정으로 Toss API 403 차단 해결

### DIFF
--- a/internal/client/account.go
+++ b/internal/client/account.go
@@ -314,6 +314,7 @@ func (c *Client) requireSession() error {
 func (c *Client) applySession(req *http.Request) {
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Referer", "https://www.tossinvest.com/account")
+	req.Header.Set("User-Agent", defaultUserAgent)
 
 	if c.session == nil {
 		return
@@ -323,12 +324,14 @@ func (c *Client) applySession(req *http.Request) {
 		req.AddCookie(&http.Cookie{Name: name, Value: value})
 	}
 
+	// Session headers override defaults (e.g. a user-set User-Agent wins).
 	for name, value := range c.session.Headers {
 		req.Header.Set(name, value)
 	}
 }
 
 func (c *Client) applyTradingHeaders(req *http.Request) {
+	req.Header.Set("User-Agent", defaultUserAgent)
 	if strings.TrimSpace(c.browserTabID) != "" {
 		req.Header.Set("Browser-Tab-Id", c.browserTabID)
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -19,6 +19,10 @@ const defaultAPIBaseURL = "https://wts-api.tossinvest.com"
 const defaultInfoBaseURL = "https://wts-info-api.tossinvest.com"
 const defaultCertBaseURL = "https://wts-cert-api.tossinvest.com"
 
+// defaultUserAgent is sent on every request to avoid being blocked by the
+// Toss Securities edge, which rejects Go's default "Go-http-client/1.1" UA.
+const defaultUserAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"
+
 type Config struct {
 	HTTPClient    *http.Client
 	APIBaseURL    string
@@ -123,6 +127,7 @@ func (c *Client) ensureTradingMetadata(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	req.Header.Set("User-Agent", defaultUserAgent)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
@@ -145,6 +150,7 @@ func (c *Client) ensureTradingMetadata(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	req.Header.Set("User-Agent", defaultUserAgent)
 	resp, err = c.httpClient.Do(req)
 	if err != nil {
 		return err

--- a/internal/client/useragent_test.go
+++ b/internal/client/useragent_test.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/junghoonkye/tossinvest-cli/internal/session"
+)
+
+// TestApplySessionSetsBrowserUserAgent verifies that every request sent
+// through the client carries a browser-like User-Agent instead of Go's
+// default "Go-http-client/1.1", which the Toss Securities API blocks (403).
+func TestApplySessionSetsBrowserUserAgent(t *testing.T) {
+	t.Parallel()
+
+	var capturedUA string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":{"accountList":[]}}`))
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		HTTPClient: server.Client(),
+		APIBaseURL: server.URL,
+		Session: &session.Session{
+			Cookies: map[string]string{"SESSION": "test-session"},
+		},
+	})
+
+	_, _, err := client.ListAccounts(context.Background())
+	if err != nil {
+		t.Fatalf("ListAccounts returned error: %v", err)
+	}
+
+	if capturedUA == "" {
+		t.Fatal("expected non-empty User-Agent header")
+	}
+	if capturedUA == "Go-http-client/1.1" {
+		t.Fatal("User-Agent was not overridden from Go default")
+	}
+	if !strings.Contains(capturedUA, "Mozilla/5.0") {
+		t.Fatalf("expected browser-like User-Agent, got: %s", capturedUA)
+	}
+}


### PR DESCRIPTION
## 변경 사항

Toss Securities API(`wts-api.tossinvest.com`)가 Go의 기본 User-Agent(`Go-http-client/1.1`)를 차단하여, 유효한 세션으로도 모든 API 요청이 **403**을 반환하는 문제를 해결합니다.

### 원인
`net/http`의 기본 UA가 Toss edge/WAF에 차단됨. `curl`로 동일한 쿠키/헤더를 보내면 200이 반환되기 때문에 원인 파악이 매우 어려웠음 (이슈 #63 참고).

### 수정
`defaultUserAgent` 상수를 추가하고, 다음 세 곳에서 `User-Agent` 헤더를 설정:
- `applySession()` — 모든 조회(GET) 요청
- `applyTradingHeaders()` — 거래(POST) 요청
- `ensureTradingMetadata()` — 앱 버전 추론용 페이지 fetch

`session.Headers`에 사용자가 직접 `User-Agent`를 지정하면 그 값이 우선합니다.

## 영향 범위

- [x] 조회 (읽기 전용)
- [x] 거래 (mutation) — `applyTradingHeaders`에도 동일하게 적용
- [ ] 설치 / CI
- [ ] 문서

## 테스트

- [x] `make test` 통과 (기존 테스트 + 새 테스트 `TestApplySessionSetsBrowserUserAgent`)
- [x] 수동 확인 완료 — 수정 전 `Live Check: invalid / 403` → 수정 후 `Live Check: valid`

```diff
# Before (session.json에 수동으로 UA를 추가하지 않은 상태)
- Live Check: invalid
- Validation Error: authenticated request rejected with status 403

# After
+ Live Check: valid
```

## 체크리스트

- [x] 기존 동작을 깨뜨리지 않음
- [x] 거래 관련 변경인 경우 안전장치(config gate, confirm token 등) 유지 확인 — 헤더만 추가, 거래 로직 변경 없음

Closes #63