### PR TITLE
docs: '공식' 표현 명확화 — WTS와 공식 Open API 구분

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -172,7 +172,7 @@ The Toss Securities official Open API is currently **rolling out in stages to pr
 | **Transaction ledger** | `transactions list --market us\|kr` (trades · transfers · dividends) | ❌ | ✅ |
 | **Cash overview** | `transactions overview --market us\|kr` (orderable · withdrawable · incoming) | ❌ | ✅ |
 | **CSV export** | `export positions\|orders --market`, `transactions list --output csv` | ❌ | ✅ |
-| **Real-time push** | `push listen` (SSE stream — order/price change events) | ❌ *(official is REST only)* | ✅ |
+| **Real-time push** | `push listen` (SSE stream — order/price change events) | ❌ *(official API is REST only)* | ✅ |
 
 ### Trading
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <div align="center">
   <h1>tossinvest-cli</h1>
-  <p><strong>토스증권 공식 API가 지원하는 범위를 100% 포함하고, 공식엔 없는 WTS 전용 기능 21가지를 더합니다.</strong></p>
+  <p><strong>토스증권 공식 API가 지원하는 범위를 100% 포함하고, 공식 API엔 없는 WTS 전용 기능 21가지를 더합니다.</strong></p>
   <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot — 어떤 AI 에이전트든 하나의 명령 체계(<code>tossctl</code>)로 토스증권 계좌·시세·거래를 다룹니다. 터미널에서 직접 써도 됩니다.</p>
   <p><sub>수급 · 시장지수 · AI 시그널 · 조건검색 · 관심종목 관리 · 거래내역 ledger · 실시간 푸시 · 원화 소수점 주문 · dry-run preview — <strong>공식 API엔 없는 토스 WTS 기능까지 전부 포함합니다.</strong> <a href="#지원-범위">전체 비교표 ↓</a></sub></p>
   <p><sub><em>An unofficial Toss Securities CLI for AI agents. Covers 100% of the official Open API — plus 21 WTS-only features you won't find there.</em></sub></p>
@@ -91,7 +91,7 @@
 ## 공식 Open API 자동 라우팅 <!--since:2026-06-27-->
 
 tossctl은 웹 세션(WTS)만으로도 전부 동작합니다. 토스 공식 Open API 키를 선택적으로
-연결하면 공식이 지원하는 기능은 공식 OAuth 경로로, 나머지는 WTS로 각각 처리하는 **자동
+연결하면 공식 Open API가 지원하는 기능은 공식 API OAuth 경로로, 나머지는 WTS로 각각 처리하는 **자동
 라우팅**이 켜집니다. 키 없이도 모든 기능을 쓸 수 있고, 원하는 시점에 추가할 수 있습니다.
 
 > 공식 Open API 와 WTS 웹 세션의 차이(인증·갱신·커버리지·안정성), IP 자동 등록, 라우팅
@@ -103,7 +103,7 @@ tossctl init                          # 온보딩 위저드 (처음 설정 시)
 tossctl openapi login                 # 공식 키 등록 (환경변수도 지원)
 tossctl openapi status                # 키·토큰·허용 IP·라우팅 진단
 tossctl openapi test                  # 연결 검증
-tossctl account summary --backend openapi  # 공식 경로 강제 (선택)
+tossctl account summary --backend openapi  # 공식 API 경로 강제 (선택)
 ```
 
 키를 연결하면 CI·서버·에이전트에서 사람 개입 없이 토큰이 자동 갱신됩니다.
@@ -181,7 +181,7 @@ Waiting for approval in the Toss app on your phone...
 ## 지원 범위
 
 > **tossctl 은 토스 공식 Open API 의 조회·거래 범위를 100% 커버하고, 그 너머까지 다룹니다.**
-> 공식 [Open API 문서](https://developers.tossinvest.com/docs)의 모든 엔드포인트(계좌·잔고·시세·호가·체결·캔들·상하한가·매도가능수량·수수료·주문 등)에 대응하며, 추가로 수급·시장지수·AI 시그널·조건검색·관심종목 관리·거래내역 ledger·실시간 푸시·원화 소수점 주문·dry-run preview 등 **21개가 공식에 없는 tossctl 고유 범위**입니다.
+> 공식 [Open API 문서](https://developers.tossinvest.com/docs)의 모든 엔드포인트(계좌·잔고·시세·호가·체결·캔들·상하한가·매도가능수량·수수료·주문 등)에 대응하며, 추가로 수급·시장지수·AI 시그널·조건검색·관심종목 관리·거래내역 ledger·실시간 푸시·원화 소수점 주문·dry-run preview 등 **21개가 공식 Open API에 없는 tossctl 고유 범위**입니다.
 
 <p align="center">
   <img src="docs/assets/api-comparison.svg" alt="tossctl vs 공식 Open API(예정) 커버리지 비교 — tossctl 이 상위집합" width="840" />
@@ -190,7 +190,7 @@ Waiting for approval in the Toss app on your phone...
 토스증권 공식 Open API 는 현재 **사전 신청자 대상으로 단계적 롤아웃** 중이며, REST only 의
 좁은 범위입니다 (공식 문서: <https://developers.tossinvest.com/docs>). 아래 표의
 `공식 API (예정)` 칼럼은 그 문서 기준 공식이 커버하는 범위이고, `tossctl` 칼럼은 우리가
-제공하는 범위입니다. **공식의 ✅ 행은 tossctl 도 전부 ✅ — 즉 공식 범위를 100% 커버합니다.**
+제공하는 범위입니다. **공식 Open API의 ✅ 행은 tossctl 도 전부 ✅ — 즉 공식 Open API 범위를 100% 커버합니다.**
 
 - ✅ 지원 · ❌ 미지원 · 🔸 부분 지원 · 🆕 최근 한 달 내 새로 추가된 기능
 - **`공식 API (예정)` 칼럼 = 공개 문서 기준 예상 커버리지** (사전 신청자 단계적 롤아웃 — 변동 가능).
@@ -232,7 +232,7 @@ Waiting for approval in the Toss app on your phone...
 | **거래내역 ledger** | `transactions list --market us\|kr` (매매·입출금·배당·입출고) | ❌ | ✅ |
 | **현금 overview** | `transactions overview --market us\|kr` (주문가능·출금가능·예정입금) | ❌ | ✅ |
 | **CSV 내보내기** | `export positions\|orders --market`, `transactions list --output csv` | ❌ | ✅ |
-| **실시간 푸시** | `push listen` (SSE 스트림 — 주문/가격 변경 알림) | ❌ *(공식 REST only)* | ✅ |
+| **실시간 푸시** | `push listen` (SSE 스트림 — 주문/가격 변경 알림) | ❌ *(공식 API REST only)* | ✅ |
 
 ### 거래
 
@@ -260,15 +260,15 @@ US 지정가는 `--currency-mode`로 가격 해석을 선택합니다: `KRW` (�
 프로모션·텔레메트리 같은 무의미한 엔드포인트는 뺀 숫자입니다.
 
 > **공식 Open API 는 그중 약 4%만 커버합니다.** tossctl 은 나머지 범위 위에서 동작하며,
-> 공식에 없는 기능(수급·시장지수·AI 시그널·스크리너·투자자별 순매수·어닝콜·배당 내역·
+> 공식 Open API에 없는 기능(수급·시장지수·AI 시그널·스크리너·투자자별 순매수·어닝콜·배당 내역·
 > 커뮤니티 랭킹·업종별 등락·뉴스 브리핑·실시간 푸시·원화 소수점 주문·dry-run preview 등)을 이미 제공하고,
 > **남은 의미있는 범위를 계속 구현해 나갑니다.**
 
 장기적으로 tossctl 이 더 나은 이유:
 
-- **범위** — 공식은 좁은 영역을 단계적으로 천천히 엽니다. tossctl 은 웹 전체(아래 카탈로그)를 추적해 골라 구현하므로 항상 더 넓습니다.
-- **속도** — 새 기능은 어느 플랫폼이든 자사 앱에서 가장 빠르게 통합되므로 늘 웹앱(WTS)에 먼저 실리고, 외부 공개용 API 는 안정적인 범위만 뒤따라 엽니다(누구의 잘못이 아니라 구조적으로 자연스러운 일). tossctl 은 주간 모니터로 신규 엔드포인트를 잡아 **공식 출시를 기다리지 않고 먼저 구현**합니다. [왜 공식 API가 늦는지 ↗](https://tossinvest-cli.vercel.app/docs/guide/hybrid-openapi)
-- **상위호환** — 공식이 커버하는 범위는 [이미 100% 지원](#지원-범위)합니다 (공식이 따라와도 우리가 앞섭니다).
+- **범위** — 공식 Open API는 좁은 영역을 단계적으로 천천히 엽니다. tossctl 은 웹 전체(아래 카탈로그)를 추적해 골라 구현하므로 항상 더 넓습니다.
+- **속도** — 새 기능은 어느 플랫폼이든 자사 앱에서 가장 빠르게 통합되므로 늘 웹앱(WTS)에 먼저 실리고, 외부 공개용 API 는 안정적인 범위만 뒤따라 엽니다(누구의 잘못이 아니라 구조적으로 자연스러운 일). tossctl 은 주간 모니터로 신규 엔드포인트를 잡아 **공식 Open API 출시를 기다리지 않고 먼저 구현**합니다. [왜 공식 API가 늦는지 ↗](https://tossinvest-cli.vercel.app/docs/guide/hybrid-openapi)
+- **상위호환** — 공식 Open API가 커버하는 범위는 [이미 100% 지원](#지원-범위)합니다 (공식 Open API가 따라와도 우리가 앞섭니다).
 - **안정성(복원력)** — 공식 Open API 는 엔드포인트 그룹별 초당 1~10회로 제한됩니다(계좌 조회가 **초당 1회**로 가장 빡빡). 빠르게 반복하면 10번 중 8번이 막혀요(실측 3개 시점). tossctl 은 막히면 **곧바로 웹 세션으로 우회**해 데이터를 가져오므로 사용자는 막힌 줄도 모르고 항상 성공합니다 — 자동매매·대시보드처럼 계속 불러야 할 때 차이가 큽니다. (한도 숫자는 토스 정책에 따라 바뀔 수 있어도 '막히면 우회'하는 구조는 그대로.) [공식 한도 표 + 실측 ↗](docs/migration/open-api.md#rate-limit-실측)
 
 #### WTS 웹 API 카탈로그 (지속 추적)

--- a/website-fumadocs/app/[lang]/(home)/page.tsx
+++ b/website-fumadocs/app/[lang]/(home)/page.tsx
@@ -43,37 +43,37 @@ const content = {
     thesis: {
       label: '왜 지금',
       headline: '공식 API, 기다릴 필요 없습니다',
-      body: 'tossctl은 공식 Open API 지원 범위를 100% 포함하고, 공식엔 없는 토스 WTS 고유 기능 21개를 더해 총 40개를 하나의 명령 체계로 제공합니다. 신청·승인 없이 지금 바로 시작할 수 있고, 공식 키를 연결하면 해당 기능은 자동으로 OAuth 경로로 라우팅돼 더 안정적입니다. 공식이 여는 범위는 토스 WTS 전체의 약 4%뿐이라, tossctl이 그만큼 더 넓은 영역을 커버합니다.',
+      body: 'tossctl은 공식 Open API 지원 범위를 100% 포함하고, 공식 Open API엔 없는 토스 WTS 고유 기능 21개를 더해 총 40개를 하나의 명령 체계로 제공합니다. 신청·승인 없이 지금 바로 시작할 수 있고, 공식 키를 연결하면 해당 기능은 자동으로 OAuth 경로로 라우팅돼 더 안정적입니다. 공식 Open API가 여는 범위는 토스 WTS 전체의 약 4%뿐이라, tossctl이 그만큼 더 넓은 영역을 커버합니다.',
       points: [
-        { k: '공식 전부 100% 커버', v: '공식이 여는 범위를 빠짐없이 100% 포함합니다. 공식 키를 연결하면 OAuth 경로로 더 안정적으로 동작합니다.' },
+        { k: '공식 Open API 전부 100% 커버', v: '공식 Open API가 여는 범위를 빠짐없이 100% 포함합니다. 공식 키를 연결하면 OAuth 경로로 더 안정적으로 동작합니다.' },
         { k: 'WTS 기능 21개 추가', v: '토스 WTS엔 있지만 공식 API엔 없는 수급·지수·AI 시그널·스크리너·배당 등 21개까지. 합계 40개.' },
         { k: '에이전트 연동', v: '모든 명령이 JSON으로 출력되어 AI 에이전트와 바로 연동됩니다.' },
-        { k: '공식은 약 4%', v: '공식 Open API는 토스 WTS 기능 ~440개 중 약 4%만 엽니다. tossctl은 그 너머까지 다룹니다.' },
+        { k: '공식 Open API는 약 4%', v: '공식 Open API는 토스 WTS 기능 ~440개 중 약 4%만 엽니다. tossctl은 그 너머까지 다룹니다.' },
       ],
     },
     why: {
       headline: '새 기능은 늘 앱(WTS)에 먼저 출시됩니다',
       p1: '어느 플랫폼이든 자사 앱은 사용자 경험이 모이는 핵심 공간입니다. 새 기능을 가장 빠르게 실험하고 통합하기 좋은 곳도 앱이라, 신기능은 자연스럽게 앱(WTS)에 먼저 들어갑니다. 반면 외부 공개용 API는 버전·호환성·지원 부담이 크기 때문에, 안정적으로 열 수 있는 범위를 신중히 골라 뒤따라 공개합니다. 공식 API가 보수적인 건 인색해서가 아니라 합리적인 선택입니다.',
-      p2: '그 결과 수급·시장지수·AI 시그널·스크리너·실시간 푸시처럼 토스의 색이 강한 기능일수록 앱에 먼저, 더 빨리 출시됩니다. 누구의 잘못이 아니라 플랫폼의 구조입니다. tossctl은 이 구조를 거스르지 않고 그대로 활용합니다. 앱이 쓰는 길(WTS)을 1차 경로로 삼아 지금 바로 쓰되, 공식이 지원하는 기능은 공식 경로로 자동 라우팅해 안정성도 함께 가져갑니다.',
+      p2: '그 결과 수급·시장지수·AI 시그널·스크리너·실시간 푸시처럼 토스의 색이 강한 기능일수록 앱에 먼저, 더 빨리 출시됩니다. 누구의 잘못이 아니라 플랫폼의 구조입니다. tossctl은 이 구조를 거스르지 않고 그대로 활용합니다. 앱이 쓰는 길(WTS)을 1차 경로로 삼아 지금 바로 쓰되, 공식 Open API가 지원하는 기능은 공식 API 경로로 자동 라우팅해 안정성도 함께 가져갑니다.',
       kicker: '더 빠른 범위와 더 안정적인 경로, 둘 다 취합니다.',
     },
     sectionLabel: '왜 tossctl 인가',
     compareLabel: '공식 OPEN API 의 상위집합',
     compareLead: (
       <>
-        공식 지원 전부(<span className="text-brand-200">100% 커버</span>) +
+        공식 Open API 지원 전부(<span className="text-brand-200">100% 커버</span>) +
         고유 <span className="text-brand-200">21개</span> = 총 <span className="text-brand-200">40개</span>
       </>
     ),
     stats: [
-      { n: '40', l: '공식 지원 전부 + 고유 21 = tossctl 총 기능 수' },
+      { n: '40', l: '공식 Open API 지원 전부 + 고유 21 = tossctl 총 기능 수' },
       { n: '21', l: '공식 API엔 없는 토스 WTS 기능' },
       { n: '약 4%', l: '(참고) 공식 Open API가 여는 토스 WTS 기능 비중' },
     ],
     coverage: {
       bright: '공식 Open API · 토스 WTS의 약 4%',
       dim: '토스 WTS 전체 기능 ~440개',
-      note: 'tossctl은 공식이 다루는 약 4%를 100% 포함하고, 공식에 없는 나머지 WTS 기능까지 넓혀갑니다.',
+      note: 'tossctl은 공식 Open API가 다루는 약 4%를 100% 포함하고, 공식 Open API에 없는 나머지 WTS 기능까지 넓혀갑니다.',
     },
     official: {
       name: '공식 Open API',
@@ -82,9 +82,9 @@ const content = {
     },
     toss: {
       name: 'tossctl',
-      note: '공식 전부 100% 커버 + 고유 21 = 총 40개',
+      note: '공식 Open API 전부 100% 커버 + 고유 21 = 총 40개',
       items: [
-        '공식 지원 기능 전부 (공식 키 연결 시 OAuth 경로로 더 안정적)',
+        '공식 Open API 지원 기능 전부 (공식 키 연결 시 OAuth 경로로 더 안정적)',
         '수급·시장지수·지수 상세·업종 등락',
         'AI 시그널·뉴스 브리핑·조건검색',
         '배당·커뮤니티 랭킹·관심종목·실시간 푸시·dry-run preview',
@@ -112,7 +112,7 @@ const content = {
       },
       {
         q: '공식 API가 넓어지면 tossctl 은 무의미해지나요?',
-        a: '오히려 더 좋아집니다. 공식이 지원하는 기능은 자동으로 공식 경로(OAuth)로 라우팅해 안정성을 높이고, 공식에 아직 없는 범위는 계속 WTS 로 채웁니다. 공식 범위는 언제나 100% 포함합니다.',
+        a: '오히려 더 좋아집니다. 공식 Open API가 지원하는 기능은 자동으로 공식 API 경로(OAuth)로 라우팅해 안정성을 높이고, 공식 Open API에 아직 없는 범위는 계속 WTS 로 채웁니다. 공식 Open API 범위는 언제나 100% 포함합니다.',
       },
       {
         q: '합법인가요? 토스 공식인가요?',
@@ -159,7 +159,7 @@ const content = {
       headline: "You don't have to wait for the official API",
       body: "tossctl covers 100% of the official Open API's supported range and adds 21 more Toss WTS features the official API doesn't expose, for a total of 40 — all through one command interface. No application, no approval, start right now. Connect an official key and those features auto-route through OAuth for extra stability. The official API only opens about 4% of the full Toss WTS surface, so tossctl reaches a lot further.",
       points: [
-        { k: '100% of official covered', v: "tossctl covers the official's whole area 100%. Add an official key and it routes through OAuth (more stable, auto-renewing)." },
+        { k: '100% of official API covered', v: "tossctl covers the official API's whole area 100%. Add an official key and it routes through OAuth (more stable, auto-renewing)." },
         { k: '+21 WTS features', v: "Flows, indices, AI signals, screener, dividends: 21 Toss WTS features the official API doesn't expose. Total: 40." },
         { k: 'Agents included', v: 'Every command answers in JSON, so people and agents use it the same way.' },
         { k: 'Official ≈ 4%', v: 'Of ~440 Toss WTS features, the official Open API opens only about 4% — tossctl covers the rest too.' },
@@ -168,26 +168,26 @@ const content = {
     why: {
       headline: 'New features always ship in the app first',
       p1: "On any platform, the first-party app is where the core experience lives. It's also the best place to ship and integrate new features fast, so new capabilities naturally land in the app (WTS) first. A public API carries real versioning, compatibility, and support costs, so it opens a carefully chosen, stable subset afterwards. The official API being conservative is reasonable, not stingy.",
-      p2: "As a result, the most Toss-flavored capabilities (flows, indices, AI signals, screener, real-time push) arrive in the app first and fastest. That is not anyone's fault, it is the shape of the platform. tossctl works with that shape rather than against it: it uses the path the app itself uses (WTS) as the primary route so you can use those features now, while auto-routing officially-supported features through the official path to keep stability.",
+      p2: "As a result, the most Toss-flavored capabilities (flows, indices, AI signals, screener, real-time push) arrive in the app first and fastest. That is not anyone's fault, it is the shape of the platform. tossctl works with that shape rather than against it: it uses the path the app itself uses (WTS) as the primary route so you can use those features now, while auto-routing features the official API supports through the official API's path to keep stability.",
       kicker: 'The faster surface and the steadier route, both at once.',
     },
     sectionLabel: 'WHY TOSSCTL',
     compareLabel: 'A SUPERSET OF THE OFFICIAL OPEN API',
     compareLead: (
       <>
-        All official-supported features (<span className="text-brand-200">100% covered</span>) +{' '}
+        Everything the official API supports (<span className="text-brand-200">100% covered</span>) +{' '}
         <span className="text-brand-200">21</span> unique = <span className="text-brand-200">40 total</span>
       </>
     ),
     stats: [
-      { n: '40', l: 'total: all official-supported + 21 unique' },
+      { n: '40', l: 'total: everything the official API supports + 21 unique' },
       { n: '21', l: "Toss WTS features the official API doesn't expose" },
       { n: '~4%', l: '(for context) of Toss WTS features the official API opens' },
     ],
     coverage: {
       bright: 'Official Open API · ~4% of WTS',
       dim: '~440 total Toss WTS features',
-      note: 'tossctl covers 100% of the official ~4% and keeps expanding into the rest of WTS.',
+      note: "tossctl covers 100% of the official API's ~4% and keeps expanding into the rest of WTS.",
     },
     official: {
       name: 'Official Open API',
@@ -196,9 +196,9 @@ const content = {
     },
     toss: {
       name: 'tossctl',
-      note: '100% of official + 21 unique = 40 total',
+      note: '100% of the official API + 21 unique = 40 total',
       items: [
-        'All official-supported features (official key unlocks OAuth routing)',
+        'Everything the official API supports (official key unlocks OAuth routing)',
         'Flows · indices · index detail · sectors',
         'AI signals · news briefing · screener',
         'Dividends · community rankings · watchlist · real-time push · dry-run',
@@ -226,7 +226,7 @@ const content = {
       },
       {
         q: 'Does tossctl become pointless once the official API grows?',
-        a: 'It gets better. Officially-supported features auto-route through the official path (OAuth) for stability, while the rest keep coming from WTS. tossctl always covers 100% of the official scope.',
+        a: "It gets better. Features the official API supports auto-route through the official API's path (OAuth) for stability, while the rest keep coming from WTS. tossctl always covers 100% of the official API's scope.",
       },
       {
         q: 'Is this legal? Is it official?',


### PR DESCRIPTION
## 요약

"공식"이라는 단어가 단독으로 쓰이면 마치 WTS(토스 자체 공식 웹/앱)가 비공식인 것처럼 오독될 수 있음. WTS는 토스의 공식 웹/앱이고, 비공식인 건 tossctl(CLI) 자체뿐 — 이 구분을 명확히 하기 위해 "공식"이 단독 주어/명사로 쓰인 곳을 전부 "공식 Open API"로 명시.

## 변경

README.md·README.en.md·웹사이트 홈페이지에서 "공식이 지원하는", "공식에 없는", "공식은 좁은", "공식이 커버하는", "official-supported", "the official scope" 같은 bare 표현을 "공식 Open API가/에/는", "the official API" 형태로 통일.

`공식 키`/`공식 문서`/`official key`처럼 이미 구체적 명사를 수식해 오독 위험이 없는 표현은 그대로 둠(과잉 수정 방지).

## 검증

- `npx tsc --noEmit` 클린
