### PR TITLE
docs(readme): 히어로 헤드라인 포괄적 AI 에이전트 CLI 소개로 재작성

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 
 <div align="center">
   <h1>tossinvest-cli</h1>
-  <p><strong>Investor flows · AI signals · screener · dividends — Toss WTS features that only lived in the web app, now in your terminal.</strong></p>
+  <p><strong>An AI agent CLI for Toss Securities. 100% of the official API, plus the features only the web app had.</strong></p>
   <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot — any AI agent drives Toss Securities accounts, quotes, and trades through one command interface (<code>tossctl</code>). Works just as well by hand in a terminal.</p>
   <p><sub>Investor flows · market indices · AI signals · screener · watchlist management · transaction ledger · real-time push · fractional orders · dry-run preview — 21 WTS-only features, and <strong>100% of the official Open API's coverage, included too.</strong> <a href="#support-scope">Full comparison ↓</a></sub></p>
   <p><sub><em>An unofficial Toss Securities CLI for AI agents. Auto-routes through the official OAuth path when you connect an official key.</em></sub></p>

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 <div align="center">
   <h1>tossinvest-cli</h1>
-  <p><strong>수급 · AI 시그널 · 조건검색 · 배당 — 토스 웹앱(WTS)에만 있던 기능을 터미널에서 씁니다.</strong></p>
+  <p><strong>토스증권을 위한 AI 에이전트 CLI. 공식 API는 물론, 웹앱에만 있던 기능까지 하나로.</strong></p>
   <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot — 어떤 AI 에이전트든 하나의 명령 체계(<code>tossctl</code>)로 토스증권 계좌·시세·거래를 다룹니다. 터미널에서 직접 써도 됩니다.</p>
   <p><sub>수급 · 시장지수 · AI 시그널 · 조건검색 · 관심종목 관리 · 거래내역 ledger · 실시간 푸시 · 원화 소수점 주문 · dry-run preview 등 WTS 전용 기능 21가지 — <strong>공식 Open API 지원 범위도 물론 100% 포함합니다.</strong> <a href="#지원-범위">전체 비교표 ↓</a></sub></p>
-  <p><sub><em>An unofficial Toss Securities CLI for AI agents. Brings 21 Toss WTS-only features to the terminal — plus 100% of the official Open API's coverage.</em></sub></p>
+  <p><sub><em>An AI agent CLI for Toss Securities — 100% of the official Open API, plus 21 features only the web app had.</em></sub></p>
 </div>
 
 <p align="center">


### PR DESCRIPTION
README 첫 문장이 특정 기능(수급·AI 시그널 등) 나열로 시작해서 '누구를 위한 무엇'인지 안 읽힌다는 피드백. 'AI 에이전트 CLI + 공식 API 100% + WTS 전용 기능'이라는 포괄적 헤드라인으로 교체. 구체적 기능 목록은 그 아래 서포트 라인에 그대로 유지.