### PR TITLE
docs: README·웹사이트 홍보 카피 정비 + 기능 숫자 정확도 검증

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,9 +6,10 @@
 
 <div align="center">
   <h1>tossinvest-cli</h1>
-  <p><strong>An unofficial Toss Securities CLI that connects AI agents to your brokerage — covers 100% of the official Open API's read &amp; trade scope, plus the Toss WTS features the official API doesn't expose (auto-routing when you connect an official key).</strong></p>
-  <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot and any AI agent drive Toss Securities accounts, quotes, and trades through one command interface (<code>tossctl</code>). It works just as well by hand in a terminal.</p>
-  <p><sub>Investor flows · market indices · Toss AI signals · screener · watchlist management · transaction ledger · real-time push · fractional orders · dry-run preview — <strong>Toss WTS features the official Open API doesn't expose.</strong> <a href="#support-scope">Full comparison ↓</a></sub></p>
+  <p><strong>Covers 100% of Toss Securities' official API — plus 20 WTS-only features you won't find there.</strong></p>
+  <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot — any AI agent drives Toss Securities accounts, quotes, and trades through one command interface (<code>tossctl</code>). Works just as well by hand in a terminal.</p>
+  <p><sub>Investor flows · market indices · AI signals · screener · watchlist management · transaction ledger · real-time push · fractional orders · dry-run preview — <strong>Toss WTS features the official API doesn't expose, all included.</strong> <a href="#support-scope">Full comparison ↓</a></sub></p>
+  <p><sub><em>An unofficial Toss Securities CLI for AI agents. Auto-routes through the official OAuth path when you connect an official key.</em></sub></p>
 </div>
 
 <p align="center">

--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 
 <div align="center">
   <h1>tossinvest-cli</h1>
-  <p><strong>Covers 100% of Toss Securities' official API — plus 20 WTS-only features you won't find there.</strong></p>
+  <p><strong>Covers 100% of Toss Securities' official API — plus 21 WTS-only features you won't find there.</strong></p>
   <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot — any AI agent drives Toss Securities accounts, quotes, and trades through one command interface (<code>tossctl</code>). Works just as well by hand in a terminal.</p>
   <p><sub>Investor flows · market indices · AI signals · screener · watchlist management · transaction ledger · real-time push · fractional orders · dry-run preview — <strong>Toss WTS features the official API doesn't expose, all included.</strong> <a href="#support-scope">Full comparison ↓</a></sub></p>
   <p><sub><em>An unofficial Toss Securities CLI for AI agents. Auto-routes through the official OAuth path when you connect an official key.</em></sub></p>
@@ -125,7 +125,7 @@ Waiting for approval in the Toss app on your phone...
 ## Support Scope
 
 > **tossctl covers 100% of the official Toss Open API's read & trade coverage — and goes beyond.**
-> It maps to every endpoint in the official [Open API docs](https://developers.tossinvest.com/docs) (accounts, holdings, quotes, orderbook, ticks, candles, price limits, sellable quantity, commissions, orders, …), and adds investor flows, market indices, AI signals, screener, watchlist management, transaction ledger, real-time push, fractional orders, dry-run preview, and more — **12+ features that aren't in the official API are tossctl-only.**
+> It maps to every endpoint in the official [Open API docs](https://developers.tossinvest.com/docs) (accounts, holdings, quotes, orderbook, ticks, candles, price limits, sellable quantity, commissions, orders, …), and adds investor flows, market indices, AI signals, screener, watchlist management, transaction ledger, real-time push, fractional orders, dry-run preview, and more — **21 features that aren't in the official API are tossctl-only.**
 
 <p align="center">
   <img src="docs/assets/api-comparison.en.svg" alt="tossctl vs official Open API (upcoming) coverage — tossctl is a superset" width="900" />
@@ -195,7 +195,7 @@ US limit prices choose interpretation via `--currency-mode`: `KRW` (default, con
 ### Why tossctl — the official API is a fraction of Toss
 
 The official Open API offers only **basic REST read/order** (~20 endpoints). Toss's
-own web app (WTS) actually uses **~430 meaningful read/trade endpoints** — that's
+own web app (WTS) actually uses **~440 meaningful read/trade endpoints** — that's
 after excluding noise like onboarding, KYC, terms, promotions, and telemetry.
 
 > **The official Open API covers only ~4% of that.** tossctl works across the
@@ -453,7 +453,7 @@ tossctl auth login|status|extend|doctor|logout
 ### API regression watch
 
 ```bash
-tossctl monitor api           # schema-probe 16 endpoints (parallel); exit 0 pass, 1 fail
+tossctl monitor api           # schema-probe 25 endpoints (parallel); exit 0 pass, 1 fail
 tossctl monitor api --quiet   # for cron
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 <div align="center">
   <h1>tossinvest-cli</h1>
-  <p><strong>토스증권 공식 API가 지원하는 범위를 100% 포함하고, 공식엔 없는 WTS 전용 기능 20가지를 더합니다.</strong></p>
+  <p><strong>토스증권 공식 API가 지원하는 범위를 100% 포함하고, 공식엔 없는 WTS 전용 기능 21가지를 더합니다.</strong></p>
   <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot — 어떤 AI 에이전트든 하나의 명령 체계(<code>tossctl</code>)로 토스증권 계좌·시세·거래를 다룹니다. 터미널에서 직접 써도 됩니다.</p>
   <p><sub>수급 · 시장지수 · AI 시그널 · 조건검색 · 관심종목 관리 · 거래내역 ledger · 실시간 푸시 · 원화 소수점 주문 · dry-run preview — <strong>공식 API엔 없는 토스 WTS 기능까지 전부 포함합니다.</strong> <a href="#지원-범위">전체 비교표 ↓</a></sub></p>
-  <p><sub><em>An unofficial Toss Securities CLI for AI agents. Covers 100% of the official Open API — plus 20 WTS-only features you won't find there.</em></sub></p>
+  <p><sub><em>An unofficial Toss Securities CLI for AI agents. Covers 100% of the official Open API — plus 21 WTS-only features you won't find there.</em></sub></p>
 </div>
 
 <p align="center">
@@ -181,7 +181,7 @@ Waiting for approval in the Toss app on your phone...
 ## 지원 범위
 
 > **tossctl 은 토스 공식 Open API 의 조회·거래 범위를 100% 커버하고, 그 너머까지 다룹니다.**
-> 공식 [Open API 문서](https://developers.tossinvest.com/docs)의 모든 엔드포인트(계좌·잔고·시세·호가·체결·캔들·상하한가·매도가능수량·수수료·주문 등)에 대응하며, 추가로 수급·시장지수·AI 시그널·조건검색·관심종목 관리·거래내역 ledger·실시간 푸시·원화 소수점 주문·dry-run preview 등 **12개 이상이 공식에 없는 tossctl 고유 범위**입니다.
+> 공식 [Open API 문서](https://developers.tossinvest.com/docs)의 모든 엔드포인트(계좌·잔고·시세·호가·체결·캔들·상하한가·매도가능수량·수수료·주문 등)에 대응하며, 추가로 수급·시장지수·AI 시그널·조건검색·관심종목 관리·거래내역 ledger·실시간 푸시·원화 소수점 주문·dry-run preview 등 **21개가 공식에 없는 tossctl 고유 범위**입니다.
 
 <p align="center">
   <img src="docs/assets/api-comparison.svg" alt="tossctl vs 공식 Open API(예정) 커버리지 비교 — tossctl 이 상위집합" width="840" />
@@ -256,7 +256,7 @@ US 지정가는 `--currency-mode`로 가격 해석을 선택합니다: `KRW` (�
 ### 왜 tossctl 인가 — 공식 API 는 토스 기능의 일부일 뿐
 
 공식 Open API 는 **REST 조회·주문의 기본만** 제공합니다 (약 20개 엔드포인트). 반면
-토스 웹앱(WTS)이 실제로 쓰는 **의미있는 조회·거래 기능은 ~430개** — 온보딩·KYC·약관·
+토스 웹앱(WTS)이 실제로 쓰는 **의미있는 조회·거래 기능은 ~440개** — 온보딩·KYC·약관·
 프로모션·텔레메트리 같은 무의미한 엔드포인트는 뺀 숫자입니다.
 
 > **공식 Open API 는 그중 약 4%만 커버합니다.** tossctl 은 나머지 범위 위에서 동작하며,
@@ -542,7 +542,7 @@ tossctl openapi logout      # 자격증명 파일 삭제
 ### API 회귀 감시
 
 ```bash
-tossctl monitor api           # 16개 endpoint schema probe (병렬); exit 0 통과, 1 실패
+tossctl monitor api           # 25개 endpoint schema probe (병렬); exit 0 통과, 1 실패
 tossctl monitor api --quiet   # cron 용
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 <div align="center">
   <h1>tossinvest-cli</h1>
-  <p><strong>AI 에이전트를 토스증권에 연결하는 비공식 CLI — 공식 Open API 범위는 100% 포함하고, 토스 WTS(웹)엔 있지만 공식 API엔 없는 기능까지 다룹니다(공식 키 연결 시 자동 라우팅).</strong></p>
-  <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot 등 어떤 AI 에이전트든 동일한 명령 체계(<code>tossctl</code>)로 토스증권 계좌·시세·거래를 다룰 수 있습니다. 사람이 직접 터미널에서 쓸 수도 있습니다.</p>
-  <p><sub>수급 · 시장지수 · 토스 AI 시그널 · 조건검색(스크리너) · 관심종목 관리 · 거래내역 ledger · 실시간 푸시 · 원화 소수점 주문 · dry-run preview — <strong>공식 Open API엔 없는 토스 WTS 고유 영역까지</strong> 커버합니다. <a href="#지원-범위">전체 비교표 ↓</a></sub></p>
-  <p><sub><em>An unofficial Toss Securities CLI for AI agents — a superset of the official Open API: 100% of its read &amp; trade coverage, plus more.</em></sub></p>
+  <p><strong>토스증권 공식 API가 지원하는 범위를 100% 포함하고, 공식엔 없는 WTS 전용 기능 20가지를 더합니다.</strong></p>
+  <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot — 어떤 AI 에이전트든 하나의 명령 체계(<code>tossctl</code>)로 토스증권 계좌·시세·거래를 다룹니다. 터미널에서 직접 써도 됩니다.</p>
+  <p><sub>수급 · 시장지수 · AI 시그널 · 조건검색 · 관심종목 관리 · 거래내역 ledger · 실시간 푸시 · 원화 소수점 주문 · dry-run preview — <strong>공식 API엔 없는 토스 WTS 기능까지 전부 포함합니다.</strong> <a href="#지원-범위">전체 비교표 ↓</a></sub></p>
+  <p><sub><em>An unofficial Toss Securities CLI for AI agents. Covers 100% of the official Open API — plus 20 WTS-only features you won't find there.</em></sub></p>
 </div>
 
 <p align="center">

--- a/website-fumadocs/app/[lang]/(home)/page.tsx
+++ b/website-fumadocs/app/[lang]/(home)/page.tsx
@@ -43,11 +43,11 @@ const content = {
     thesis: {
       label: '왜 지금',
       headline: '공식 API, 기다릴 필요 없습니다',
-      body: '토스증권 공식 Open API가 여는 범위는 토스 WTS 전체 기능의 약 4%뿐입니다. tossctl은 그 범위를 100% 포함하고, 공식엔 없는 토스 WTS 고유 기능 18개를 더해 총 27개를 제공합니다. 공식 키를 등록하면 해당 기능은 공식 OAuth 경로로 자동 라우팅되어 더 안정적입니다. 신청이나 승인 없이 바로 시작할 수 있습니다.',
+      body: '토스증권 공식 Open API가 여는 범위는 토스 WTS 전체 기능의 약 4%뿐입니다. tossctl은 그 범위를 100% 포함하고, 공식엔 없는 토스 WTS 고유 기능 21개를 더해 총 40개를 제공합니다. 공식 키를 등록하면 해당 기능은 공식 OAuth 경로로 자동 라우팅되어 더 안정적입니다. 신청이나 승인 없이 바로 시작할 수 있습니다.',
       points: [
-        { k: '공식은 약 4%', v: '공식 Open API는 토스 WTS 기능 ~430개 중 약 4%만 엽니다.' },
+        { k: '공식은 약 4%', v: '공식 Open API는 토스 WTS 기능 ~440개 중 약 4%만 엽니다.' },
         { k: '공식 전부 100% 커버', v: '공식이 여는 범위를 빠짐없이 100% 포함합니다. 공식 키를 연결하면 OAuth 경로로 더 안정적으로 동작합니다.' },
-        { k: 'WTS 기능 18개 추가', v: '토스 WTS엔 있지만 공식 API엔 없는 수급·지수·AI 시그널·스크리너·배당 등 18개까지. 합계 27개.' },
+        { k: 'WTS 기능 21개 추가', v: '토스 WTS엔 있지만 공식 API엔 없는 수급·지수·AI 시그널·스크리너·배당 등 21개까지. 합계 40개.' },
         { k: '에이전트 연동', v: '모든 명령이 JSON으로 출력되어 AI 에이전트와 바로 연동됩니다.' },
       ],
     },
@@ -62,17 +62,17 @@ const content = {
     compareLead: (
       <>
         공식 지원 전부(<span className="text-brand-200">100% 커버</span>) +
-        고유 <span className="text-brand-200">18개</span> = 총 <span className="text-brand-200">27개</span>
+        고유 <span className="text-brand-200">21개</span> = 총 <span className="text-brand-200">40개</span>
       </>
     ),
     stats: [
       { n: '약 4%', l: '공식 Open API가 여는 토스 WTS 기능 비중' },
-      { n: '18', l: '공식 API엔 없는 토스 WTS 기능' },
-      { n: '27', l: '공식 지원 전부 + 고유 18 = tossctl 총 기능 수' },
+      { n: '21', l: '공식 API엔 없는 토스 WTS 기능' },
+      { n: '40', l: '공식 지원 전부 + 고유 21 = tossctl 총 기능 수' },
     ],
     coverage: {
       bright: '공식 Open API · 토스 WTS의 약 4%',
-      dim: '토스 WTS 전체 기능 ~430개',
+      dim: '토스 WTS 전체 기능 ~440개',
       note: 'tossctl은 공식이 다루는 약 4%를 100% 포함하고, 공식에 없는 나머지 WTS 기능까지 넓혀갑니다.',
     },
     official: {
@@ -82,7 +82,7 @@ const content = {
     },
     toss: {
       name: 'tossctl',
-      note: '공식 전부 100% 커버 + 고유 18 = 총 27개',
+      note: '공식 전부 100% 커버 + 고유 21 = 총 40개',
       items: [
         '공식 지원 기능 전부 (공식 키 연결 시 OAuth 경로로 더 안정적)',
         '수급·시장지수·지수 상세·업종 등락',
@@ -157,11 +157,11 @@ const content = {
     thesis: {
       label: 'WHY NOW',
       headline: "You don't have to wait for the official API",
-      body: "Toss Securities' official Open API opens only about 4% of the full Toss WTS feature set. tossctl covers that 100% and adds 18 more Toss WTS features the official API doesn't expose, for a total of 27. Plug in an official key and those features auto-route through OAuth for extra stability. No application, no approval to start.",
+      body: "Toss Securities' official Open API opens only about 4% of the full Toss WTS feature set. tossctl covers that 100% and adds 21 more Toss WTS features the official API doesn't expose, for a total of 40. Plug in an official key and those features auto-route through OAuth for extra stability. No application, no approval to start.",
       points: [
-        { k: 'Official ≈ 4%', v: 'Of ~430 Toss WTS features, the official Open API opens only about 4%.' },
+        { k: 'Official ≈ 4%', v: 'Of ~440 Toss WTS features, the official Open API opens only about 4%.' },
         { k: '100% of official covered', v: "tossctl covers the official's whole area 100%. Add an official key and it routes through OAuth (more stable, auto-renewing)." },
-        { k: '+18 WTS features', v: "Flows, indices, AI signals, screener, dividends: 18 Toss WTS features the official API doesn't expose. Total: 27." },
+        { k: '+21 WTS features', v: "Flows, indices, AI signals, screener, dividends: 21 Toss WTS features the official API doesn't expose. Total: 40." },
         { k: 'Agents included', v: 'Every command answers in JSON, so people and agents use it the same way.' },
       ],
     },
@@ -176,17 +176,17 @@ const content = {
     compareLead: (
       <>
         All official-supported features (<span className="text-brand-200">100% covered</span>) +{' '}
-        <span className="text-brand-200">18</span> unique = <span className="text-brand-200">27 total</span>
+        <span className="text-brand-200">21</span> unique = <span className="text-brand-200">40 total</span>
       </>
     ),
     stats: [
       { n: '~4%', l: 'of Toss WTS features the official API opens' },
-      { n: '18', l: "Toss WTS features the official API doesn't expose" },
-      { n: '27', l: 'total: all official-supported + 18 unique' },
+      { n: '21', l: "Toss WTS features the official API doesn't expose" },
+      { n: '40', l: 'total: all official-supported + 21 unique' },
     ],
     coverage: {
       bright: 'Official Open API · ~4% of WTS',
-      dim: '~430 total Toss WTS features',
+      dim: '~440 total Toss WTS features',
       note: 'tossctl covers 100% of the official ~4% and keeps expanding into the rest of WTS.',
     },
     official: {
@@ -196,7 +196,7 @@ const content = {
     },
     toss: {
       name: 'tossctl',
-      note: '100% of official + 18 unique = 27 total',
+      note: '100% of official + 21 unique = 40 total',
       items: [
         'All official-supported features (official key unlocks OAuth routing)',
         'Flows · indices · index detail · sectors',

--- a/website-fumadocs/app/[lang]/(home)/page.tsx
+++ b/website-fumadocs/app/[lang]/(home)/page.tsx
@@ -43,12 +43,12 @@ const content = {
     thesis: {
       label: '왜 지금',
       headline: '공식 API, 기다릴 필요 없습니다',
-      body: '토스증권 공식 Open API가 여는 범위는 토스 WTS 전체 기능의 약 4%뿐입니다. tossctl은 그 범위를 100% 포함하고, 공식엔 없는 토스 WTS 고유 기능 21개를 더해 총 40개를 제공합니다. 공식 키를 등록하면 해당 기능은 공식 OAuth 경로로 자동 라우팅되어 더 안정적입니다. 신청이나 승인 없이 바로 시작할 수 있습니다.',
+      body: 'tossctl은 공식 Open API 지원 범위를 100% 포함하고, 공식엔 없는 토스 WTS 고유 기능 21개를 더해 총 40개를 하나의 명령 체계로 제공합니다. 신청·승인 없이 지금 바로 시작할 수 있고, 공식 키를 연결하면 해당 기능은 자동으로 OAuth 경로로 라우팅돼 더 안정적입니다. 공식이 여는 범위는 토스 WTS 전체의 약 4%뿐이라, tossctl이 그만큼 더 넓은 영역을 커버합니다.',
       points: [
-        { k: '공식은 약 4%', v: '공식 Open API는 토스 WTS 기능 ~440개 중 약 4%만 엽니다.' },
         { k: '공식 전부 100% 커버', v: '공식이 여는 범위를 빠짐없이 100% 포함합니다. 공식 키를 연결하면 OAuth 경로로 더 안정적으로 동작합니다.' },
         { k: 'WTS 기능 21개 추가', v: '토스 WTS엔 있지만 공식 API엔 없는 수급·지수·AI 시그널·스크리너·배당 등 21개까지. 합계 40개.' },
         { k: '에이전트 연동', v: '모든 명령이 JSON으로 출력되어 AI 에이전트와 바로 연동됩니다.' },
+        { k: '공식은 약 4%', v: '공식 Open API는 토스 WTS 기능 ~440개 중 약 4%만 엽니다. tossctl은 그 너머까지 다룹니다.' },
       ],
     },
     why: {
@@ -66,9 +66,9 @@ const content = {
       </>
     ),
     stats: [
-      { n: '약 4%', l: '공식 Open API가 여는 토스 WTS 기능 비중' },
-      { n: '21', l: '공식 API엔 없는 토스 WTS 기능' },
       { n: '40', l: '공식 지원 전부 + 고유 21 = tossctl 총 기능 수' },
+      { n: '21', l: '공식 API엔 없는 토스 WTS 기능' },
+      { n: '약 4%', l: '(참고) 공식 Open API가 여는 토스 WTS 기능 비중' },
     ],
     coverage: {
       bright: '공식 Open API · 토스 WTS의 약 4%',
@@ -157,12 +157,12 @@ const content = {
     thesis: {
       label: 'WHY NOW',
       headline: "You don't have to wait for the official API",
-      body: "Toss Securities' official Open API opens only about 4% of the full Toss WTS feature set. tossctl covers that 100% and adds 21 more Toss WTS features the official API doesn't expose, for a total of 40. Plug in an official key and those features auto-route through OAuth for extra stability. No application, no approval to start.",
+      body: "tossctl covers 100% of the official Open API's supported range and adds 21 more Toss WTS features the official API doesn't expose, for a total of 40 — all through one command interface. No application, no approval, start right now. Connect an official key and those features auto-route through OAuth for extra stability. The official API only opens about 4% of the full Toss WTS surface, so tossctl reaches a lot further.",
       points: [
-        { k: 'Official ≈ 4%', v: 'Of ~440 Toss WTS features, the official Open API opens only about 4%.' },
         { k: '100% of official covered', v: "tossctl covers the official's whole area 100%. Add an official key and it routes through OAuth (more stable, auto-renewing)." },
         { k: '+21 WTS features', v: "Flows, indices, AI signals, screener, dividends: 21 Toss WTS features the official API doesn't expose. Total: 40." },
         { k: 'Agents included', v: 'Every command answers in JSON, so people and agents use it the same way.' },
+        { k: 'Official ≈ 4%', v: 'Of ~440 Toss WTS features, the official Open API opens only about 4% — tossctl covers the rest too.' },
       ],
     },
     why: {
@@ -180,9 +180,9 @@ const content = {
       </>
     ),
     stats: [
-      { n: '~4%', l: 'of Toss WTS features the official API opens' },
-      { n: '21', l: "Toss WTS features the official API doesn't expose" },
       { n: '40', l: 'total: all official-supported + 21 unique' },
+      { n: '21', l: "Toss WTS features the official API doesn't expose" },
+      { n: '~4%', l: '(for context) of Toss WTS features the official API opens' },
     ],
     coverage: {
       bright: 'Official Open API · ~4% of WTS',


### PR DESCRIPTION
## 요약

README·웹사이트 홍보 카피 정비 — 품질을 공식 제품급으로 다듬되, "비공식"이라는 사실은 그대로 명시 유지(WARNING 배너로 고지 위치만 이동, 삭제 아님).

## 변경

**카피 품질**
- 헤드라인을 만연체에서 능력치 중심 확신형 문장으로
- "공식 API"와 "기능 개수"를 다른 절로 분리해 숫자가 API 개수로 오독되지 않게 함
- 4% 통계(공식 API가 여는 범위) 강조를 완화 — tossctl 자체 가치(100%+21=40)를 먼저 말하고, 4%는 보조 근거로 뒤에 배치. 공식 API를 깎아내리는 톤 방지.

**숫자 정확도 (전수 재검증)**
비교표를 프로그램적으로 정밀 파싱해 실제 개수 확인, 여러 릴리즈 지나며 stale해진 숫자들을 수정:

| 항목 | 기존 | 실제 |
|---|---|---|
| WTS 전용 기능 | 18개 / 12+ | **21개** |
| 총 기능 수 | 27개 | **40개** (공식커버 19 + WTS전용 21) |
| WTS 전체 기능 | ~430개 | **~440개** |
| monitor probe | 16개 | **25개** |

공식 엔드포인트 수(~20개)는 `.openapi-snapshot.json`과 대조해 이미 정확해서 안 건드림.

## 검증

- `npx tsc --noEmit` 클린
- README 앵커/링크 무변경 확인
