### PR TITLE
docs(readme): Star History 임베드 갱신 + Rank 배지 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,19 @@
 <p align="center">
   <a href="https://www.star-history.com/?repos=JungHoonGhae%2Ftossinvest-cli&type=date&legend=top-left">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=JungHoonGhae/tossinvest-cli&type=date&theme=dark&legend=top-left" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=JungHoonGhae/tossinvest-cli&type=date&legend=top-left" />
-      <img alt="Star History Chart" src="https://api.star-history.com/image?repos=JungHoonGhae/tossinvest-cli&type=date&legend=top-left" width="600" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=JungHoonGhae/tossinvest-cli&type=date&theme=dark&legend=top-left" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=JungHoonGhae/tossinvest-cli&type=date&legend=top-left" />
+      <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=JungHoonGhae/tossinvest-cli&type=date&legend=top-left" width="600" />
+    </picture>
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://www.star-history.com/?repos=JungHoonGhae%2Ftossinvest-cli">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/badge?repo=JungHoonGhae/tossinvest-cli&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/badge?repo=JungHoonGhae/tossinvest-cli" />
+      <img alt="Star History Rank" src="https://api.star-history.com/badge?repo=JungHoonGhae/tossinvest-cli" />
     </picture>
   </a>
 </p>


### PR DESCRIPTION
구 `/image` 엔드포인트가 우리 저장소만 인덱싱이 안 돼서 안 뜨던 문제 발견(star-history.com 쪽 이슈, 이후 토큰 재조회로 해소된 것으로 보임) — 최신 `/chart` 엔드포인트로 교체. 요청받은 Star History Rank 배지도 추가.