### PR TITLE
docs(website): 커버리지 그리드 3색 재설계 — tossctl이 결론이 되도록

### DIFF
--- a/website-fumadocs/app/[lang]/(home)/page.tsx
+++ b/website-fumadocs/app/[lang]/(home)/page.tsx
@@ -71,9 +71,10 @@ const content = {
       { n: '약 4%', l: '(참고) 공식 Open API가 여는 토스 WTS 기능 비중' },
     ],
     coverage: {
-      bright: '공식 Open API · 토스 WTS의 약 4%',
-      dim: '토스 WTS 전체 기능 ~440개',
-      note: 'tossctl은 공식 Open API가 다루는 약 4%를 100% 포함하고, 공식 Open API에 없는 나머지 WTS 기능까지 넓혀갑니다.',
+      addedLabel: 'tossctl 고유 21개 추가',
+      officialLabel: '공식 Open API 19개',
+      restLabel: '아직 다루지 않은 나머지 WTS',
+      note: 'tossctl은 공식 Open API 지원 범위(19개)를 100% 포함하고, 고유 기능 21개를 더해 총 40개를 하나의 명령 체계로 제공합니다. 토스 WTS 전체 ~440개 중 의미있는 범위를 계속 넓혀갑니다.',
     },
     official: {
       name: '공식 Open API',
@@ -185,9 +186,10 @@ const content = {
       { n: '~4%', l: '(for context) of Toss WTS features the official API opens' },
     ],
     coverage: {
-      bright: 'Official Open API · ~4% of WTS',
-      dim: '~440 total Toss WTS features',
-      note: "tossctl covers 100% of the official API's ~4% and keeps expanding into the rest of WTS.",
+      addedLabel: '21 tossctl-only additions',
+      officialLabel: '19 official API features',
+      restLabel: 'not yet covered',
+      note: "tossctl covers 100% of what the official API supports (19) and adds 21 more, for 40 total — all through one command interface. Continuing to expand across the ~440 total Toss WTS features.",
     },
     official: {
       name: 'Official Open API',
@@ -349,10 +351,22 @@ const COMPANIES: { name: string; logo?: string; h?: number; w?: number }[] = [
   { name: 'Daangn', logo: '/logos/companies/daangn.svg', h: 43 },
 ];
 
-// Coverage dot-map: the official API is a sliver of the Toss web-app surface.
-function CoverageGrid({ bright, dim, note }: { bright: string; dim: string; note: string }) {
+// Coverage dot-map: tossctl (official-matching + unique) reaches much further into
+// the Toss web-app surface than the official API alone.
+function CoverageGrid({
+  addedLabel,
+  officialLabel,
+  restLabel,
+  note,
+}: {
+  addedLabel: string;
+  officialLabel: string;
+  restLabel: string;
+  note: string;
+}) {
   const total = 160;
-  const official = 6; // ~4%
+  const official = 7; // ~19/440
+  const tossctlTotal = 15; // ~40/440
   return (
     <div className="rounded-xl border border-white/10 bg-[#0f0f0f] p-6">
       <div className="grid grid-cols-[repeat(20,minmax(0,1fr))] gap-1.5">
@@ -360,17 +374,25 @@ function CoverageGrid({ bright, dim, note }: { bright: string; dim: string; note
           <span
             key={i}
             className={
-              'aspect-square rounded-[2px] ' + (i < official ? 'bg-brand-200' : 'bg-white/[0.06]')
+              'aspect-square rounded-[2px] ' +
+              (i < official
+                ? 'bg-brand-200/40'
+                : i < tossctlTotal
+                  ? 'bg-brand-200'
+                  : 'bg-white/[0.06]')
             }
           />
         ))}
       </div>
       <div className="mt-5 flex flex-wrap items-center gap-x-6 gap-y-2 font-mono text-[11px] text-white/45">
         <span className="inline-flex items-center gap-2">
-          <span className="size-2.5 rounded-[2px] bg-brand-200" /> {bright}
+          <span className="size-2.5 rounded-[2px] bg-brand-200" /> {addedLabel}
         </span>
         <span className="inline-flex items-center gap-2">
-          <span className="size-2.5 rounded-[2px] bg-white/[0.12]" /> {dim}
+          <span className="size-2.5 rounded-[2px] bg-brand-200/40" /> {officialLabel}
+        </span>
+        <span className="inline-flex items-center gap-2">
+          <span className="size-2.5 rounded-[2px] bg-white/[0.12]" /> {restLabel}
         </span>
       </div>
       <p className="mt-3 text-[12px] leading-relaxed text-white/45">{note}</p>
@@ -622,7 +644,12 @@ $ tossctl order preview --symbol TSLA --side buy --qty 1 --price 250`}</code>
           <p className="mb-8 max-w-2xl text-lg text-white/80">{t.compareLead}</p>
 
           <div className="mb-8 grid gap-6 lg:grid-cols-[1.5fr_1fr] lg:items-stretch">
-            <CoverageGrid bright={t.coverage.bright} dim={t.coverage.dim} note={t.coverage.note} />
+            <CoverageGrid
+              addedLabel={t.coverage.addedLabel}
+              officialLabel={t.coverage.officialLabel}
+              restLabel={t.coverage.restLabel}
+              note={t.coverage.note}
+            />
             <div className="grid grid-cols-1 divide-y divide-white/10 overflow-hidden rounded-xl border border-white/10 bg-[#0f0f0f] sm:grid-cols-3 sm:divide-x sm:divide-y-0 lg:grid-cols-1 lg:divide-x-0 lg:divide-y">
               {t.stats.map((s) => (
                 <div key={s.l} className="px-4 py-6 text-center lg:py-5">


### PR DESCRIPTION
## 요약

사용자가 배포된 화면 스크린샷을 보고 지적: "핵심은 토스가 WTS의 4%만 지원이 아니라, 우리가 하이브리드로 더 많이 제공하는게 결론이 되어야 한다." 기존 `CoverageGrid` 컴포넌트는 "공식 API가 WTS 대비 얼마나 작은지"만 2색(공식/전체)으로 시각화해서, 텍스트로 아무리 "tossctl이 더 넓힌다"를 강조해도 그래픽 자체가 "공식은 작다"만 보여주는 구조적 한계가 있었음.

## 변경

`CoverageGrid`를 2색 → **3색**으로 재설계:
- 밝은 브랜드색(가장 눈에 띔) = **tossctl 고유 21개**
- 흐린 브랜드색(보조) = 공식 Open API 19개
- 어두운 회색 = 아직 다루지 않은 나머지 WTS

같은 그리드 안에서 "밝은 색 블록이 흐린 색 블록보다 크다"가 시각적으로 바로 보여서, 결론이 자연스럽게 "tossctl이 공식보다 훨씬 넓게 커버한다"로 읽힘. 범례·본문도 이 순서(고유 → 공식 → 미커버)로 맞춤. KO/EN 동일 적용.

## 검증

- `npx tsc --noEmit` 클린, `npm run build` 성공
- 로컬 프로덕션 서버(`next start`) 기동 후 브라우저로 실제 렌더링 확인 (스크린샷 첨부 확인 완료 — 2톤 구분 명확)
