### PR TITLE
fix(website): Superset 미리보기 /home 경로 리다이렉트

### DIFF
--- a/website-fumadocs/middleware.ts
+++ b/website-fumadocs/middleware.ts
@@ -1,7 +1,26 @@
+import { NextResponse, type NextFetchEvent, type NextRequest } from 'next/server';
 import { createI18nMiddleware } from 'fumadocs-core/i18n/middleware';
 import { i18n } from '@/lib/i18n';
 
-export default createI18nMiddleware(i18n);
+const i18nMiddleware = createI18nMiddleware(i18n);
+
+// Some external tools that scan the Next.js app directory for routes don't
+// know that a parenthesized folder (app/[lang]/(home)/page.tsx) is a route
+// group excluded from the URL — they read the folder name literally and
+// guess "/home" (or "/en/home") as the homepage path. That path doesn't
+// exist in this app (the real homepage is "/" or "/en"), so redirect it
+// here rather than relying on the external tool to be fixed.
+const HOME_ALIAS = /^\/(?:(en)\/)?home\/?$/;
+
+export default function middleware(request: NextRequest, event: NextFetchEvent) {
+  const match = request.nextUrl.pathname.match(HOME_ALIAS);
+  if (match) {
+    const url = request.nextUrl.clone();
+    url.pathname = match[1] ? `/${match[1]}` : '/';
+    return NextResponse.redirect(url);
+  }
+  return i18nMiddleware(request, event);
+}
 
 export const config = {
   // 라우트 핸들러(api·llms·og)·정적파일·_next 는 제외하고 페이지만 로케일 처리


### PR DESCRIPTION
Superset 미리보기 패널의 "Local" 버튼이 `app/[lang]/(home)/page.tsx`의 라우트 그룹 폴더명 `(home)`을 문자 그대로 읽어 `/en/home`으로 이동시키는 문제 발견(정상 라우트는 `(home)`이 URL에서 제외됨). middleware에서 `/home`·`/en/home`을 실제 홈으로 리다이렉트해서 해결.

로컬에서 `/home`·`/en/home`·`/en/home/`(트레일링 슬래시) 전부 정상 리다이렉트 확인, 일반 라우트(`/`, `/en`, `/docs` 등) 회귀 없음 확인.