### PR TITLE
docs: 헤드라인을 WTS 고유기능 중심으로 재작성

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,9 +6,9 @@
 
 <div align="center">
   <h1>tossinvest-cli</h1>
-  <p><strong>Covers 100% of Toss Securities' official API — plus 21 WTS-only features you won't find there.</strong></p>
+  <p><strong>Investor flows · AI signals · screener · dividends — Toss WTS features that only lived in the web app, now in your terminal.</strong></p>
   <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot — any AI agent drives Toss Securities accounts, quotes, and trades through one command interface (<code>tossctl</code>). Works just as well by hand in a terminal.</p>
-  <p><sub>Investor flows · market indices · AI signals · screener · watchlist management · transaction ledger · real-time push · fractional orders · dry-run preview — <strong>Toss WTS features the official API doesn't expose, all included.</strong> <a href="#support-scope">Full comparison ↓</a></sub></p>
+  <p><sub>Investor flows · market indices · AI signals · screener · watchlist management · transaction ledger · real-time push · fractional orders · dry-run preview — 21 WTS-only features, and <strong>100% of the official Open API's coverage, included too.</strong> <a href="#support-scope">Full comparison ↓</a></sub></p>
   <p><sub><em>An unofficial Toss Securities CLI for AI agents. Auto-routes through the official OAuth path when you connect an official key.</em></sub></p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 <div align="center">
   <h1>tossinvest-cli</h1>
-  <p><strong>토스증권 공식 API가 지원하는 범위를 100% 포함하고, 공식 API엔 없는 WTS 전용 기능 21가지를 더합니다.</strong></p>
+  <p><strong>수급 · AI 시그널 · 조건검색 · 배당 — 토스 웹앱(WTS)에만 있던 기능을 터미널에서 씁니다.</strong></p>
   <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot — 어떤 AI 에이전트든 하나의 명령 체계(<code>tossctl</code>)로 토스증권 계좌·시세·거래를 다룹니다. 터미널에서 직접 써도 됩니다.</p>
-  <p><sub>수급 · 시장지수 · AI 시그널 · 조건검색 · 관심종목 관리 · 거래내역 ledger · 실시간 푸시 · 원화 소수점 주문 · dry-run preview — <strong>공식 API엔 없는 토스 WTS 기능까지 전부 포함합니다.</strong> <a href="#지원-범위">전체 비교표 ↓</a></sub></p>
-  <p><sub><em>An unofficial Toss Securities CLI for AI agents. Covers 100% of the official Open API — plus 21 WTS-only features you won't find there.</em></sub></p>
+  <p><sub>수급 · 시장지수 · AI 시그널 · 조건검색 · 관심종목 관리 · 거래내역 ledger · 실시간 푸시 · 원화 소수점 주문 · dry-run preview 등 WTS 전용 기능 21가지 — <strong>공식 Open API 지원 범위도 물론 100% 포함합니다.</strong> <a href="#지원-범위">전체 비교표 ↓</a></sub></p>
+  <p><sub><em>An unofficial Toss Securities CLI for AI agents. Brings 21 Toss WTS-only features to the terminal — plus 100% of the official Open API's coverage.</em></sub></p>
 </div>
 
 <p align="center">

--- a/website-fumadocs/app/[lang]/(home)/page.tsx
+++ b/website-fumadocs/app/[lang]/(home)/page.tsx
@@ -31,8 +31,8 @@ const content = {
     sub: 'connect your AI agents to Toss Securities',
     desc: (
       <>
-        토스증권 계좌·시세·거래내역을 조회하고, 주문을 넣습니다. 공식 Open API는 100% 포함하고,
-        토스 WTS 고유 기능까지 <code className="font-mono text-white/90">tossctl</code> 로 지금 바로.
+        토스증권 계좌·시세·거래내역을 조회하고, 주문을 넣습니다. 토스 WTS 고유 기능까지
+        <code className="font-mono text-white/90">tossctl</code> 하나로 — 공식 Open API 100% 포함은 물론입니다.
       </>
     ),
     cta: '5분 만에 시작',
@@ -42,11 +42,11 @@ const content = {
     },
     thesis: {
       label: '왜 지금',
-      headline: '공식 API, 기다릴 필요 없습니다',
-      body: 'tossctl은 공식 Open API 지원 범위를 100% 포함하고, 공식 Open API엔 없는 토스 WTS 고유 기능 21개를 더해 총 40개를 하나의 명령 체계로 제공합니다. 신청·승인 없이 지금 바로 시작할 수 있고, 공식 키를 연결하면 해당 기능은 자동으로 OAuth 경로로 라우팅돼 더 안정적입니다. 공식 Open API가 여는 범위는 토스 WTS 전체의 약 4%뿐이라, tossctl이 그만큼 더 넓은 영역을 커버합니다.',
+      headline: '토스 앱에만 있던 기능, 지금 터미널에서',
+      body: 'tossctl은 수급·AI 시그널·조건검색·배당 등 토스 WTS에만 있는 고유 기능 21개를 제공하고, 공식 Open API 지원 범위도 100% 포함해 총 40개를 하나의 명령 체계로 씁니다. 신청·승인 없이 지금 바로 시작할 수 있고, 공식 키를 연결하면 해당 기능은 자동으로 OAuth 경로로 라우팅돼 더 안정적입니다. 공식 Open API가 여는 범위는 토스 WTS 전체의 약 4%뿐이라, tossctl이 그만큼 더 넓은 영역을 커버합니다.',
       points: [
+        { k: 'WTS 기능 21개', v: '토스 WTS엔 있지만 공식 API엔 없는 수급·지수·AI 시그널·스크리너·배당 등 21개. 앱에서만 쓰던 기능을 터미널로.' },
         { k: '공식 Open API 전부 100% 커버', v: '공식 Open API가 여는 범위를 빠짐없이 100% 포함합니다. 공식 키를 연결하면 OAuth 경로로 더 안정적으로 동작합니다.' },
-        { k: 'WTS 기능 21개 추가', v: '토스 WTS엔 있지만 공식 API엔 없는 수급·지수·AI 시그널·스크리너·배당 등 21개까지. 합계 40개.' },
         { k: '에이전트 연동', v: '모든 명령이 JSON으로 출력되어 AI 에이전트와 바로 연동됩니다.' },
         { k: '공식 Open API는 약 4%', v: '공식 Open API는 토스 WTS 기능 ~440개 중 약 4%만 엽니다. tossctl은 그 너머까지 다룹니다.' },
       ],
@@ -66,8 +66,8 @@ const content = {
       </>
     ),
     stats: [
+      { n: '21', l: '공식 API엔 없는 토스 WTS 고유 기능' },
       { n: '40', l: '공식 Open API 지원 전부 + 고유 21 = tossctl 총 기능 수' },
-      { n: '21', l: '공식 API엔 없는 토스 WTS 기능' },
       { n: '약 4%', l: '(참고) 공식 Open API가 여는 토스 WTS 기능 비중' },
     ],
     coverage: {
@@ -144,9 +144,9 @@ const content = {
     sub: 'connect your AI agents to Toss Securities',
     desc: (
       <>
-        Read accounts, quotes, and transactions, and place orders. Covers the official Open API in
-        full, plus the Toss WTS features it doesn't expose. All from{' '}
-        <code className="font-mono text-white/90">tossctl</code>, right now.
+        Read accounts, quotes, and transactions, and place orders — plus the Toss WTS features the
+        official API doesn't expose. All from{' '}
+        <code className="font-mono text-white/90">tossctl</code>, right now, official API coverage included.
       </>
     ),
     cta: 'Start in 5 minutes',
@@ -156,11 +156,11 @@ const content = {
     },
     thesis: {
       label: 'WHY NOW',
-      headline: "You don't have to wait for the official API",
-      body: "tossctl covers 100% of the official Open API's supported range and adds 21 more Toss WTS features the official API doesn't expose, for a total of 40 — all through one command interface. No application, no approval, start right now. Connect an official key and those features auto-route through OAuth for extra stability. The official API only opens about 4% of the full Toss WTS surface, so tossctl reaches a lot further.",
+      headline: 'Features that only lived in the app, now in your terminal',
+      body: "tossctl brings 21 Toss WTS-only features (flows, AI signals, screener, dividends, and more) to the terminal, and covers 100% of the official Open API's supported range too, for a total of 40 — all through one command interface. No application, no approval, start right now. Connect an official key and those features auto-route through OAuth for extra stability. The official API only opens about 4% of the full Toss WTS surface, so tossctl reaches a lot further.",
       points: [
+        { k: '21 WTS-only features', v: "Flows, indices, AI signals, screener, dividends: 21 Toss WTS features the official API doesn't expose. App-only, now in your terminal." },
         { k: '100% of official API covered', v: "tossctl covers the official API's whole area 100%. Add an official key and it routes through OAuth (more stable, auto-renewing)." },
-        { k: '+21 WTS features', v: "Flows, indices, AI signals, screener, dividends: 21 Toss WTS features the official API doesn't expose. Total: 40." },
         { k: 'Agents included', v: 'Every command answers in JSON, so people and agents use it the same way.' },
         { k: 'Official ≈ 4%', v: 'Of ~440 Toss WTS features, the official Open API opens only about 4% — tossctl covers the rest too.' },
       ],
@@ -180,8 +180,8 @@ const content = {
       </>
     ),
     stats: [
+      { n: '21', l: "unique Toss WTS features the official API doesn't expose" },
       { n: '40', l: 'total: everything the official API supports + 21 unique' },
-      { n: '21', l: "Toss WTS features the official API doesn't expose" },
       { n: '~4%', l: '(for context) of Toss WTS features the official API opens' },
     ],
     coverage: {


### PR DESCRIPTION
## 요약

헤드라인·thesis 섹션을 "공식 API와 비교" 프레임에서 "토스 앱에만 있던 기능을 터미널에서 쓴다"는 tossctl 자체 가치 중심으로 재작성. 숫자(21/40/4%)는 그대로, 등장 순서와 문장 주어만 재배치.

## 변경

- README 히어로 헤드라인: "공식 API 100% 포함 + WTS 21가지" → **"수급·AI 시그널·조건검색·배당 — 토스 웹앱에만 있던 기능을 터미널에서"** (구체적 기능명이 주어, 공식 API 커버리지는 뒤따르는 서포트 문장)
- 웹사이트 thesis 헤드라인: "공식 API, 기다릴 필요 없습니다" → **"토스 앱에만 있던 기능, 지금 터미널에서"**
- thesis body/points/stats 순서: WTS 고유 기능(21)이 먼저, 공식 API 100% 커버는 그다음, 4%는 참고로 마지막 (이전 라운드에서 tossctl 총합(40) 우선이었던 걸 한 단계 더 — WTS 고유성 자체를 주인공으로)
- 최상단 hero desc(`content.desc`)도 동일 원칙 적용

"공식 Open API" 정밀 표기 규칙(이전 PR #74)은 새로 쓴 문장에도 그대로 적용 — bare "공식" 재검증 완료.

## 검증

- `npx tsc --noEmit` 클린
