### PR TITLE
feat(website): changelog nav 링크 + 단일 소스화 + GitHub star 뱃지

### DIFF
--- a/website-fumadocs/components/layouts/shared.tsx
+++ b/website-fumadocs/components/layouts/shared.tsx
@@ -1,5 +1,5 @@
 import type { BaseLayoutProps, LinkItemType } from 'fumadocs-ui/layouts/shared';
-import { Bot, Github, Rocket, ShieldCheck, TerminalSquare } from 'lucide-react';
+import { Bot, Github, History, Rocket, ShieldCheck, TerminalSquare } from 'lucide-react';
 import {
   NavbarMenu,
   NavbarMenuContent,
@@ -106,6 +106,12 @@ export const linkItems: LinkItemType[] = [
     text: '명령',
     url: '/docs/reference/commands',
     icon: <TerminalSquare />,
+    active: 'nested-url',
+  },
+  {
+    text: '변경 이력',
+    url: '/docs/changelog',
+    icon: <History />,
     active: 'nested-url',
   },
   {

--- a/website-fumadocs/components/layouts/shared.tsx
+++ b/website-fumadocs/components/layouts/shared.tsx
@@ -10,6 +10,7 @@ import Link from 'fumadocs-core/link';
 import { TossctlIcon } from '@/app/layout.client';
 import { defineI18nUI } from 'fumadocs-ui/i18n';
 import { i18n } from '@/lib/i18n';
+import { GithubInfo } from 'fumadocs-ui/components/github-info';
 
 export const gitConfig = {
   user: 'JungHoonGhae',
@@ -138,6 +139,13 @@ export function baseOptions(): BaseLayoutProps {
     i18n: true,
     nav: {
       title: logo,
+      children: (
+        <GithubInfo
+          owner={gitConfig.user}
+          repo={gitConfig.repo}
+          className="max-lg:hidden"
+        />
+      ),
     },
   };
 }

--- a/website-fumadocs/content/docs/changelog.en.mdx
+++ b/website-fumadocs/content/docs/changelog.en.mdx
@@ -1,52 +1,301 @@
 ---
 title: Changelog
-description: tossctl version history
+description: Version history for tossctl, from the user's perspective
 ---
 
-Version history. Full per-release notes (and binaries) are on [GitHub Releases](https://github.com/JungHoonGhae/tossinvest-cli/releases). The detailed changelog is written in Korean — see the [Korean changelog](/docs/changelog).
+{/* AUTO-GENERATED from ../../../CHANGELOG.md by scripts/sync-changelog.mjs — do not edit directly. */}
 
-| Version | Date | Release |
-| --- | --- | --- |
-| Unreleased | — | [main](https://github.com/JungHoonGhae/tossinvest-cli/releases) |
-| 0.12.0 | 2026-06-27 | [v0.12.0](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.12.0) |
-| 0.11.1 | 2026-06-25 | [v0.11.1](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.11.1) |
-| 0.11.0 | 2026-06-25 | [v0.11.0](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.11.0) |
-| 0.10.1 | 2026-06-23 | [v0.10.1](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.10.1) |
-| 0.10.0 | 2026-06-21 | [v0.10.0](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.10.0) |
-| 0.9.1 | 2026-06-19 | [v0.9.1](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.9.1) |
-| 0.9.0 | 2026-06-19 | [v0.9.0](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.9.0) |
-| 0.8.0 | 2026-06-19 | [v0.8.0](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.8.0) |
-| 0.7.0 | 2026-06-18 | [v0.7.0](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.7.0) |
-| 0.6.0 | 2026-06-04 | [v0.6.0](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.6.0) |
-| 0.5.2 | 2026-06-04 | [v0.5.2](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.5.2) |
-| 0.5.1 | 2026-06-04 | [v0.5.1](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.5.1) |
-| 0.5.0 | 2026-06-04 | [v0.5.0](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.5.0) |
-| 0.4.19 | 2026-06-03 | [v0.4.19](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.19) |
-| 0.4.18 | 2026-06-03 | [v0.4.18](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.18) |
-| 0.4.17 | 2026-06-03 | [v0.4.17](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.17) |
-| 0.4.16 | 2026-05-28 | [v0.4.16](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.16) |
-| 0.4.15 | 2026-05-20 | [v0.4.15](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.15) |
-| 0.4.14 | 2026-05-14 | [v0.4.14](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.14) |
-| 0.4.13 | 2026-05-14 | [v0.4.13](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.13) |
-| 0.4.12 | 2026-05-14 | [v0.4.12](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.12) |
-| 0.4.10 | 2026-05-13 | [v0.4.10](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.10) |
-| 0.4.9 | 2026-05-13 | [v0.4.9](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.9) |
-| 0.4.8 | 2026-05-13 | [v0.4.8](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.8) |
-| 0.4.7 | 2026-05-06 | [v0.4.7](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.7) |
-| 0.4.6 | 2026-05-06 | [v0.4.6](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.6) |
-| 0.4.5 | 2026-04-29 | [v0.4.5](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.5) |
-| 0.4.4 | 2026-04-23 | [v0.4.4](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.4) |
-| 0.4.3 | 2026-04-23 | [v0.4.3](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.3) |
-| 0.4.2 | 2026-04-23 | [v0.4.2](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.2) |
-| 0.4.1 | 2026-04-23 | [v0.4.1](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.1) |
-| 0.4.0 | 2026-04-23 | [v0.4.0](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.4.0) |
-| 0.3.6 | 2026-04-17 | [v0.3.6](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.3.6) |
-| 0.3.5 | 2026-03-30 | [v0.3.5](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.3.5) |
-| 0.3.4 | 2026-03-28 | [v0.3.4](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.3.4) |
-| 0.3.3 | 2026-03-24 | [v0.3.3](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.3.3) |
-| 0.3.2 | 2026-03-23 | [v0.3.2](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.3.2) |
-| 0.3.1 | 2026-03-21 | [v0.3.1](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.3.1) |
-| 0.3.0 | 2026-03-21 | [v0.3.0](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.3.0) |
-| 0.2.2 | 2026-03-21 | [v0.2.2](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.2.2) |
-| 0.1.7 | 2026-03-21 | [v0.1.7](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.1.7) |
-| 0.1.6 | 2026-03-21 | [v0.1.6](https://github.com/JungHoonGhae/tossinvest-cli/releases/tag/v0.1.6) |
+Version history below (source: the Korean-language [CHANGELOG.md](https://github.com/JungHoonGhae/tossinvest-cli/blob/main/CHANGELOG.md) — entries are not yet translated). Binaries and release notes for each version are also on [GitHub Releases](https://github.com/JungHoonGhae/tossinvest-cli/releases).
+
+## [Unreleased]
+
+## [0.14.0] - 2026-07-01
+
+### 새 기능
+- **한국어 UI 라우팅** — `--lang ko` (또는 환경변수 `LANG`/`TOSSCTL_LANG`) 로 help·온보딩 프롬프트·표 출력을 한국어로 볼 수 있습니다. 기본값은 OS 로케일을 따르고, 감지되지 않으면 영어로 표시합니다. `--output json|csv` 는 언어 설정과 무관하게 항상 고정된 형식을 유지합니다.
+
+### 개선
+- CLI 커맨드 설명(`--help`)을 영어로 통일하고, 각 커맨드가 어떤 경로로 동작하는지(공식 Open API / WTS / 둘 다 / 로컬) 구조화된 메타로 노출했습니다.
+
+## [0.13.1] - 2026-06-29
+
+### 개선
+- `market themes` 테이블 정렬 개선 — 한글 표시폭을 반영해 열을 맞추고 헤더 구분선을 추가했습니다.
+
+## [0.13.0] - 2026-06-29
+
+### 새 기능
+- **`market themes`** — 테마 등락 랭킹. 오늘 가장 많이 오른 토스 테마(예: 배터리·연예기획사)를 등락률·상승종목수와 함께 보여줍니다. `--size N` 으로 개수 조정(0=전체). 공식 Open API 에는 없는 토스 WTS 고유 기능입니다. `--output json|csv` 지원.
+
+### 개선
+- 라우팅 백엔드 값 명칭 정리 — `--backend` 플래그와 `openapi.prefer` 의 `official` 값을 `openapi` 로 바꿨습니다(`tossctl openapi` 서브커맨드·`openapi.*` 설정과 일관). 기존 `official` 은 deprecated 별칭으로 계속 동작하므로 기존 설정·스크립트는 그대로 작동합니다.
+
+## [0.12.0] - 2026-06-27
+
+### 새 기능
+- **대화형 주문·폴더 선택** — 터미널에서 `order cancel`, `order amend`, `order show`를 `--order-id` 없이 실행하면 대기/최근 주문 목록을 직접 골라 진행할 수 있습니다. `watchlist group delete`·`rename`도 폴더 이름 없이 실행하면 목록에서 선택합니다 (`rename "새이름"`처럼 새 이름만 전달하면 폴더를 고릅니다). 플래그·인자를 지정하면 기존과 동일하게 비대화형으로 동작하며, 파이프·비TTY에서는 프롬프트 없이 명확한 오류를 반환합니다.
+- **하이브리드 공식 Open API 연동** — 토스 공식 Open API 키를 선택적으로 연결할 수 있습니다. 연결하면 공식이 지원하는 조회·거래 기능은 OAuth 경로로 처리되어 더 안정적이며, 토큰을 자동 갱신합니다. 공식에 없는 기능은 기존대로 WTS 경로를 씁니다. 키 없이도 모든 기능이 동작하며, 원하는 시점에 선택적으로 추가할 수 있습니다.
+- **`tossctl init`** — 온보딩 위저드. 처음 설치한 사용자를 위해 웹 세션 로그인·공식 키 등록·거래 설정을 단계별로 안내합니다.
+- **`tossctl openapi login`** — 공식 API Key·Secret을 등록합니다. 환경변수(`TOSSCTL_OPENAPI_KEY`/`TOSSCTL_OPENAPI_SECRET`) 또는 플래그로 전달하거나 대화형으로 입력할 수 있습니다. 자격증명 파일은 `0600` 권한으로 저장됩니다.
+- **`tossctl openapi status`** — 현재 키·토큰·허용 IP·라우팅 상태를 진단합니다. IP 미허용·토큰 만료·키 미설정 등 오류 원인을 설명합니다.
+- **`tossctl openapi test`** — 실제 API 호출로 공식 키 연결을 검증합니다.
+- **`tossctl openapi logout`** — 자격증명 파일을 삭제합니다.
+- **`--backend auto|wts|official`** 전역 플래그 — 요청별로 라우팅 백엔드를 직접 지정합니다.
+- **`doctor` 하이브리드 진단** — `tossctl doctor` 가 공식 키·토큰·IP 허용 상태를 함께 점검합니다.
+
+### 개선
+- **핵심 출력 손익 색상** — 포트폴리오·계좌·시세·관심종목의 주요 손익 수치에 한국식 색(상승/이익=빨강, 하락/손실=파랑)을 표시합니다. 파이프·비TTY·`NO_COLOR` 환경 및 `--output json|csv` 에서는 색 없이 기존과 동일하게 동작합니다.
+- **관심종목 등락·등락률 컬럼** — `watchlist list` 결과 표에 기준가 대비 등락액·등락률 컬럼이 추가됐습니다. JSON/CSV 출력은 변경 없습니다.
+
+### 버그 수정
+- 설치 스크립트(`curl ... install.sh | sh`)가 `/usr/local/bin` 이 없는 환경(주로 새로 설정한 Apple Silicon Mac — Homebrew 가 `/opt/homebrew` 에 있어 `/usr/local/bin` 이 아직 없는 경우)에서 `mv: ... No such file or directory` 로 설치에 실패하던 문제 수정. 설치 디렉터리를 먼저 만들고, 쓰기 권한이 있으면 sudo 없이 설치합니다. `INSTALL_DIR`·`SHARE_DIR` 환경변수로 설치 위치를 바꿀 수도 있습니다.
+
+## [0.11.1] - 2026-06-25
+
+### 버그 수정
+- 소수점 매수(`order place --fractional --amount <값>`, `--qty` 미사용)가 `required flag(s) "qty" not set` 로 거부되던 문제 수정. `--qty` 를 정적 필수에서 제외하고, 수량/금액 검증을 케이스별로 `order preview`·`place` 에서 일원화했습니다. (소수점 매도는 `--qty`, 소수점 매수는 `--amount` 사용.)
+
+## [0.11.0] - 2026-06-25
+
+### 새 기능
+- **소수점 매도 (US, beta)** — 미국 주식 시장가에서 소수점 수량으로 매도할 수 있습니다: `order place --fractional --side sell --qty 0.5` (소수점 6자리까지). 공식 Open API 1.1.5에 추가된 기능을 반영했습니다. 소수점 매수는 기존대로 금액 기반(`--amount`)입니다. 계약 테스트는 통과했으나 라이브 검증 전이니 실거래 전 `order preview` 로 확인하세요.
+
+### 문서
+- 공식 Open API 가 소수점 주문(금액 기반 매수 + 1.1.5 소수점 매도)을 지원함을 반영해 비교표·소개를 정정했습니다. tossctl 고유 부분은 **원화(KRW) 결제 모드**(공식 금액 주문은 USD)·dry-run preview·안전 게이트로 명확히 했습니다.
+
+## [0.10.1] - 2026-06-23
+
+### 버그 수정
+- Windows·Linux 에서 로그인은 성공하는데 `auth status` 와 모든 인증 요청이 거부(400/401/403)되던 문제 수정. tossctl 이 보내는 User-Agent 가 macOS 로 고정돼 있어, 다른 OS 에서 로그인한 세션과 불일치해 토스 서버가 거부하던 것이 원인이었습니다. 이제 로그인한 브라우저의 실제 User-Agent 를 세션에 저장해 그대로 쓰고, 기본값도 실행 OS 에 맞춰 만듭니다. (#36)
+- Windows 설치 시 playwright 설치 단계에서 실제로는 성공했는데도 빨간 `NativeCommandError` 가 표시되던 문제 수정 (PowerShell이 pip 진행 메시지를 오류로 처리). 이제 종료 코드로만 성공/실패를 판정합니다. (#35)
+
+## [0.10.0] - 2026-06-21
+
+### 새 기능
+- **`market index <코드|이름>`** — 지수 상세 시세(OHLC·52주 고저·거래량). 예: `market index nasdaq`, `market index 코스피`. 인자 없으면 기존처럼 주요 지수 목록(코드 포함).
+
+## [0.9.1] - 2026-06-19
+
+### 버그 수정
+- 소스 설치 경로 정정 — `go install github.com/JungHoonGhae/tossinvest-cli/cmd/tossctl@latest` 가 정상 동작합니다 (모듈 경로가 실제 저장소와 불일치하던 문제). 바이너리·Homebrew 설치에는 영향 없습니다.
+
+## [0.9.0] - 2026-06-19
+
+### 새 기능
+- **`portfolio dividends`** — 연간 배당 내역(총액·수령·예정, 지역별 KR/US, 월별). `--by-payment-date` 로 지급일 기준(세금·수수료 포함), `--year` 로 연도 선택.
+- **`community rankings --type influencer|profit|followers`** — 토스 커뮤니티 랭킹(인플루언서·수익금·팔로워 급증).
+- **`market sectors [id]`** — 업종별 등락(대분류 39개·하위 업종, 1일·1개월·1년 수익률). 인자로 업종 id 를 주면 하위 업종.
+- **`market briefing`** — 개인화 AI 뉴스 브리핑(테마별로 묶인 뉴스 헤드라인).
+- **`market earnings --major`** — 주요 기업 어닝콜만 큐레이션해서 표시.
+
+(모두 토스 공식 Open API 에는 없는 tossctl 고유 기능입니다.)
+
+## [0.8.0] - 2026-06-19
+
+### 새 기능
+- **`market investors`** — 외국인·기관·개인 투자자별 순매수 상위 종목.
+- **`market earnings`** — 다가오는 어닝콜(실적발표) 일정.
+
+(둘 다 토스 공식 Open API 에는 없는 tossctl 고유 기능입니다.)
+
+## [0.7.0] - 2026-06-18
+
+### 새 기능
+- **Windows 설치 지원** — PowerShell 한 줄로 설치합니다: `irm https://raw.githubusercontent.com/JungHoonGhae/tossinvest-cli/main/install.ps1 | iex`. 다운로드·체크섬 검증·PATH 등록·Chrome/Python 점검까지 자동으로 처리합니다. (기여: @thsvkd)
+
+### 개선
+- Windows 설치 시 기존 PATH 환경변수가 손상되지 않도록 안전하게 등록합니다.
+
+## [0.6.0] - 2026-06-04
+
+### 새 기능
+- **`quote orderbook <종목>`** — 10단계 호가(매도·매수 잔량).
+- **`quote sellable <종목>`** — 보유 종목의 매도가능수량.
+- **`quote commission <종목>`** — 수수료율·거래세율.
+
+이로써 토스 공식 Open API 가 제공하는 조회·거래 기능을 **100% 커버**합니다.
+
+## [0.5.2] - 2026-06-04
+
+### 개선
+- 국내주식 6자리 코드(예: `005930`)를 넣으면 `--market kr` 없이 자동으로 인식합니다.
+- 멀티 시세·시세 조회 속도 향상(병렬 처리).
+- 거래 설정 단순화 — 이제 US/KR 시장 구분 없이 동일하게 동작합니다 (기존엔 국내거래만 별도 옵션이 필요했습니다).
+
+## [0.5.1] - 2026-06-04
+
+### 개선
+- 실거래 실행 절차를 `--execute` + `--confirm <token>` 두 단계로 단순화했습니다(보호 강도는 동일).
+- 오래된 설정 항목이 남아 있으면 명령 실행 시 한 줄로 안내합니다.
+
+### 지원 종료 예정
+- `--dangerously-skip-permissions` 플래그는 더 이상 필요 없습니다. 당분간 호환을 위해 받아들이지만 다음 릴리즈에서 제거됩니다. `--execute` + `--confirm <token>` 을 사용하세요.
+
+## [0.5.0] - 2026-06-04
+
+### 새 기능
+- **`market index`** — 코스피·코스닥·나스닥·S&P500·VIX 등 주요 시장 지수.
+- **`market ranking`** — 실시간 인기 종목 순위.
+- **`quote flows <종목>`** — 종목별 투자자 수급(개인·외국인·기관, 국내).
+- **`market signals`** — 토스 AI 시그널.
+- **`market screener`** — 가치주·배당주·성장주 등 조건 검색.
+- **관심종목 관리** — 폴더 생성·이름변경·삭제, 종목 추가·제거 (`watchlist group ...`, `watchlist add|remove`).
+
+## [0.4.19] - 2026-06-03
+
+### 새 기능
+- `quote get` 정보 확장 — 당일 OHLC, 52주 고저, 시가총액, 거래대금, 체결강도, 상/하한가.
+- **`market fx`** — 달러 환율·달러 인덱스.
+- `market hours` 가 휴장일에는 다음 영업일도 함께 표시합니다.
+
+## [0.4.18] - 2026-06-03
+
+### 개선
+- 미국 종목에 `quote limits`(상/하한가)를 쓰면 친절한 안내를 표시합니다 (상/하한가는 국내 전용 제도).
+
+## [0.4.17] - 2026-06-03
+
+### 새 기능
+- **`quote trades`** (체결 틱), **`quote limits`** (상/하한가), **`quote warnings`** (매수 유의사항), **`market hours`** (장 운영 시간).
+
+## [0.4.16] - 2026-05-28
+
+### 새 기능
+- **`quote batch --live`** — 실시간 갱신 모드(`watch` 대체). (기여: @Castor103)
+- `quote batch` 에서 쉼표로 여러 종목을 한 번에 조회.
+
+## [0.4.15] - 2026-05-20
+
+### 새 기능
+- **`quote chart <종목>`** — 분봉 ASCII 캔들 차트(색상 지원). `quote batch --chart` 로 스파크라인 표시. (기여: @Castor103)
+- `quote get` / `quote chart` 가 여러 단어 종목명(`"KODEX 인버스"` 등)을 지원합니다.
+
+## [0.4.14] - 2026-05-14
+
+### 개선
+- 새 버전 알림이 AI 에이전트 환경에서도 표시되도록 했습니다(하루 1회).
+- `tossctl version` 에 최신 버전·업데이트 가능 여부를 표시합니다.
+
+## [0.4.13] - 2026-05-14
+
+### 새 기능
+- **자동 업데이트 알림** — 새 버전이 있으면 명령 실행 후 한 줄로 안내합니다. 설정에서 끌 수 있고(`update_check.enabled=false`), 자동화 출력(JSON/CSV)은 오염시키지 않습니다.
+
+## [0.4.12] - 2026-05-14
+
+### 버그 수정
+- Windows 에서 `auth login` 이 중간에 멈추던 문제를 수정했습니다. (제보·수정: @netics01)
+
+## [0.4.10] - 2026-05-13
+
+### 개선
+- `monitor api` 단순화 — 통과/실패만 반환하고 알림 채널(Discord·Slack·이메일 등)은 cron 에서 자유롭게 연결합니다. (가이드: `AGENTS.md`)
+
+## [0.4.9] - 2026-05-13
+
+### 새 기능
+- **`tossctl monitor api`** — 핵심 조회 API 상태를 점검해, 토스 서버 측 변경으로 명령이 깨지기 전에 조기 감지합니다.
+
+## [0.4.8] - 2026-05-13
+
+### 버그 수정
+- 토스 서버 변경으로 `portfolio positions`·`watchlist list` 가 실패하던 문제를 긴급 수정했습니다. (제보: kwakmu18)
+
+## [0.4.7] - 2026-05-06
+
+### 버그 수정
+- `order place --fractional --currency-mode USD` 가 거부되던 문제를 수정했습니다. (제보: @leesj10147)
+
+## [0.4.6] - 2026-05-06
+
+### 새 기능
+- **`tossctl auth extend`** — 폰 토스 앱 푸시 승인으로 세션을 약 7일 연장합니다(재로그인 불필요). (기여: @skyisle)
+- 세션 만료 24시간 전부터 경고를 표시합니다.
+
+## [0.4.5] - 2026-04-29
+
+### 새 기능
+- **`tossctl push listen`** — 실시간 푸시(주문/체결/보유 변경) 알림 스트림. (기여: @skyisle)
+
+## [0.4.4] - 2026-04-23
+
+### 새 기능
+- 미국 지정가 주문에 USD 가격 입력 허용 — `order place --currency-mode USD --price 158.01`. (기여: @skyisle)
+
+## [0.4.3] - 2026-04-23
+
+### 개선
+- 실제로 동작하지 않던 설정 항목들을 정리했습니다. 기존 설정은 그대로 둬도 되며, `doctor` 가 안내합니다.
+
+## [0.4.2] - 2026-04-23
+
+### 새 기능
+- **`tossctl doctor --report`** — 환경·세션·엔드포인트 상태를 JSON 한 번에 출력합니다. 홈 경로는 자동으로 가려져 GitHub 이슈에 그대로 붙일 수 있습니다.
+
+## [0.4.1] - 2026-04-23
+
+### 보안
+- 로그인 중간 파일·QR 이미지·상태 폴더 권한을 소유자 전용으로 강화했습니다(공유 컴퓨터에서 다른 사용자가 세션을 읽지 못하도록).
+
+## [0.4.0] - 2026-04-23
+
+### 새 기능
+- **거래내역·현금 요약** — `transactions list`(매매·입출금·배당·입출고), `transactions overview`(주문가능·출금가능·예정입금). (기여: @skyisle)
+- **로그인 유지(영속 세션)** — 폰에서 "이 기기 로그인 유지"까지 마치면 약 1시간 뒤 만료되던 문제가 해결됩니다.
+- **원격/헤드리스 로그인** — `auth login --headless`. QR URL 을 폰으로 보내 카메라 없이 인증. (기여: @skyisle)
+- helper Python 자동 탐지로 `uv` 설치 환경도 지원. (기여: @keenranger)
+
+## [0.3.6] - 2026-04-17
+
+### 버그 수정
+- `auth login` 이 멈추거나 조회 API 가 차단(403)되던 문제를 수정했습니다. (제보: @pinion05)
+
+## [0.3.5] - 2026-03-30
+
+### 개선
+- 표 출력 정렬 개선(종목명 좌측, 숫자 우측, 천단위 쉼표).
+
+## [0.3.4] - 2026-03-28
+
+### 버그 수정
+- `auth login` 브라우저 차단 해결 — 시스템 Google Chrome 을 사용합니다(별도 Chromium 설치 불필요).
+
+## [0.3.3] - 2026-03-24
+
+### 새 기능
+- 미국 포지션에 USD 금액 병기. (기여: @seilk)
+- 한 줄 설치 스크립트(`curl ... | sh`, macOS/Linux).
+
+### 버그 수정
+- Linux 에서 `auth login` 이 실패하던 문제 수정.
+
+## [0.3.2] - 2026-03-23
+
+### 새 기능
+- Windows·Linux 바이너리 제공.
+
+## [0.3.1] - 2026-03-21
+
+### 버그 수정
+- 미국 주가가 센트($0.01) 단위로 반올림되도록 수정(가격 오류 해결).
+
+## [0.3.0] - 2026-03-21
+
+### 새 기능
+- **소수점(금액 기반) 주문** — `order place --symbol TSLL --fractional --amount 18000` (미국 시장가).
+
+## [0.2.2] - 2026-03-21
+
+### 새 기능
+- `quote batch` — 여러 종목 시세 한 번에.
+- `export positions|orders --market` — 시장별 CSV 내보내기.
+
+## [0.1.7] - 2026-03-21
+
+### 새 기능
+- 국내주식 거래 — `order place --symbol 005930 --market kr`.
+
+## [0.1.6] - 2026-03-21
+
+### 새 기능
+- 매도 주문 — `order place --side sell`.

--- a/website-fumadocs/content/docs/changelog.mdx
+++ b/website-fumadocs/content/docs/changelog.mdx
@@ -3,25 +3,45 @@ title: 변경 이력
 description: tossctl 버전별 변경 사항 (사용자 관점)
 ---
 
+{/* AUTO-GENERATED from ../../../CHANGELOG.md by scripts/sync-changelog.mjs — do not edit directly. */}
+
 버전별 변경 사항입니다. 각 릴리즈의 바이너리·릴리즈 노트는 [GitHub Releases](https://github.com/JungHoonGhae/tossinvest-cli/releases)에서도 볼 수 있습니다.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-01
+
+### 새 기능
+- **한국어 UI 라우팅** — `--lang ko` (또는 환경변수 `LANG`/`TOSSCTL_LANG`) 로 help·온보딩 프롬프트·표 출력을 한국어로 볼 수 있습니다. 기본값은 OS 로케일을 따르고, 감지되지 않으면 영어로 표시합니다. `--output json|csv` 는 언어 설정과 무관하게 항상 고정된 형식을 유지합니다.
+
 ### 개선
-- 라우팅 백엔드 값 `official` → `openapi` 로 명칭 정리 (`--backend openapi`, `openapi.prefer: "openapi"`). `tossctl openapi`·`openapi.*` 와 일관됩니다. 기존 `official` 은 deprecated 별칭으로 계속 동작합니다.
+- CLI 커맨드 설명(`--help`)을 영어로 통일하고, 각 커맨드가 어떤 경로로 동작하는지(공식 Open API / WTS / 둘 다 / 로컬) 구조화된 메타로 노출했습니다.
+
+## [0.13.1] - 2026-06-29
+
+### 개선
+- `market themes` 테이블 정렬 개선 — 한글 표시폭을 반영해 열을 맞추고 헤더 구분선을 추가했습니다.
+
+## [0.13.0] - 2026-06-29
+
+### 새 기능
+- **`market themes`** — 테마 등락 랭킹. 오늘 가장 많이 오른 토스 테마(예: 배터리·연예기획사)를 등락률·상승종목수와 함께 보여줍니다. `--size N` 으로 개수 조정(0=전체). 공식 Open API 에는 없는 토스 WTS 고유 기능입니다. `--output json|csv` 지원.
+
+### 개선
+- 라우팅 백엔드 값 명칭 정리 — `--backend` 플래그와 `openapi.prefer` 의 `official` 값을 `openapi` 로 바꿨습니다(`tossctl openapi` 서브커맨드·`openapi.*` 설정과 일관). 기존 `official` 은 deprecated 별칭으로 계속 동작하므로 기존 설정·스크립트는 그대로 작동합니다.
 
 ## [0.12.0] - 2026-06-27
 
 ### 새 기능
 - **대화형 주문·폴더 선택** — 터미널에서 `order cancel`, `order amend`, `order show`를 `--order-id` 없이 실행하면 대기/최근 주문 목록을 직접 골라 진행할 수 있습니다. `watchlist group delete`·`rename`도 폴더 이름 없이 실행하면 목록에서 선택합니다 (`rename "새이름"`처럼 새 이름만 전달하면 폴더를 고릅니다). 플래그·인자를 지정하면 기존과 동일하게 비대화형으로 동작하며, 파이프·비TTY에서는 프롬프트 없이 명확한 오류를 반환합니다.
-- **공식 Open API 자동 라우팅** — 토스 공식 Open API 키를 선택적으로 연결할 수 있습니다. 연결하면 공식이 지원하는 조회·거래 기능은 공식 OAuth 경로로 처리되어 더 안정적이며, 토큰을 자동 갱신합니다. 공식에 없는 기능은 기존대로 WTS 경로를 씁니다. 키 없이도 모든 기능이 동작하며, 원하는 시점에 선택적으로 추가할 수 있습니다.
+- **하이브리드 공식 Open API 연동** — 토스 공식 Open API 키를 선택적으로 연결할 수 있습니다. 연결하면 공식이 지원하는 조회·거래 기능은 OAuth 경로로 처리되어 더 안정적이며, 토큰을 자동 갱신합니다. 공식에 없는 기능은 기존대로 WTS 경로를 씁니다. 키 없이도 모든 기능이 동작하며, 원하는 시점에 선택적으로 추가할 수 있습니다.
 - **`tossctl init`** — 온보딩 위저드. 처음 설치한 사용자를 위해 웹 세션 로그인·공식 키 등록·거래 설정을 단계별로 안내합니다.
 - **`tossctl openapi login`** — 공식 API Key·Secret을 등록합니다. 환경변수(`TOSSCTL_OPENAPI_KEY`/`TOSSCTL_OPENAPI_SECRET`) 또는 플래그로 전달하거나 대화형으로 입력할 수 있습니다. 자격증명 파일은 `0600` 권한으로 저장됩니다.
 - **`tossctl openapi status`** — 현재 키·토큰·허용 IP·라우팅 상태를 진단합니다. IP 미허용·토큰 만료·키 미설정 등 오류 원인을 설명합니다.
 - **`tossctl openapi test`** — 실제 API 호출로 공식 키 연결을 검증합니다.
 - **`tossctl openapi logout`** — 자격증명 파일을 삭제합니다.
-- **`--backend auto|wts|openapi`** 전역 플래그 — 요청별로 라우팅 백엔드를 직접 지정합니다.
-- **`doctor` 공식 키 진단** — `tossctl doctor` 가 공식 키·토큰·IP 허용 상태를 함께 점검합니다.
+- **`--backend auto|wts|official`** 전역 플래그 — 요청별로 라우팅 백엔드를 직접 지정합니다.
+- **`doctor` 하이브리드 진단** — `tossctl doctor` 가 공식 키·토큰·IP 허용 상태를 함께 점검합니다.
 
 ### 개선
 - **핵심 출력 손익 색상** — 포트폴리오·계좌·시세·관심종목의 주요 손익 수치에 한국식 색(상승/이익=빨강, 하락/손실=파랑)을 표시합니다. 파이프·비TTY·`NO_COLOR` 환경 및 `--output json|csv` 에서는 색 없이 기존과 동일하게 동작합니다.

--- a/website-fumadocs/package.json
+++ b/website-fumadocs/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "packageManager": "pnpm@10.27.0",
   "scripts": {
-    "build": "next build",
-    "dev": "next dev",
+    "build": "node scripts/sync-changelog.mjs && next build",
+    "dev": "node scripts/sync-changelog.mjs && next dev",
     "start": "serve out",
-    "types:check": "fumadocs-mdx && next build"
+    "types:check": "node scripts/sync-changelog.mjs && fumadocs-mdx && next build",
+    "sync:changelog": "node scripts/sync-changelog.mjs"
   },
   "dependencies": {
     "@orama/orama": "^3.1.18",

--- a/website-fumadocs/scripts/sync-changelog.mjs
+++ b/website-fumadocs/scripts/sync-changelog.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// Generates content/docs/changelog.mdx (+ .en.mdx) from the repo-root
+// CHANGELOG.md. Do not hand-edit the generated .mdx files — edit
+// ../../CHANGELOG.md and re-run this script (or `pnpm build` / `pnpm dev`).
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+const changelogPath = path.join(repoRoot, 'CHANGELOG.md');
+const outDir = path.join(__dirname, '..', 'content', 'docs');
+
+function loadBody() {
+  const raw = readFileSync(changelogPath, 'utf8');
+  const idx = raw.indexOf('## [');
+  if (idx === -1) {
+    throw new Error(`sync-changelog: no "## [" version heading found in ${changelogPath}`);
+  }
+  return raw.slice(idx).trimEnd() + '\n';
+}
+
+const GENERATED_NOTICE =
+  '{/* AUTO-GENERATED from ../../../CHANGELOG.md by scripts/sync-changelog.mjs — do not edit directly. */}\n\n';
+
+function writeKo(body) {
+  const frontmatter = `---\ntitle: 변경 이력\ndescription: tossctl 버전별 변경 사항 (사용자 관점)\n---\n\n`;
+  const intro =
+    '버전별 변경 사항입니다. 각 릴리즈의 바이너리·릴리즈 노트는 ' +
+    '[GitHub Releases](https://github.com/JungHoonGhae/tossinvest-cli/releases)에서도 볼 수 있습니다.\n\n';
+  writeFileSync(
+    path.join(outDir, 'changelog.mdx'),
+    frontmatter + GENERATED_NOTICE + intro + body,
+  );
+}
+
+function writeEn(body) {
+  const frontmatter = `---\ntitle: Changelog\ndescription: Version history for tossctl, from the user's perspective\n---\n\n`;
+  const intro =
+    'Version history below (source: the Korean-language ' +
+    '[CHANGELOG.md](https://github.com/JungHoonGhae/tossinvest-cli/blob/main/CHANGELOG.md) — entries are not yet translated). ' +
+    'Binaries and release notes for each version are also on ' +
+    '[GitHub Releases](https://github.com/JungHoonGhae/tossinvest-cli/releases).\n\n';
+  writeFileSync(
+    path.join(outDir, 'changelog.en.mdx'),
+    frontmatter + GENERATED_NOTICE + intro + body,
+  );
+}
+
+const body = loadBody();
+writeKo(body);
+writeEn(body);
+console.log('sync-changelog: wrote content/docs/changelog.mdx + changelog.en.mdx');


### PR DESCRIPTION
## 요약

- navbar에 "변경 이력" 링크 추가.
- 웹 changelog(`changelog.mdx`/`changelog.en.mdx`)를 저장소 루트 `CHANGELOG.md` 단일 소스에서 빌드 시 자동 생성하도록 변경 — 웹이 [0.12.0]에 멈춰 있던 드리프트를 원천 차단.
- navbar에 GitHub star 카운트 뱃지 추가 (fumadocs-ui 공식 `GithubInfo` 컴포넌트, 60초 revalidate).

## 세부

- `scripts/sync-changelog.mjs` — `../CHANGELOG.md`를 읽어 frontmatter를 씌워 KR/EN `changelog.mdx` 생성. EN 페이지는 영어 안내문 + 동일한 한국어 본문(별도 번역 없음).
- `dev`/`build`/`types:check` 스크립트가 생성 스크립트를 선행 실행하도록 배선. 앞으로 릴리즈 시 root CHANGELOG.md만 갱신하면 웹도 자동 반영됨.
- `baseOptions().nav.children`에 `GithubInfo` 추가 — Home/Docs 레이아웃 공통 적용, 데스크톱에서만 노출(`max-lg:hidden`), 기존 GitHub 아이콘 링크(모바일 메뉴)는 유지.

## 테스트

- `pnpm build` 성공 (changelog 라우트·OG 이미지 포함, GitHub API 실제 fetch까지 확인).
- `tsc --noEmit` clean.
