### PR TITLE
feat(cmd): tossctl update 커맨드 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,11 @@ Rules for agents:
 - Prefer `--json` for machine-readable output.
 - Treat `source: wts` results as best-effort; add a `monitor api` probe when you
   build automation on top of them.
+- **Don't auto-run `tossctl update`.** It changes the tossctl binary itself
+  (not account state), but an agent silently switching versions mid-task can
+  surprise the human running it — let a human trigger it, or run
+  `tossctl update --check` (read-only) if you need to know whether an update
+  exists.
 
 ## API 회귀 감지 → 알림
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ tossctl 사용자 관점의 변경 이력입니다. 각 버전에서 "무엇을 
 
 ## [Unreleased]
 
+### 새 기능
+- **`tossctl update`** — 설치 경로(Homebrew / install.sh·install.ps1 / 소스 빌드)를 자동 감지해 알맞은 방식으로 tossctl을 최신 버전으로 갱신합니다. `--check` 로 다운로드 없이 새 버전 여부만 확인, `--yes` 로 확인 프롬프트 생략 가능.
+
 ## [0.14.0] - 2026-07-01
 
 ### 새 기능

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ tossctl auth login
 tossctl account summary --output json
 ```
 
+설치 후 새 버전이 나오면 `tossctl update` 로 갱신할 수 있습니다 (Homebrew로 설치했다면 `brew upgrade tossctl-cli` 로 자동 위임됩니다).
+
 > `auth login`에는 Google Chrome과 Python이 필요하며, 설치 스크립트가 자동으로 설정합니다.
 > Windows, Homebrew, 소스 빌드 등 다른 설치 방법은 [설치](#설치) 섹션을 참고하세요.
 >

--- a/cmd/tossctl/root.go
+++ b/cmd/tossctl/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/JungHoonGhae/tossinvest-cli/internal/onboarding"
 	"github.com/JungHoonGhae/tossinvest-cli/internal/orderlineage"
 	"github.com/JungHoonGhae/tossinvest-cli/internal/output"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/selfupdate"
 	"github.com/JungHoonGhae/tossinvest-cli/internal/session"
 	"github.com/JungHoonGhae/tossinvest-cli/internal/trading"
 	"github.com/JungHoonGhae/tossinvest-cli/internal/tui"
@@ -132,6 +133,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		newInitCmd(opts),
 		newVersionCmd(opts),
+		newUpdateCmd(opts),
 		newDoctorCmd(opts),
 		newConfigCmd(opts),
 		newAuthCmd(opts),
@@ -316,13 +318,32 @@ func writeUpdateNoticeIfNeeded(ctx context.Context, stderr io.Writer, opts *root
 	configFile, _ := configFilePath(opts)
 	fmt.Fprintf(
 		stderr,
-		"\n✨ tossctl %s available (current %s) — `brew upgrade tossctl-cli` or %s\n   Disable: set update_check.enabled=false in %s\n",
+		"\n✨ tossctl %s available (current %s) — %s\n   Disable: set update_check.enabled=false in %s\n",
 		latest,
 		version.Version,
-		version.ReleasesLatestURL,
+		updateActionHint(version.Version),
 		configFile,
 	)
 	checker.MarkUpdateNotified()
+}
+
+// updateActionHint returns the right upgrade instruction for the running
+// binary's install method, so the "update available" nudge doesn't tell a
+// curl-installed user to run `brew upgrade` (or a brew user to run
+// `tossctl update`, which would just re-delegate to brew anyway but is a
+// confusing detour).
+func updateActionHint(currentVersion string) string {
+	execPath, err := os.Executable()
+	if err != nil {
+		return "`tossctl update` or " + version.ReleasesLatestURL
+	}
+	if resolved, err := filepath.EvalSymlinks(execPath); err == nil {
+		execPath = resolved
+	}
+	if selfupdate.DetectInstallMethod(execPath, currentVersion) == selfupdate.MethodHomebrew {
+		return "`brew upgrade tossctl-cli` or " + version.ReleasesLatestURL
+	}
+	return "`tossctl update` or " + version.ReleasesLatestURL
 }
 
 // newUpdateChecker constructs an updatecheck.Checker honoring update_check

--- a/cmd/tossctl/update.go
+++ b/cmd/tossctl/update.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/i18n"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/output"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/selfupdate"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/tui"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/updatecheck"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/version"
+	"github.com/spf13/cobra"
+)
+
+func newUpdateCmd(opts *rootOptions) *cobra.Command {
+	var assumeYes bool
+	var checkOnly bool
+
+	cmd := &cobra.Command{
+		Use:         "update",
+		Short:       i18n.T("update.short"),
+		Long:        i18n.T("update.long"),
+		Annotations: map[string]string{"source": "local"},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			format, err := output.ParseFormat(opts.outputFormat)
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+
+			execPath, err := os.Executable()
+			if err != nil {
+				return fmt.Errorf("resolving executable path: %w", err)
+			}
+			if resolved, err := filepath.EvalSymlinks(execPath); err == nil {
+				execPath = resolved
+			}
+			method := selfupdate.DetectInstallMethod(execPath, version.Version)
+
+			if method == selfupdate.MethodDev {
+				return selfupdate.ErrDevBuild
+			}
+
+			cachePath, err := resolveUpdateCachePath(opts)
+			if err != nil {
+				return fmt.Errorf("resolving update cache path: %w", err)
+			}
+			checker := updatecheck.New(cachePath)
+
+			var latest string
+			spinErr := tui.WithSpinner("Checking latest version", func() error {
+				latest = checker.LatestStable(cmd.Context())
+				return nil
+			})
+			if spinErr != nil {
+				return spinErr
+			}
+
+			updateAvailable := updatecheck.IsNewer(latest, version.Version)
+
+			if checkOnly {
+				return writeUpdateCheckResult(out, format, version.Version, latest, updateAvailable, method)
+			}
+
+			if !updateAvailable {
+				fmt.Fprintf(out, "Already up to date (v%s).\n", version.Version)
+				return nil
+			}
+
+			enabled := output.ColorEnabled(out, format)
+			if !assumeYes {
+				title := fmt.Sprintf(
+					"Update tossctl %s -> %s?",
+					version.Version,
+					output.StyleHighlight(latest, enabled),
+				)
+				confirmed, confirmErr := tui.Confirm(title)
+				switch {
+				case errors.Is(confirmErr, tui.ErrNotInteractive):
+					assumeYes = true
+				case confirmErr != nil:
+					return confirmErr
+				case !confirmed:
+					fmt.Fprintln(out, "Update canceled.")
+					return nil
+				}
+			}
+			if assumeYes {
+				fmt.Fprintf(out, "Updating %s -> %s...\n", version.Version, latest)
+			}
+
+			runErr := selfupdate.Run(cmd.Context(), selfupdate.Options{
+				Method: method,
+				Out:    out,
+				ErrOut: cmd.ErrOrStderr(),
+			})
+			if runErr != nil {
+				fmt.Fprintln(out, output.StyleFail(fmt.Sprintf("✗ Update failed: %v", runErr), enabled))
+				return runErr
+			}
+			if method == selfupdate.MethodBinary && runtime.GOOS == "windows" {
+				// install.ps1 is still running in the background at this
+				// point (see selfupdate.Run's Windows branch) — it hasn't
+				// necessarily finished replacing tossctl.exe yet, so we
+				// don't claim success here.
+				return nil
+			}
+			fmt.Fprintln(out, output.StyleSuccess(fmt.Sprintf("✓ Updated to v%s", latest), enabled))
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "skip the confirmation prompt (also implied when stdin/stdout are not a TTY)")
+	cmd.Flags().BoolVar(&checkOnly, "check", false, "only report whether an update is available; do not update")
+
+	return cmd
+}
+
+func writeUpdateCheckResult(out io.Writer, format output.Format, current, latest string, available bool, method selfupdate.InstallMethod) error {
+	if format == output.FormatJSON {
+		encoder := json.NewEncoder(out)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(map[string]any{
+			"current":          current,
+			"latest":           latest,
+			"update_available": available,
+			"install_method":   method.String(),
+		})
+	}
+	if available {
+		fmt.Fprintf(out, "Update available: %s -> %s (install method: %s)\n", current, latest, method.String())
+	} else {
+		fmt.Fprintf(out, "Already up to date (v%s).\n", current)
+	}
+	return nil
+}

--- a/cmd/tossctl/version.go
+++ b/cmd/tossctl/version.go
@@ -54,7 +54,7 @@ func newVersionCmd(opts *rootOptions) *cobra.Command {
 				if latest != "" {
 					suffix := ""
 					if updateAvailable {
-						suffix = " (update available — `brew upgrade tossctl-cli` or " + version.ReleasesLatestURL + ")"
+						suffix = " (update available — " + updateActionHint(info.Version) + ")"
 					}
 					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "latest: %s%s\n", latest, suffix); err != nil {
 						return err

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/JungHoonGhae/tossinvest-cli
 go 1.25.0
 
 require (
+	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
+	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/spf13/cobra v1.10.1
@@ -12,8 +14,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
-	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 // indirect
-	github.com/charmbracelet/bubbletea v1.3.6 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect

--- a/internal/i18n/en.json
+++ b/internal/i18n/en.json
@@ -1,5 +1,7 @@
 {
   "_meta.lang": "en",
+  "update.short": "Update tossctl to the latest version",
+  "update.long": "Detects how this tossctl binary was installed (Homebrew, install.sh/install.ps1, or a source build) and upgrades it using that same mechanism.",
   "account.list.short": "List available accounts",
   "account.short": "Read account-level data",
   "account.summary.short": "Show a summary for the selected account",

--- a/internal/i18n/ko.json
+++ b/internal/i18n/ko.json
@@ -1,5 +1,7 @@
 {
   "_meta.lang": "ko",
+  "update.short": "tossctl를 최신 버전으로 업데이트",
+  "update.long": "이 tossctl 바이너리가 어떻게 설치됐는지(Homebrew, install.sh/install.ps1, 또는 소스 빌드) 감지해 같은 방식으로 갱신합니다.",
   "account.list.short": "이용 가능한 계좌 목록 조회",
   "account.short": "계좌 단위 데이터 조회",
   "account.summary.short": "선택한 계좌의 요약 정보 표시",

--- a/internal/output/style.go
+++ b/internal/output/style.go
@@ -51,3 +51,43 @@ func profitText(s string, value float64, enabled bool) string {
 		return s
 	}
 }
+
+// ColorEnabled reports whether ANSI styling should be applied for w under
+// format — true only for table output on a real terminal with NO_COLOR
+// unset. Exported so commands outside this package (e.g. `tossctl update`)
+// can gate their own highlighted text using the same rule as the table
+// renderers in this package, instead of duplicating the NO_COLOR/TTY check.
+func ColorEnabled(w io.Writer, format Format) bool {
+	return colorEnabled(w, format)
+}
+
+var (
+	styleSuccess   = colorRenderer.NewStyle().Foreground(lipgloss.Color("10")) // 초록
+	styleFail      = colorRenderer.NewStyle().Foreground(lipgloss.Color("9"))  // 빨강
+	styleHighlight = colorRenderer.NewStyle().Bold(true).Foreground(lipgloss.Color("10"))
+)
+
+// StyleSuccess renders s in green when enabled, or returns s unchanged.
+func StyleSuccess(s string, enabled bool) string {
+	if !enabled {
+		return s
+	}
+	return styleSuccess.Render(s)
+}
+
+// StyleFail renders s in red when enabled, or returns s unchanged.
+func StyleFail(s string, enabled bool) string {
+	if !enabled {
+		return s
+	}
+	return styleFail.Render(s)
+}
+
+// StyleHighlight renders s in bold green when enabled, or returns s
+// unchanged (used e.g. for the target version in an update confirmation).
+func StyleHighlight(s string, enabled bool) string {
+	if !enabled {
+		return s
+	}
+	return styleHighlight.Render(s)
+}

--- a/internal/output/style_test.go
+++ b/internal/output/style_test.go
@@ -40,3 +40,42 @@ func TestProfitTextEnabledColors(t *testing.T) {
 		t.Fatal("up/down must differ")
 	}
 }
+
+func TestStyleSuccessDisabled(t *testing.T) {
+	if got := StyleSuccess("ok", false); got != "ok" {
+		t.Errorf("StyleSuccess with enabled=false = %q, want unchanged %q", got, "ok")
+	}
+}
+
+func TestStyleSuccessEnabled(t *testing.T) {
+	got := StyleSuccess("ok", true)
+	if got == "ok" {
+		t.Error("StyleSuccess with enabled=true should add ANSI styling, got unchanged string")
+	}
+}
+
+func TestStyleFailDisabled(t *testing.T) {
+	if got := StyleFail("bad", false); got != "bad" {
+		t.Errorf("StyleFail with enabled=false = %q, want unchanged %q", got, "bad")
+	}
+}
+
+func TestStyleFailEnabled(t *testing.T) {
+	got := StyleFail("bad", true)
+	if got == "bad" {
+		t.Error("StyleFail with enabled=true should add ANSI styling, got unchanged string")
+	}
+}
+
+func TestStyleHighlightDisabled(t *testing.T) {
+	if got := StyleHighlight("0.15.0", false); got != "0.15.0" {
+		t.Errorf("StyleHighlight with enabled=false = %q, want unchanged %q", got, "0.15.0")
+	}
+}
+
+func TestStyleHighlightEnabled(t *testing.T) {
+	got := StyleHighlight("0.15.0", true)
+	if got == "0.15.0" {
+		t.Error("StyleHighlight with enabled=true should add ANSI styling, got unchanged string")
+	}
+}

--- a/internal/selfupdate/method.go
+++ b/internal/selfupdate/method.go
@@ -1,0 +1,65 @@
+// Package selfupdate detects how the running tossctl binary was installed
+// and re-invokes the matching, already-tested upgrade mechanism (Homebrew,
+// or the install.sh/install.ps1 scripts) — it does not reimplement
+// download/checksum/extract logic itself.
+package selfupdate
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// InstallMethod identifies how the running tossctl binary was installed,
+// which determines how `tossctl update` should upgrade it.
+type InstallMethod int
+
+const (
+	// MethodDev is a source build (version.Version == "dev") — nothing to
+	// update to.
+	MethodDev InstallMethod = iota
+	// MethodHomebrew is managed by Homebrew — delegate to `brew upgrade`.
+	MethodHomebrew
+	// MethodBinary was installed by install.sh or install.ps1 — re-run the
+	// matching installer to fetch and swap in the latest release.
+	MethodBinary
+)
+
+func (m InstallMethod) String() string {
+	switch m {
+	case MethodDev:
+		return "dev"
+	case MethodHomebrew:
+		return "homebrew"
+	case MethodBinary:
+		return "binary"
+	default:
+		return "unknown"
+	}
+}
+
+// homebrewCellarPrefixes are path prefixes (after symlink resolution) that
+// indicate a Homebrew-managed install of the tossctl-cli formula, across the
+// three common Homebrew prefix locations (Apple Silicon, Intel, Linuxbrew).
+var homebrewCellarPrefixes = []string{
+	"/opt/homebrew/Cellar/tossctl-cli/",
+	"/usr/local/Cellar/tossctl-cli/",
+	"/home/linuxbrew/.linuxbrew/Cellar/tossctl-cli/",
+}
+
+// DetectInstallMethod classifies how the running binary at execPath was
+// installed. execPath should already be symlink-resolved by the caller
+// (typically via filepath.EvalSymlinks(os.Executable()) — Homebrew's `brew
+// link` puts a symlink in .../bin, and only the resolved Cellar path
+// contains the "Cellar/tossctl-cli/" segment this function looks for).
+func DetectInstallMethod(execPath, currentVersion string) InstallMethod {
+	if currentVersion == "dev" {
+		return MethodDev
+	}
+	normalized := filepath.ToSlash(execPath)
+	for _, prefix := range homebrewCellarPrefixes {
+		if strings.HasPrefix(normalized, prefix) {
+			return MethodHomebrew
+		}
+	}
+	return MethodBinary
+}

--- a/internal/selfupdate/method_test.go
+++ b/internal/selfupdate/method_test.go
@@ -1,0 +1,46 @@
+// internal/selfupdate/method_test.go
+package selfupdate
+
+import "testing"
+
+func TestDetectInstallMethod(t *testing.T) {
+	cases := []struct {
+		name     string
+		execPath string
+		version  string
+		want     InstallMethod
+	}{
+		{"dev build", "/usr/local/bin/tossctl", "dev", MethodDev},
+		{"dev build even under cellar path", "/opt/homebrew/Cellar/tossctl-cli/0.14.0/bin/tossctl", "dev", MethodDev},
+		{"homebrew apple silicon", "/opt/homebrew/Cellar/tossctl-cli/0.14.0/bin/tossctl", "0.14.0", MethodHomebrew},
+		{"homebrew intel", "/usr/local/Cellar/tossctl-cli/0.14.0/bin/tossctl", "0.14.0", MethodHomebrew},
+		{"homebrew linuxbrew", "/home/linuxbrew/.linuxbrew/Cellar/tossctl-cli/0.14.0/bin/tossctl", "0.14.0", MethodHomebrew},
+		{"install.sh binary in usr local bin", "/usr/local/bin/tossctl", "0.14.0", MethodBinary},
+		{"windows install.ps1 binary", `C:\Users\me\AppData\Local\tossctl\tossctl.exe`, "0.14.0", MethodBinary},
+		{"custom INSTALL_DIR binary", "/home/me/.local/bin/tossctl", "0.14.0", MethodBinary},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DetectInstallMethod(tc.execPath, tc.version)
+			if got != tc.want {
+				t.Errorf("DetectInstallMethod(%q, %q) = %v, want %v", tc.execPath, tc.version, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInstallMethodString(t *testing.T) {
+	cases := []struct {
+		m    InstallMethod
+		want string
+	}{
+		{MethodDev, "dev"},
+		{MethodHomebrew, "homebrew"},
+		{MethodBinary, "binary"},
+	}
+	for _, tc := range cases {
+		if got := tc.m.String(); got != tc.want {
+			t.Errorf("String() = %q, want %q", got, tc.want)
+		}
+	}
+}

--- a/internal/selfupdate/run.go
+++ b/internal/selfupdate/run.go
@@ -1,0 +1,90 @@
+package selfupdate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"runtime"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/version"
+)
+
+// Options configures Run.
+type Options struct {
+	// Method is the install method to act on — normally the result of
+	// DetectInstallMethod.
+	Method InstallMethod
+	// Out and ErrOut receive the child process's stdout/stderr, streamed
+	// live so users see brew/curl/install-script progress as it happens.
+	Out    io.Writer
+	ErrOut io.Writer
+}
+
+// ErrDevBuild is returned by Run when Options.Method is MethodDev — there is
+// nothing to update a source build to.
+var ErrDevBuild = errors.New("source build (dev) — use `git pull && make build` instead of `tossctl update`")
+
+// Run performs the upgrade for opts.Method:
+//   - MethodDev: returns ErrDevBuild without any I/O.
+//   - MethodHomebrew: runs `brew upgrade tossctl-cli` synchronously,
+//     relaying its output, and returns its error (if any) wrapped with
+//     context.
+//   - MethodBinary on non-Windows: re-runs install.sh via `sh -c 'curl ... |
+//     sh'` synchronously — safe because Unix allows replacing a running
+//     binary's directory entry without disturbing the currently-executing
+//     process.
+//   - MethodBinary on Windows: starts install.ps1 via PowerShell and returns
+//     immediately without waiting for it to finish. install.ps1 needs this
+//     process's file lock on tossctl.exe released before it can overwrite
+//     the binary, so Run hands off and lets the caller exit right after —
+//     it does not (and cannot, without duplicating install.ps1's own
+//     "tossctl is running" check) confirm the swap actually completed.
+func Run(ctx context.Context, opts Options) error {
+	switch opts.Method {
+	case MethodDev:
+		return ErrDevBuild
+	case MethodHomebrew:
+		cmd := exec.CommandContext(ctx, "brew", "upgrade", "tossctl-cli")
+		cmd.Stdout = opts.Out
+		cmd.Stderr = opts.ErrOut
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("brew upgrade tossctl-cli: %w", err)
+		}
+		return nil
+	case MethodBinary:
+		if runtime.GOOS == "windows" {
+			return runWindowsInstaller(opts)
+		}
+		return runUnixInstaller(ctx, opts)
+	default:
+		return fmt.Errorf("unknown install method %v", opts.Method)
+	}
+}
+
+func runUnixInstaller(ctx context.Context, opts Options) error {
+	script := fmt.Sprintf("curl -fsSL %s | sh", version.RawMainURL("install.sh"))
+	cmd := exec.CommandContext(ctx, "sh", "-c", script)
+	cmd.Stdout = opts.Out
+	cmd.Stderr = opts.ErrOut
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("running install.sh: %w", err)
+	}
+	return nil
+}
+
+func runWindowsInstaller(opts Options) error {
+	script := fmt.Sprintf("irm %s | iex", version.RawMainURL("install.ps1"))
+	// Intentionally exec.Command, not exec.CommandContext: this process is
+	// about to exit so the child can take over the file lock on tossctl.exe;
+	// tying its lifetime to our context would risk killing it on cancel.
+	cmd := exec.Command("powershell", "-NoProfile", "-Command", script)
+	cmd.Stdout = opts.Out
+	cmd.Stderr = opts.ErrOut
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting install.ps1: %w", err)
+	}
+	fmt.Fprintln(opts.Out, "Handed off to install.ps1 — this process will exit now so it can replace tossctl.exe.")
+	return nil
+}

--- a/internal/selfupdate/run_test.go
+++ b/internal/selfupdate/run_test.go
@@ -1,0 +1,30 @@
+package selfupdate
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+)
+
+func TestRunDevBuildReturnsErrDevBuild(t *testing.T) {
+	err := Run(context.Background(), Options{
+		Method: MethodDev,
+		Out:    io.Discard,
+		ErrOut: io.Discard,
+	})
+	if !errors.Is(err, ErrDevBuild) {
+		t.Fatalf("expected ErrDevBuild, got %v", err)
+	}
+}
+
+func TestRunUnknownMethodReturnsError(t *testing.T) {
+	err := Run(context.Background(), Options{
+		Method: InstallMethod(99),
+		Out:    io.Discard,
+		ErrOut: io.Discard,
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unknown InstallMethod, got nil")
+	}
+}

--- a/internal/tui/spinner.go
+++ b/internal/tui/spinner.go
@@ -1,0 +1,92 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// WithSpinner runs fn while showing an animated spinner next to label, when
+// stdin/stdout are a TTY. In non-interactive contexts (piped I/O, CI, agent
+// loops) it prints "label..." once, runs fn synchronously, and prints
+// "done"/"failed" on completion — no ANSI or animation, safe for logs.
+func WithSpinner(label string, fn func() error) error {
+	return withSpinnerWith(os.Stdin, os.Stdout, label, fn)
+}
+
+func withSpinnerWith(in, out *os.File, label string, fn func() error) error {
+	if !IsInteractive(in, out) {
+		fmt.Fprintf(out, "%s...\n", label)
+		err := fn()
+		if err != nil {
+			fmt.Fprintln(out, "failed")
+			return err
+		}
+		fmt.Fprintln(out, "done")
+		return nil
+	}
+
+	m := newSpinnerModel(label, fn)
+	p := tea.NewProgram(m, tea.WithInput(in), tea.WithOutput(out))
+	finalModel, err := p.Run()
+	if err != nil {
+		return err
+	}
+	fm, ok := finalModel.(*spinnerModel)
+	if !ok {
+		return nil
+	}
+	return fm.err
+}
+
+type spinnerModel struct {
+	label string
+	spin  spinner.Model
+	fn    func() error
+	err   error
+	done  bool
+}
+
+func newSpinnerModel(label string, fn func() error) *spinnerModel {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	return &spinnerModel{label: label, spin: s, fn: fn}
+}
+
+func (m *spinnerModel) Init() tea.Cmd {
+	return tea.Batch(m.spin.Tick, runFn(m.fn))
+}
+
+func (m *spinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case fnDoneMsg:
+		m.err = msg.err
+		m.done = true
+		return m, tea.Quit
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spin, cmd = m.spin.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m *spinnerModel) View() string {
+	if m.done {
+		return ""
+	}
+	return fmt.Sprintf("%s %s\n", m.spin.View(), m.label)
+}
+
+type fnDoneMsg struct{ err error }
+
+// runFn wraps fn as a tea.Cmd. Bubble Tea runs every returned tea.Cmd in its
+// own goroutine, so this is how the spinner keeps animating while fn (e.g. a
+// network call) runs in the background.
+func runFn(fn func() error) tea.Cmd {
+	return func() tea.Msg {
+		return fnDoneMsg{err: fn()}
+	}
+}

--- a/internal/tui/spinner_test.go
+++ b/internal/tui/spinner_test.go
@@ -1,0 +1,58 @@
+package tui
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestWithSpinnerNonInteractiveRunsFn(t *testing.T) {
+	r, w, _ := os.Pipe()
+	defer r.Close()
+	defer w.Close()
+
+	called := false
+	err := withSpinnerWith(r, w, "Checking latest version", func() error {
+		called = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("fn was not called")
+	}
+}
+
+func TestWithSpinnerNonInteractivePropagatesError(t *testing.T) {
+	r, w, _ := os.Pipe()
+	defer r.Close()
+	defer w.Close()
+
+	wantErr := errors.New("boom")
+	err := withSpinnerWith(r, w, "Checking latest version", func() error {
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+}
+
+func TestWithSpinnerNonInteractivePrintsLabelAndStatus(t *testing.T) {
+	r, w, _ := os.Pipe()
+	defer r.Close()
+	defer w.Close()
+
+	outR, outW, _ := os.Pipe()
+	go func() {
+		_ = withSpinnerWith(r, outW, "Checking latest version", func() error { return nil })
+		outW.Close()
+	}()
+	buf := make([]byte, 256)
+	n, _ := outR.Read(buf)
+	out := string(buf[:n])
+	if !strings.Contains(out, "Checking latest version") {
+		t.Errorf("expected output to contain label, got %q", out)
+	}
+}


### PR DESCRIPTION
## 요약

`tossctl update` 커맨드 추가 — 설치 경로(Homebrew / install.sh·install.ps1 / 소스 빌드)를 자동 감지해 알맞은 방식으로 갱신한다.

## 설계 결정

steipete(Peter Steinberger)가 자체 Homebrew tap으로 배포하는 Go CLI 16종을 조사한 결과 어느 것도 자체 self-update 로직을 구현하지 않음(전부 `brew upgrade`에 위임) — 이를 반영해 **다운로드·체크섬·압축해제를 Go로 재구현하지 않고**, 이미 검증된 `brew upgrade tossctl-cli` 또는 `install.sh`/`install.ps1`을 재호출하는 얇은 래퍼로 설계했다. 상세: `docs/superpowers/specs/2026-07-01-tossctl-update-design.md`.

## 변경

- `internal/selfupdate` — 설치 경로 감지(`DetectInstallMethod`) + 실행기(`Run`, brew/install.sh/install.ps1 재호출).
- `internal/output` — `ColorEnabled`/`StyleSuccess`/`StyleFail`/`StyleHighlight` export (기존 NO_COLOR 인지 팔레트 재사용).
- `internal/tui` — `WithSpinner` 헬퍼(charmbracelet/bubbles, 기존 간접 의존성 승격 — 새 모듈 추가 없음). huh/bubbles/bubbletea는 여전히 `internal/tui`에만 격리.
- `cmd/tossctl update` — `--yes`(확인 생략)/`--check`(다운로드 없이 버전만 확인) 지원, 인터랙티브 확인 프롬프트 + 비대화형 자동 대응.
- `version`/`root.go`의 기존 "업데이트 가능" 안내가 설치 경로별로 올바른 명령(`brew upgrade` vs `tossctl update`)을 안내하도록 통합.
- AGENTS.md/README.md/CHANGELOG.md 문서화.

## 프로세스

SDD(subagent-driven development)로 진행 — 7개 태스크 각각 구현→스펙/품질 리뷰 통과, 최종 전체 브랜치 리뷰(opus) 완료. 계획 문서 진행 중 플랜 자체의 테스트 버그(`defer w.Close()` 누락) 1건 발견·수정.

## 검증

- `go build ./... && go vet ./... && go test ./... -count=1` 전체 통과 (23개 패키지).
- go.mod 변경은 bubbles/bubbletea의 indirect→direct 승격뿐 (새 모듈 없음).
- 최종 리뷰: **MERGE-READY**, Critical/Important 없음. Minor 2건은 기존 `updatecheck` 캐시 설계·Homebrew tap 반영 지연 특성으로 이 브랜치의 회귀 아님(fix 안 함, PR 코멘트로 남김).
