### PR TITLE
feat(mcp): 공식 Open API를 catalog 방식 stdio MCP 서버로 노출 (`tossctl mcp`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ tossctl 사용자 관점의 변경 이력입니다. 각 버전에서 "무엇을 
 ## [Unreleased]
 
 ### 새 기능
-- **`tossctl mcp`** — 공식 Toss Open API를 MCP(Model Context Protocol) 서버로 노출합니다. stdin/stdout(JSON-RPC 2.0) 위에서 동작하며 Claude Code·Claude Desktop·Codex 등 MCP 호스트에 `tossctl mcp` 커맨드로 등록해 쓸 수 있습니다. 20여 개의 API를 개별 툴로 등록하는 대신, 상시 컨텍스트를 최소화하는 **catalog 방식**(`list_operations` / `describe_operation` / `call_operation` 3개 툴)으로 노출합니다. 조회(계좌·잔고·주문·시세·호가·체결·캔들·환율 등)뿐 아니라 **주문 실행(매수/매도·취소·정정)** 도 지원합니다. 주문은 CLI(`tossctl order`)와 동일하게 config 게이트(`trading.*` + `allow_live_order_actions`)와 preview→execute/confirm 2단계 흐름을 따르며(기본은 dry-run preview), **공식 API 경로만 사용(WTS 미경유)** 합니다. `tossctl openapi login` 으로 저장한 자격증명이 필요합니다.
+- **`tossctl mcp`** — 공식 Toss Open API를 MCP(Model Context Protocol) 서버로 노출합니다. stdin/stdout(JSON-RPC 2.0) 위에서 동작하며 Claude Code·Claude Desktop·Codex 등 MCP 호스트에 `tossctl mcp` 커맨드로 등록해 쓸 수 있습니다. 20여 개의 API를 개별 툴로 등록하는 대신, 상시 컨텍스트를 최소화하는 **catalog 방식**(`list_operations` / `describe_operation` / `call_operation` 3개 툴)으로 노출합니다. 공식 Open API의 **조회·거래 엔드포인트를 100% 커버**합니다 — 조회(계좌·잔고·주문·시세·호가·체결·캔들·환율·수수료·장운영시간 등)뿐 아니라 **주문 실행(매수/매도·취소·정정)** 도 지원합니다. 주문은 CLI(`tossctl order`)와 동일하게 config 게이트(`trading.*` + `allow_live_order_actions`)와 preview→execute/confirm 2단계 흐름을 따르며(기본은 dry-run preview), **공식 API 경로만 사용(WTS 미경유)** 합니다. `tossctl openapi login` 으로 저장한 자격증명이 필요합니다.
 
 ## [0.18.0] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ tossctl 사용자 관점의 변경 이력입니다. 각 버전에서 "무엇을 
 
 ## [Unreleased]
 
+### 새 기능
+- **`tossctl mcp`** — 공식 Toss Open API를 MCP(Model Context Protocol) 서버로 노출합니다. stdin/stdout(JSON-RPC 2.0) 위에서 동작하며 Claude Code·Claude Desktop·Codex 등 MCP 호스트에 `tossctl mcp` 커맨드로 등록해 쓸 수 있습니다. 20여 개의 API를 개별 툴로 등록하는 대신, 상시 컨텍스트를 최소화하는 **catalog 방식**(`list_operations` / `describe_operation` / `call_operation` 3개 툴)으로 조회 기능을 노출합니다. 현재는 읽기 전용(계좌·잔고·주문 조회·시세·호가·체결·캔들·환율 등)이며 주문 실행은 포함되지 않습니다. `tossctl openapi login` 으로 저장한 자격증명이 필요합니다.
+
 ## [0.18.0] - 2026-07-08
 
 ### 새 기능

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ tossctl 사용자 관점의 변경 이력입니다. 각 버전에서 "무엇을 
 ## [Unreleased]
 
 ### 새 기능
-- **`tossctl mcp`** — 공식 Toss Open API를 MCP(Model Context Protocol) 서버로 노출합니다. stdin/stdout(JSON-RPC 2.0) 위에서 동작하며 Claude Code·Claude Desktop·Codex 등 MCP 호스트에 `tossctl mcp` 커맨드로 등록해 쓸 수 있습니다. 20여 개의 API를 개별 툴로 등록하는 대신, 상시 컨텍스트를 최소화하는 **catalog 방식**(`list_operations` / `describe_operation` / `call_operation` 3개 툴)으로 조회 기능을 노출합니다. 현재는 읽기 전용(계좌·잔고·주문 조회·시세·호가·체결·캔들·환율 등)이며 주문 실행은 포함되지 않습니다. `tossctl openapi login` 으로 저장한 자격증명이 필요합니다.
+- **`tossctl mcp`** — 공식 Toss Open API를 MCP(Model Context Protocol) 서버로 노출합니다. stdin/stdout(JSON-RPC 2.0) 위에서 동작하며 Claude Code·Claude Desktop·Codex 등 MCP 호스트에 `tossctl mcp` 커맨드로 등록해 쓸 수 있습니다. 20여 개의 API를 개별 툴로 등록하는 대신, 상시 컨텍스트를 최소화하는 **catalog 방식**(`list_operations` / `describe_operation` / `call_operation` 3개 툴)으로 노출합니다. 조회(계좌·잔고·주문·시세·호가·체결·캔들·환율 등)뿐 아니라 **주문 실행(매수/매도·취소·정정)** 도 지원합니다. 주문은 CLI(`tossctl order`)와 동일하게 config 게이트(`trading.*` + `allow_live_order_actions`)와 preview→execute/confirm 2단계 흐름을 따르며(기본은 dry-run preview), **공식 API 경로만 사용(WTS 미경유)** 합니다. `tossctl openapi login` 으로 저장한 자격증명이 필요합니다.
 
 ## [0.18.0] - 2026-07-08
 

--- a/README.en.md
+++ b/README.en.md
@@ -63,9 +63,10 @@
 
 `tossctl` can expose the official Toss Open API as an **MCP (Model Context Protocol) server**.
 Register it in an MCP host (Claude Code, Claude Desktop, Codex, …) and an agent can query
-accounts, holdings, prices, order book, trades, and candles — and **place, cancel, or modify
-orders** — in natural language. It speaks JSON-RPC 2.0 over stdin/stdout — no separate server
-or port.
+accounts, holdings, prices, order book, trades, candles, and market hours — and **place,
+cancel, or modify orders** — in natural language, covering 100% of the official Open API's
+read and trade endpoints. It speaks JSON-RPC 2.0 over stdin/stdout — no separate server or
+port.
 
 Registering ~20 APIs as individual tools would bloat the always-on context, so it uses a
 **catalog** surface of just three tools: `list_operations`, `describe_operation`, and

--- a/README.en.md
+++ b/README.en.md
@@ -63,13 +63,16 @@
 
 `tossctl` can expose the official Toss Open API as an **MCP (Model Context Protocol) server**.
 Register it in an MCP host (Claude Code, Claude Desktop, Codex, …) and an agent can query
-accounts, holdings, prices, order book, trades, and candles in natural language. It speaks
-JSON-RPC 2.0 over stdin/stdout — no separate server or port.
+accounts, holdings, prices, order book, trades, and candles — and **place, cancel, or modify
+orders** — in natural language. It speaks JSON-RPC 2.0 over stdin/stdout — no separate server
+or port.
 
 Registering ~20 APIs as individual tools would bloat the always-on context, so it uses a
 **catalog** surface of just three tools: `list_operations`, `describe_operation`, and
-`call_operation`. Read-only for now (no order placement — deferred for safety). Save
-credentials first with `tossctl openapi login`.
+`call_operation`. Order mutations are **gated exactly like the `tossctl order` CLI**: enable
+them in config (`trading.*` + `allow_live_order_actions`); a plain call returns a dry-run
+preview with a `confirm_token`, and submitting requires `execute: true` plus `confirm: <token>`.
+Writes use the official API only (no WTS). Save credentials first with `tossctl openapi login`.
 
 ```json
 {

--- a/README.en.md
+++ b/README.en.md
@@ -59,6 +59,26 @@
 
 <!-- sponsors:end -->
 
+## MCP server (`tossctl mcp`) <!--since:2026-07-08-->
+
+`tossctl` can expose the official Toss Open API as an **MCP (Model Context Protocol) server**.
+Register it in an MCP host (Claude Code, Claude Desktop, Codex, …) and an agent can query
+accounts, holdings, prices, order book, trades, and candles in natural language. It speaks
+JSON-RPC 2.0 over stdin/stdout — no separate server or port.
+
+Registering ~20 APIs as individual tools would bloat the always-on context, so it uses a
+**catalog** surface of just three tools: `list_operations`, `describe_operation`, and
+`call_operation`. Read-only for now (no order placement — deferred for safety). Save
+credentials first with `tossctl openapi login`.
+
+```json
+{
+  "mcpServers": {
+    "tossinvest": { "command": "tossctl", "args": ["mcp"] }
+  }
+}
+```
+
 ## Quick Start
 
 ### For Agents

--- a/README.md
+++ b/README.md
@@ -124,17 +124,21 @@ tossctl account summary --backend openapi  # 공식 API 경로 강제 (선택)
 
 공식 Open API 를 **MCP(Model Context Protocol) 서버**로도 노출합니다. Claude Code·Claude
 Desktop·Codex 등 MCP 호스트에 등록하면 에이전트가 자연어로 계좌·잔고·시세·호가·체결·캔들을
-조회할 수 있습니다. stdin/stdout(JSON-RPC 2.0) 으로 동작하며 별도 서버·포트가 필요 없습니다.
+조회하고 **주문(매수/매도·취소·정정)** 까지 실행할 수 있습니다. stdin/stdout(JSON-RPC 2.0) 으로
+동작하며 별도 서버·포트가 필요 없습니다.
 
 20여 개의 API 를 개별 툴로 등록하면 상시 컨텍스트가 커지므로, **catalog 방식**으로 딱 3개
 툴만 상시 노출합니다:
 
-- `list_operations` — 사용 가능한 오퍼레이션 목록(id·요약) 조회, `query` 로 필터
+- `list_operations` — 사용 가능한 오퍼레이션 목록(id·요약·write 여부) 조회, `query` 로 필터
 - `describe_operation` — 특정 오퍼레이션의 파라미터 스키마 조회
 - `call_operation` — id + 파라미터로 실제 호출
 
-현재는 **읽기 전용**이며 주문 실행은 포함하지 않습니다(안전상 후속 작업). `tossctl openapi login`
-으로 자격증명을 먼저 저장하세요. MCP 호스트 설정 예시:
+**주문 실행은 CLI(`tossctl order`)와 동일하게 게이트**됩니다: config 의 `trading.*` +
+`allow_live_order_actions` 토글로 켜야 하고, 기본 호출은 **dry-run preview**(confirm_token·경고
+반환)를 돌려줍니다. 실제 제출은 `execute: true` + `confirm: <token>` 을 함께 넘겨야 합니다. 주문은
+**공식 API 경로만 사용(WTS 미경유)** 합니다. `tossctl openapi login` 으로 자격증명을 먼저
+저장하세요. MCP 호스트 설정 예시:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -123,9 +123,10 @@ tossctl account summary --backend openapi  # 공식 API 경로 강제 (선택)
 ### MCP 서버 (`tossctl mcp`) <!--since:2026-07-08-->
 
 공식 Open API 를 **MCP(Model Context Protocol) 서버**로도 노출합니다. Claude Code·Claude
-Desktop·Codex 등 MCP 호스트에 등록하면 에이전트가 자연어로 계좌·잔고·시세·호가·체결·캔들을
-조회하고 **주문(매수/매도·취소·정정)** 까지 실행할 수 있습니다. stdin/stdout(JSON-RPC 2.0) 으로
-동작하며 별도 서버·포트가 필요 없습니다.
+Desktop·Codex 등 MCP 호스트에 등록하면 에이전트가 자연어로 계좌·잔고·시세·호가·체결·캔들·
+장운영시간을 조회하고 **주문(매수/매도·취소·정정)** 까지 실행할 수 있습니다 — 공식 Open API의
+조회·거래 엔드포인트를 100% 커버합니다. stdin/stdout(JSON-RPC 2.0) 으로 동작하며 별도 서버·
+포트가 필요 없습니다.
 
 20여 개의 API 를 개별 툴로 등록하면 상시 컨텍스트가 커지므로, **catalog 방식**으로 딱 3개
 툴만 상시 노출합니다:

--- a/README.md
+++ b/README.md
@@ -120,6 +120,30 @@ tossctl account summary --backend openapi  # 공식 API 경로 강제 (선택)
 
 > 공식 한도는 빡빡합니다 — 공식 문서 기준 계좌 조회는 **초당 1회**로 가장 낮고, 빠르게 반복하면 10번 중 8번이 거절됩니다 ([공식 한도 표 + 실측](docs/migration/open-api.md#rate-limit-실측), 토스 정책에 따라 변동 가능). tossctl 은 막히면 자동으로 웹 세션(WTS)으로 우회하므로 반복 조회·모니터링에서도 끊김이 없습니다.
 
+### MCP 서버 (`tossctl mcp`) <!--since:2026-07-08-->
+
+공식 Open API 를 **MCP(Model Context Protocol) 서버**로도 노출합니다. Claude Code·Claude
+Desktop·Codex 등 MCP 호스트에 등록하면 에이전트가 자연어로 계좌·잔고·시세·호가·체결·캔들을
+조회할 수 있습니다. stdin/stdout(JSON-RPC 2.0) 으로 동작하며 별도 서버·포트가 필요 없습니다.
+
+20여 개의 API 를 개별 툴로 등록하면 상시 컨텍스트가 커지므로, **catalog 방식**으로 딱 3개
+툴만 상시 노출합니다:
+
+- `list_operations` — 사용 가능한 오퍼레이션 목록(id·요약) 조회, `query` 로 필터
+- `describe_operation` — 특정 오퍼레이션의 파라미터 스키마 조회
+- `call_operation` — id + 파라미터로 실제 호출
+
+현재는 **읽기 전용**이며 주문 실행은 포함하지 않습니다(안전상 후속 작업). `tossctl openapi login`
+으로 자격증명을 먼저 저장하세요. MCP 호스트 설정 예시:
+
+```json
+{
+  "mcpServers": {
+    "tossinvest": { "command": "tossctl", "args": ["mcp"] }
+  }
+}
+```
+
 ## Quick Start
 
 ### For Agent

--- a/cmd/tossctl/init_test.go
+++ b/cmd/tossctl/init_test.go
@@ -59,53 +59,53 @@ func TestShouldHintOnboarding(t *testing.T) {
 	}{
 		// ── should hint ────────────────────────────────────────────────────────
 		{
-			name: "needs onboarding + interactive + eligible cmd (portfolio)",
+			name:  "needs onboarding + interactive + eligible cmd (portfolio)",
 			state: needsOnboarding, interactive: true, cmdName: "portfolio", want: true,
 		},
 		{
-			name: "needs onboarding + interactive + eligible cmd (account)",
+			name:  "needs onboarding + interactive + eligible cmd (account)",
 			state: needsOnboarding, interactive: true, cmdName: "account", want: true,
 		},
 		{
-			name: "needs onboarding + interactive + eligible cmd (quote)",
+			name:  "needs onboarding + interactive + eligible cmd (quote)",
 			state: needsOnboarding, interactive: true, cmdName: "quote", want: true,
 		},
 
 		// ── excluded by cmdName ────────────────────────────────────────────────
 		{
-			name: "needs onboarding + interactive + init",
+			name:  "needs onboarding + interactive + init",
 			state: needsOnboarding, interactive: true, cmdName: "init", want: false,
 		},
 		{
-			name: "needs onboarding + interactive + help",
+			name:  "needs onboarding + interactive + help",
 			state: needsOnboarding, interactive: true, cmdName: "help", want: false,
 		},
 		{
-			name: "needs onboarding + interactive + completion",
+			name:  "needs onboarding + interactive + completion",
 			state: needsOnboarding, interactive: true, cmdName: "completion", want: false,
 		},
 		{
-			name: "needs onboarding + interactive + version",
+			name:  "needs onboarding + interactive + version",
 			state: needsOnboarding, interactive: true, cmdName: "version", want: false,
 		},
 
 		// ── excluded by non-interactive ────────────────────────────────────────
 		{
-			name: "needs onboarding + non-interactive + eligible cmd",
+			name:  "needs onboarding + non-interactive + eligible cmd",
 			state: needsOnboarding, interactive: false, cmdName: "portfolio", want: false,
 		},
 
 		// ── excluded because no onboarding needed ─────────────────────────────
 		{
-			name: "has session only — no hint",
+			name:  "has session only — no hint",
 			state: hasSession, interactive: true, cmdName: "portfolio", want: false,
 		},
 		{
-			name: "has official only — no hint",
+			name:  "has official only — no hint",
 			state: hasOfficial, interactive: true, cmdName: "portfolio", want: false,
 		},
 		{
-			name: "has both — no hint",
+			name:  "has both — no hint",
 			state: hasBoth, interactive: true, cmdName: "portfolio", want: false,
 		},
 	}

--- a/cmd/tossctl/mcp.go
+++ b/cmd/tossctl/mcp.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/mcp"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/official"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/version"
+	"github.com/spf13/cobra"
+)
+
+// newMCPCmd builds the `tossctl mcp` command: a stdio Model Context Protocol
+// server exposing the official Toss Open API through a catalog tool surface
+// (list_operations / describe_operation / call_operation).
+//
+// It speaks JSON-RPC 2.0 over stdin/stdout and is meant to be launched by an
+// MCP host (Claude Code, Claude Desktop, Codex, etc.), not run interactively.
+func newMCPCmd(opts *rootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "mcp",
+		Short: "Run a stdio MCP server over the official Toss Open API (read-only catalog)",
+		Long: "Run a Model Context Protocol server on stdin/stdout that exposes the " +
+			"official Toss Open API as a catalog of read-only operations. Configure it " +
+			"in an MCP host as the command `tossctl mcp`. Requires saved Open API " +
+			"credentials (`tossctl openapi login`).",
+		Annotations:  map[string]string{"source": "official"},
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			credFile, tokenFile, err := resolveOpenAPIPaths(opts)
+			if err != nil {
+				return err
+			}
+			creds, err := official.LoadCredentials(os.Getenv, credFile)
+			if err != nil {
+				return err
+			}
+			if creds == nil {
+				return fmt.Errorf("no Open API credentials found; run `tossctl openapi login --key K --secret S` first")
+			}
+			client := official.New(*creds, tokenFile)
+			server := mcp.NewServer(client, "tossinvest-cli", version.Current().Version)
+			// Serve blocks until stdin reaches EOF (host closed the pipe).
+			return server.Serve(cmd.Context(), cmd.InOrStdin(), cmd.OutOrStdout())
+		},
+	}
+}

--- a/cmd/tossctl/mcp.go
+++ b/cmd/tossctl/mcp.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/JungHoonGhae/tossinvest-cli/internal/mcp"
 	"github.com/JungHoonGhae/tossinvest-cli/internal/official"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/trading"
 	"github.com/JungHoonGhae/tossinvest-cli/internal/version"
 	"github.com/spf13/cobra"
 )
@@ -19,11 +20,13 @@ import (
 func newMCPCmd(opts *rootOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "mcp",
-		Short: "Run a stdio MCP server over the official Toss Open API (read-only catalog)",
+		Short: "Run a stdio MCP server over the official Toss Open API (catalog surface)",
 		Long: "Run a Model Context Protocol server on stdin/stdout that exposes the " +
-			"official Toss Open API as a catalog of read-only operations. Configure it " +
-			"in an MCP host as the command `tossctl mcp`. Requires saved Open API " +
-			"credentials (`tossctl openapi login`).",
+			"official Toss Open API as a catalog of operations (reads plus gated order " +
+			"place/cancel/modify). Configure it in an MCP host as the command " +
+			"`tossctl mcp`. Order mutations follow the same config gate and " +
+			"execute/confirm flow as `tossctl order` and use the official API only " +
+			"(no WTS). Requires saved Open API credentials (`tossctl openapi login`).",
 		Annotations:  map[string]string{"source": "official"},
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
@@ -40,7 +43,17 @@ func newMCPCmd(opts *rootOptions) *cobra.Command {
 				return fmt.Errorf("no Open API credentials found; run `tossctl openapi login --key K --secret S` first")
 			}
 			client := official.New(*creds, tokenFile)
-			server := mcp.NewServer(client, "tossinvest-cli", version.Current().Version)
+
+			// Trading (order place/cancel/modify) is gated by config exactly as
+			// the CLI's `tossctl order` is, and routed through an official-only
+			// broker so writes never touch a WTS session.
+			cfg, err := loadConfig(opts)
+			if err != nil {
+				return err
+			}
+			tradingSvc := trading.NewService(cfg.Trading, mcp.OfficialBroker{Client: client})
+
+			server := mcp.NewServer(client, tradingSvc, "tossinvest-cli", version.Current().Version)
 			// Serve blocks until stdin reaches EOF (host closed the pipe).
 			return server.Serve(cmd.Context(), cmd.InOrStdin(), cmd.OutOrStdout())
 		},

--- a/cmd/tossctl/root.go
+++ b/cmd/tossctl/root.go
@@ -150,6 +150,7 @@ func newRootCmd() *cobra.Command {
 		newExportCmd(opts),
 		newPushCmd(opts),
 		newMonitorCmd(opts),
+		newMCPCmd(opts),
 	)
 
 	return cmd

--- a/internal/mcp/catalog.go
+++ b/internal/mcp/catalog.go
@@ -1,0 +1,129 @@
+// Package mcp implements a minimal stdio Model Context Protocol server that
+// fronts the official Toss Open API with a catalog-style tool surface.
+//
+// Rather than registering one MCP tool per API operation (which forces every
+// operation's schema into the model's context permanently), the server exposes
+// three fixed meta-tools — list_operations, describe_operation, call_operation —
+// backed by an internal registry of operations. This keeps the always-on tool
+// context small (three schemas) while still making every operation callable.
+//
+// The design mirrors the catalog mode of the KIS_MCP_Server reference
+// (list-kis-api-specs / get-kis-api-spec / call-kis-api).
+//
+// ponytail: operations are hand-registered as thin dispatchers over the tested
+// official.Client typed methods. When the official OpenAPI surface stabilises
+// further, this registry is the natural seam to generate directly from the spec
+// (see docs/migration; project goal "discovery-based dynamic commands"). Writes
+// (place/cancel/modify order) are intentionally not exposed yet — they must
+// route through the trading confirmation flow, tracked as a follow-up.
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/official"
+)
+
+// Param describes a single input parameter of an operation.
+type Param struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"` // "string" | "integer" | "boolean" | "string[]"
+	Required bool   `json:"required"`
+	Desc     string `json:"description,omitempty"`
+}
+
+// Operation is one callable API operation in the catalog.
+type Operation struct {
+	ID       string  `json:"id"`
+	Method   string  `json:"method"`
+	Path     string  `json:"path"`
+	Category string  `json:"category"`
+	Summary  string  `json:"summary"`
+	Params   []Param `json:"params"`
+	// handler executes the operation against an authenticated client.
+	handler func(ctx context.Context, c *official.Client, args map[string]any) (any, error)
+}
+
+// requiredNames returns the names of the operation's required parameters.
+func (o Operation) requiredNames() []string {
+	var out []string
+	for _, p := range o.Params {
+		if p.Required {
+			out = append(out, p.Name)
+		}
+	}
+	return out
+}
+
+// Catalog is the immutable registry of operations, indexed by ID.
+type Catalog struct {
+	ops  []Operation
+	byID map[string]Operation
+}
+
+// NewCatalog builds the read-only operation catalog over the official API.
+func NewCatalog() *Catalog {
+	ops := readOperations()
+	byID := make(map[string]Operation, len(ops))
+	for _, o := range ops {
+		byID[o.ID] = o
+	}
+	return &Catalog{ops: ops, byID: byID}
+}
+
+// List returns operations whose searchable text contains query (case-insensitive).
+// An empty query returns all operations. The result is capped at limit (<=0 means
+// the default of 200).
+func (c *Catalog) List(query string, limit int) []Operation {
+	if limit <= 0 || limit > 200 {
+		limit = 200
+	}
+	q := strings.ToLower(strings.TrimSpace(query))
+	out := make([]Operation, 0, len(c.ops))
+	for _, o := range c.ops {
+		if q != "" {
+			hay := strings.ToLower(o.ID + " " + o.Path + " " + o.Category + " " + o.Summary)
+			if !strings.Contains(hay, q) {
+				continue
+			}
+		}
+		out = append(out, o)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
+// Get returns the operation with the given ID.
+func (c *Catalog) Get(id string) (Operation, bool) {
+	o, ok := c.byID[id]
+	return o, ok
+}
+
+// Call validates the arguments against the operation's required parameters and
+// dispatches to its handler. It returns the operation's result payload.
+func (c *Catalog) Call(ctx context.Context, client *official.Client, id string, args map[string]any) (any, error) {
+	op, ok := c.byID[id]
+	if !ok {
+		return nil, fmt.Errorf("unknown operation %q (use list_operations to discover valid ids)", id)
+	}
+	if args == nil {
+		args = map[string]any{}
+	}
+	var missing []string
+	for _, p := range op.Params {
+		if !p.Required {
+			continue
+		}
+		if _, ok := args[p.Name]; !ok {
+			missing = append(missing, p.Name)
+		}
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("operation %q is missing required parameter(s): %s", id, strings.Join(missing, ", "))
+	}
+	return op.handler(ctx, client, args)
+}

--- a/internal/mcp/catalog.go
+++ b/internal/mcp/catalog.go
@@ -10,12 +10,16 @@
 // The design mirrors the catalog mode of the KIS_MCP_Server reference
 // (list-kis-api-specs / get-kis-api-spec / call-kis-api).
 //
-// ponytail: operations are hand-registered as thin dispatchers over the tested
-// official.Client typed methods. When the official OpenAPI surface stabilises
-// further, this registry is the natural seam to generate directly from the spec
-// (see docs/migration; project goal "discovery-based dynamic commands"). Writes
-// (place/cancel/modify order) are intentionally not exposed yet — they must
-// route through the trading confirmation flow, tracked as a follow-up.
+// Read operations are thin dispatchers over the tested official.Client typed
+// methods. Write operations (order place/cancel/modify) go through the shared
+// trading.Service — the same config gate, dry-run preview, and execute/confirm
+// token flow the `tossctl order` CLI uses — bound to an official-only broker so
+// no WTS web session is ever involved.
+//
+// ponytail: operations are hand-registered. When the official OpenAPI surface
+// stabilises further, this registry is the natural seam to generate directly
+// from the spec (see docs/migration; project goal "discovery-based dynamic
+// commands").
 package mcp
 
 import (
@@ -24,7 +28,18 @@ import (
 	"strings"
 
 	"github.com/JungHoonGhae/tossinvest-cli/internal/official"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/trading"
 )
+
+// Deps carries the backends a handler may need. Read operations use Client;
+// write (order-mutation) operations go through Trading, which applies the
+// config gate, dry-run preview, and confirm-token flow — the same policy the
+// `tossctl order` CLI enforces. Trading routes to an official-only broker, so
+// no WTS web session is involved.
+type Deps struct {
+	Client  *official.Client
+	Trading *trading.Service
+}
 
 // Param describes a single input parameter of an operation.
 type Param struct {
@@ -36,14 +51,17 @@ type Param struct {
 
 // Operation is one callable API operation in the catalog.
 type Operation struct {
-	ID       string  `json:"id"`
-	Method   string  `json:"method"`
-	Path     string  `json:"path"`
-	Category string  `json:"category"`
-	Summary  string  `json:"summary"`
-	Params   []Param `json:"params"`
-	// handler executes the operation against an authenticated client.
-	handler func(ctx context.Context, c *official.Client, args map[string]any) (any, error)
+	ID       string `json:"id"`
+	Method   string `json:"method"`
+	Path     string `json:"path"`
+	Category string `json:"category"`
+	Summary  string `json:"summary"`
+	// Write marks state-changing operations (order place/cancel/modify). They
+	// are gated by config and require an explicit execute + confirm token.
+	Write  bool    `json:"write"`
+	Params []Param `json:"params"`
+	// handler executes the operation against the given backends.
+	handler func(ctx context.Context, d *Deps, args map[string]any) (any, error)
 }
 
 // requiredNames returns the names of the operation's required parameters.
@@ -63,9 +81,10 @@ type Catalog struct {
 	byID map[string]Operation
 }
 
-// NewCatalog builds the read-only operation catalog over the official API.
+// NewCatalog builds the operation catalog over the official API (reads plus
+// gated order-mutation writes).
 func NewCatalog() *Catalog {
-	ops := readOperations()
+	ops := append(readOperations(), writeOperations()...)
 	byID := make(map[string]Operation, len(ops))
 	for _, o := range ops {
 		byID[o.ID] = o
@@ -105,7 +124,7 @@ func (c *Catalog) Get(id string) (Operation, bool) {
 
 // Call validates the arguments against the operation's required parameters and
 // dispatches to its handler. It returns the operation's result payload.
-func (c *Catalog) Call(ctx context.Context, client *official.Client, id string, args map[string]any) (any, error) {
+func (c *Catalog) Call(ctx context.Context, deps *Deps, id string, args map[string]any) (any, error) {
 	op, ok := c.byID[id]
 	if !ok {
 		return nil, fmt.Errorf("unknown operation %q (use list_operations to discover valid ids)", id)
@@ -125,5 +144,5 @@ func (c *Catalog) Call(ctx context.Context, client *official.Client, id string, 
 	if len(missing) > 0 {
 		return nil, fmt.Errorf("operation %q is missing required parameter(s): %s", id, strings.Join(missing, ", "))
 	}
-	return op.handler(ctx, client, args)
+	return op.handler(ctx, deps, args)
 }

--- a/internal/mcp/operations.go
+++ b/internal/mcp/operations.go
@@ -311,5 +311,24 @@ func readOperations() []Operation {
 				return d.Client.Commissions(ctx, symbol)
 			},
 		},
+		{
+			ID: "market_calendar", Method: "GET", Path: "/api/v1/market-calendar/{country}",
+			Category: "market", Summary: "Trading-hours calendar (prev/today/next business day) for KR or US.",
+			Params: []Param{
+				{Name: "country", Type: "string", Required: true, Desc: `"KR" or "US"`},
+				{Name: "date", Type: "string", Desc: "reference date YYYY-MM-DD (default: today)"},
+			},
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
+				country, err := argString(args, "country")
+				if err != nil {
+					return nil, err
+				}
+				date, err := argString(args, "date")
+				if err != nil {
+					return nil, err
+				}
+				return d.Client.MarketCalendar(ctx, country, date)
+			},
+		},
 	}
 }

--- a/internal/mcp/operations.go
+++ b/internal/mcp/operations.go
@@ -1,0 +1,315 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/official"
+)
+
+// ---------------------------------------------------------------------------
+// Argument coercion helpers.
+//
+// Arguments arrive as a JSON-decoded map, so numbers are float64, strings are
+// string, and arrays are []any. These helpers coerce leniently and report
+// clear errors for wrong types on required fields.
+// ---------------------------------------------------------------------------
+
+func argString(args map[string]any, name string) (string, error) {
+	v, ok := args[name]
+	if !ok {
+		return "", nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("parameter %q must be a string", name)
+	}
+	return s, nil
+}
+
+func argInt(args map[string]any, name string) (int, error) {
+	v, ok := args[name]
+	if !ok {
+		return 0, nil
+	}
+	switch n := v.(type) {
+	case float64:
+		return int(n), nil
+	case int:
+		return n, nil
+	default:
+		return 0, fmt.Errorf("parameter %q must be an integer", name)
+	}
+}
+
+func argBool(args map[string]any, name string) (bool, error) {
+	v, ok := args[name]
+	if !ok {
+		return false, nil
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return false, fmt.Errorf("parameter %q must be a boolean", name)
+	}
+	return b, nil
+}
+
+func argStringSlice(args map[string]any, name string) ([]string, error) {
+	v, ok := args[name]
+	if !ok {
+		return nil, nil
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf("parameter %q must be an array of strings", name)
+	}
+	out := make([]string, 0, len(arr))
+	for i, e := range arr {
+		s, ok := e.(string)
+		if !ok {
+			return nil, fmt.Errorf("parameter %q[%d] must be a string", name, i)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// readOperations returns the catalog of read-only official API operations.
+func readOperations() []Operation {
+	return []Operation{
+		{
+			ID: "accounts", Method: "GET", Path: "/api/v1/accounts",
+			Category: "account", Summary: "List brokerage accounts.",
+			handler: func(ctx context.Context, c *official.Client, _ map[string]any) (any, error) {
+				return c.Accounts(ctx)
+			},
+		},
+		{
+			ID: "buying_power", Method: "GET", Path: "/api/v1/buying-power",
+			Category: "account", Summary: "Cash buying power for a currency.",
+			Params: []Param{{Name: "currency", Type: "string", Required: true, Desc: `"KRW" or "USD"`}},
+			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+				currency, err := argString(args, "currency")
+				if err != nil {
+					return nil, err
+				}
+				return c.BuyingPower(ctx, currency)
+			},
+		},
+		{
+			ID: "holdings", Method: "GET", Path: "/api/v1/holdings",
+			Category: "account", Summary: "Current stock holdings; optionally filter by symbol.",
+			Params: []Param{{Name: "symbol", Type: "string", Desc: "optional ticker filter"}},
+			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+				symbol, err := argString(args, "symbol")
+				if err != nil {
+					return nil, err
+				}
+				return c.Holdings(ctx, symbol)
+			},
+		},
+		{
+			ID: "orders", Method: "GET", Path: "/api/v1/orders",
+			Category: "order", Summary: "List orders with optional filters.",
+			Params: []Param{
+				{Name: "status", Type: "string", Desc: `"OPEN" or "CLOSED"`},
+				{Name: "symbol", Type: "string"},
+				{Name: "from", Type: "string", Desc: "start date YYYY-MM-DD"},
+				{Name: "to", Type: "string", Desc: "end date YYYY-MM-DD"},
+				{Name: "cursor", Type: "string", Desc: "pagination cursor"},
+				{Name: "limit", Type: "integer"},
+			},
+			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+				var f official.OrdersFilter
+				var err error
+				if f.Status, err = argString(args, "status"); err != nil {
+					return nil, err
+				}
+				if f.Symbol, err = argString(args, "symbol"); err != nil {
+					return nil, err
+				}
+				if f.From, err = argString(args, "from"); err != nil {
+					return nil, err
+				}
+				if f.To, err = argString(args, "to"); err != nil {
+					return nil, err
+				}
+				if f.Cursor, err = argString(args, "cursor"); err != nil {
+					return nil, err
+				}
+				if f.Limit, err = argInt(args, "limit"); err != nil {
+					return nil, err
+				}
+				return c.Orders(ctx, f)
+			},
+		},
+		{
+			ID: "order", Method: "GET", Path: "/api/v1/orders/{orderId}",
+			Category: "order", Summary: "Fetch a single order by id.",
+			Params: []Param{{Name: "order_id", Type: "string", Required: true}},
+			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+				orderID, err := argString(args, "order_id")
+				if err != nil {
+					return nil, err
+				}
+				return c.OrderByID(ctx, orderID)
+			},
+		},
+		{
+			ID: "sellable_quantity", Method: "GET", Path: "/api/v1/sellable-quantity",
+			Category: "order", Summary: "Sellable quantity for a symbol.",
+			Params: []Param{{Name: "symbol", Type: "string", Required: true}},
+			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+				symbol, err := argString(args, "symbol")
+				if err != nil {
+					return nil, err
+				}
+				return c.SellableQuantity(ctx, symbol)
+			},
+		},
+		{
+			ID: "prices", Method: "GET", Path: "/api/v1/prices",
+			Category: "market", Summary: "Latest prices for one or more symbols.",
+			Params: []Param{{Name: "symbols", Type: "string[]", Required: true, Desc: "list of tickers"}},
+			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+				symbols, err := argStringSlice(args, "symbols")
+				if err != nil {
+					return nil, err
+				}
+				return c.Prices(ctx, symbols)
+			},
+		},
+		{
+			ID: "stocks", Method: "GET", Path: "/api/v1/stocks",
+			Category: "market", Summary: "Stock metadata/quotes for one or more symbols.",
+			Params: []Param{{Name: "symbols", Type: "string[]", Required: true, Desc: "list of tickers"}},
+			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+				symbols, err := argStringSlice(args, "symbols")
+				if err != nil {
+					return nil, err
+				}
+				return c.Stocks(ctx, symbols)
+			},
+		},
+		{
+			ID: "orderbook", Method: "GET", Path: "/api/v1/orderbook",
+			Category: "market", Summary: "Order book (bids/asks) for a symbol.",
+			Params: []Param{{Name: "symbol", Type: "string", Required: true}},
+			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+				symbol, err := argString(args, "symbol")
+				if err != nil {
+					return nil, err
+				}
+				return c.Orderbook(ctx, symbol)
+			},
+		},
+		{
+			ID: "trades", Method: "GET", Path: "/api/v1/trades",
+			Category: "market", Summary: "Recent trades for a symbol.",
+			Params: []Param{
+				{Name: "symbol", Type: "string", Required: true},
+				{Name: "count", Type: "integer", Desc: "number of trades (0 = API default)"},
+			},
+			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+				symbol, err := argString(args, "symbol")
+				if err != nil {
+					return nil, err
+				}
+				count, err := argInt(args, "count")
+				if err != nil {
+					return nil, err
+				}
+				return c.Trades(ctx, symbol, count)
+			},
+		},
+		{
+			ID: "candles", Method: "GET", Path: "/api/v1/candles",
+			Category: "market", Summary: "OHLC candles for a symbol.",
+			Params: []Param{
+				{Name: "symbol", Type: "string", Required: true},
+				{Name: "interval", Type: "string", Required: true, Desc: "e.g. 1d, 1w, 1m"},
+				{Name: "count", Type: "integer", Desc: "number of candles (0 = API default)"},
+				{Name: "before", Type: "string", Desc: "cursor: return candles before this timestamp"},
+				{Name: "adjusted", Type: "boolean", Desc: "price adjusted for splits/dividends"},
+			},
+			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+				symbol, err := argString(args, "symbol")
+				if err != nil {
+					return nil, err
+				}
+				interval, err := argString(args, "interval")
+				if err != nil {
+					return nil, err
+				}
+				count, err := argInt(args, "count")
+				if err != nil {
+					return nil, err
+				}
+				before, err := argString(args, "before")
+				if err != nil {
+					return nil, err
+				}
+				adjusted, err := argBool(args, "adjusted")
+				if err != nil {
+					return nil, err
+				}
+				return c.Candles(ctx, symbol, interval, count, before, adjusted)
+			},
+		},
+		{
+			ID: "price_limits", Method: "GET", Path: "/api/v1/price-limits",
+			Category: "market", Summary: "Upper/lower price limits for a symbol.",
+			Params: []Param{{Name: "symbol", Type: "string", Required: true}},
+			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+				symbol, err := argString(args, "symbol")
+				if err != nil {
+					return nil, err
+				}
+				return c.PriceLimits(ctx, symbol)
+			},
+		},
+		{
+			ID: "warnings", Method: "GET", Path: "/api/v1/stocks/{symbol}/warnings",
+			Category: "market", Summary: "Trading warnings/designations for a symbol.",
+			Params: []Param{{Name: "symbol", Type: "string", Required: true}},
+			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+				symbol, err := argString(args, "symbol")
+				if err != nil {
+					return nil, err
+				}
+				return c.Warnings(ctx, symbol)
+			},
+		},
+		{
+			ID: "exchange_rate", Method: "GET", Path: "/api/v1/exchange-rate",
+			Category: "market", Summary: "Exchange rate between two currencies.",
+			Params: []Param{
+				{Name: "base", Type: "string", Required: true, Desc: `e.g. "USD"`},
+				{Name: "quote", Type: "string", Required: true, Desc: `e.g. "KRW"`},
+			},
+			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+				base, err := argString(args, "base")
+				if err != nil {
+					return nil, err
+				}
+				quote, err := argString(args, "quote")
+				if err != nil {
+					return nil, err
+				}
+				return c.ExchangeRate(ctx, base, quote)
+			},
+		},
+		{
+			ID: "commissions", Method: "GET", Path: "/api/v1/commissions",
+			Category: "market", Summary: "Commission/fee schedule for a symbol.",
+			Params: []Param{{Name: "symbol", Type: "string", Required: true}},
+			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+				symbol, err := argString(args, "symbol")
+				if err != nil {
+					return nil, err
+				}
+				return c.Commissions(ctx, symbol)
+			},
+		},
+	}
+}

--- a/internal/mcp/operations.go
+++ b/internal/mcp/operations.go
@@ -80,32 +80,32 @@ func readOperations() []Operation {
 		{
 			ID: "accounts", Method: "GET", Path: "/api/v1/accounts",
 			Category: "account", Summary: "List brokerage accounts.",
-			handler: func(ctx context.Context, c *official.Client, _ map[string]any) (any, error) {
-				return c.Accounts(ctx)
+			handler: func(ctx context.Context, d *Deps, _ map[string]any) (any, error) {
+				return d.Client.Accounts(ctx)
 			},
 		},
 		{
 			ID: "buying_power", Method: "GET", Path: "/api/v1/buying-power",
 			Category: "account", Summary: "Cash buying power for a currency.",
 			Params: []Param{{Name: "currency", Type: "string", Required: true, Desc: `"KRW" or "USD"`}},
-			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
 				currency, err := argString(args, "currency")
 				if err != nil {
 					return nil, err
 				}
-				return c.BuyingPower(ctx, currency)
+				return d.Client.BuyingPower(ctx, currency)
 			},
 		},
 		{
 			ID: "holdings", Method: "GET", Path: "/api/v1/holdings",
 			Category: "account", Summary: "Current stock holdings; optionally filter by symbol.",
 			Params: []Param{{Name: "symbol", Type: "string", Desc: "optional ticker filter"}},
-			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
 				symbol, err := argString(args, "symbol")
 				if err != nil {
 					return nil, err
 				}
-				return c.Holdings(ctx, symbol)
+				return d.Client.Holdings(ctx, symbol)
 			},
 		},
 		{
@@ -119,7 +119,7 @@ func readOperations() []Operation {
 				{Name: "cursor", Type: "string", Desc: "pagination cursor"},
 				{Name: "limit", Type: "integer"},
 			},
-			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
 				var f official.OrdersFilter
 				var err error
 				if f.Status, err = argString(args, "status"); err != nil {
@@ -140,67 +140,67 @@ func readOperations() []Operation {
 				if f.Limit, err = argInt(args, "limit"); err != nil {
 					return nil, err
 				}
-				return c.Orders(ctx, f)
+				return d.Client.Orders(ctx, f)
 			},
 		},
 		{
 			ID: "order", Method: "GET", Path: "/api/v1/orders/{orderId}",
 			Category: "order", Summary: "Fetch a single order by id.",
 			Params: []Param{{Name: "order_id", Type: "string", Required: true}},
-			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
 				orderID, err := argString(args, "order_id")
 				if err != nil {
 					return nil, err
 				}
-				return c.OrderByID(ctx, orderID)
+				return d.Client.OrderByID(ctx, orderID)
 			},
 		},
 		{
 			ID: "sellable_quantity", Method: "GET", Path: "/api/v1/sellable-quantity",
 			Category: "order", Summary: "Sellable quantity for a symbol.",
 			Params: []Param{{Name: "symbol", Type: "string", Required: true}},
-			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
 				symbol, err := argString(args, "symbol")
 				if err != nil {
 					return nil, err
 				}
-				return c.SellableQuantity(ctx, symbol)
+				return d.Client.SellableQuantity(ctx, symbol)
 			},
 		},
 		{
 			ID: "prices", Method: "GET", Path: "/api/v1/prices",
 			Category: "market", Summary: "Latest prices for one or more symbols.",
 			Params: []Param{{Name: "symbols", Type: "string[]", Required: true, Desc: "list of tickers"}},
-			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
 				symbols, err := argStringSlice(args, "symbols")
 				if err != nil {
 					return nil, err
 				}
-				return c.Prices(ctx, symbols)
+				return d.Client.Prices(ctx, symbols)
 			},
 		},
 		{
 			ID: "stocks", Method: "GET", Path: "/api/v1/stocks",
 			Category: "market", Summary: "Stock metadata/quotes for one or more symbols.",
 			Params: []Param{{Name: "symbols", Type: "string[]", Required: true, Desc: "list of tickers"}},
-			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
 				symbols, err := argStringSlice(args, "symbols")
 				if err != nil {
 					return nil, err
 				}
-				return c.Stocks(ctx, symbols)
+				return d.Client.Stocks(ctx, symbols)
 			},
 		},
 		{
 			ID: "orderbook", Method: "GET", Path: "/api/v1/orderbook",
 			Category: "market", Summary: "Order book (bids/asks) for a symbol.",
 			Params: []Param{{Name: "symbol", Type: "string", Required: true}},
-			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
 				symbol, err := argString(args, "symbol")
 				if err != nil {
 					return nil, err
 				}
-				return c.Orderbook(ctx, symbol)
+				return d.Client.Orderbook(ctx, symbol)
 			},
 		},
 		{
@@ -210,7 +210,7 @@ func readOperations() []Operation {
 				{Name: "symbol", Type: "string", Required: true},
 				{Name: "count", Type: "integer", Desc: "number of trades (0 = API default)"},
 			},
-			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
 				symbol, err := argString(args, "symbol")
 				if err != nil {
 					return nil, err
@@ -219,7 +219,7 @@ func readOperations() []Operation {
 				if err != nil {
 					return nil, err
 				}
-				return c.Trades(ctx, symbol, count)
+				return d.Client.Trades(ctx, symbol, count)
 			},
 		},
 		{
@@ -232,7 +232,7 @@ func readOperations() []Operation {
 				{Name: "before", Type: "string", Desc: "cursor: return candles before this timestamp"},
 				{Name: "adjusted", Type: "boolean", Desc: "price adjusted for splits/dividends"},
 			},
-			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
 				symbol, err := argString(args, "symbol")
 				if err != nil {
 					return nil, err
@@ -253,31 +253,31 @@ func readOperations() []Operation {
 				if err != nil {
 					return nil, err
 				}
-				return c.Candles(ctx, symbol, interval, count, before, adjusted)
+				return d.Client.Candles(ctx, symbol, interval, count, before, adjusted)
 			},
 		},
 		{
 			ID: "price_limits", Method: "GET", Path: "/api/v1/price-limits",
 			Category: "market", Summary: "Upper/lower price limits for a symbol.",
 			Params: []Param{{Name: "symbol", Type: "string", Required: true}},
-			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
 				symbol, err := argString(args, "symbol")
 				if err != nil {
 					return nil, err
 				}
-				return c.PriceLimits(ctx, symbol)
+				return d.Client.PriceLimits(ctx, symbol)
 			},
 		},
 		{
 			ID: "warnings", Method: "GET", Path: "/api/v1/stocks/{symbol}/warnings",
 			Category: "market", Summary: "Trading warnings/designations for a symbol.",
 			Params: []Param{{Name: "symbol", Type: "string", Required: true}},
-			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
 				symbol, err := argString(args, "symbol")
 				if err != nil {
 					return nil, err
 				}
-				return c.Warnings(ctx, symbol)
+				return d.Client.Warnings(ctx, symbol)
 			},
 		},
 		{
@@ -287,7 +287,7 @@ func readOperations() []Operation {
 				{Name: "base", Type: "string", Required: true, Desc: `e.g. "USD"`},
 				{Name: "quote", Type: "string", Required: true, Desc: `e.g. "KRW"`},
 			},
-			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
 				base, err := argString(args, "base")
 				if err != nil {
 					return nil, err
@@ -296,19 +296,19 @@ func readOperations() []Operation {
 				if err != nil {
 					return nil, err
 				}
-				return c.ExchangeRate(ctx, base, quote)
+				return d.Client.ExchangeRate(ctx, base, quote)
 			},
 		},
 		{
 			ID: "commissions", Method: "GET", Path: "/api/v1/commissions",
 			Category: "market", Summary: "Commission/fee schedule for a symbol.",
 			Params: []Param{{Name: "symbol", Type: "string", Required: true}},
-			handler: func(ctx context.Context, c *official.Client, args map[string]any) (any, error) {
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
 				symbol, err := argString(args, "symbol")
 				if err != nil {
 					return nil, err
 				}
-				return c.Commissions(ctx, symbol)
+				return d.Client.Commissions(ctx, symbol)
 			},
 		},
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,279 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/official"
+)
+
+// protocolVersion is the MCP protocol version this server defaults to when the
+// client does not specify one during initialize.
+const protocolVersion = "2025-06-18"
+
+// Server is a minimal stdio MCP server exposing the catalog tool surface over
+// an authenticated official.Client.
+//
+// ponytail: the MCP stdio transport is newline-delimited JSON-RPC 2.0 with a
+// tiny method set (initialize, tools/list, tools/call). It is hand-rolled here
+// to avoid a new dependency for three tools; swap in an MCP SDK if the surface
+// grows materially.
+type Server struct {
+	catalog *Catalog
+	client  *official.Client
+	name    string
+	version string
+}
+
+// NewServer constructs a Server over the given authenticated client.
+func NewServer(client *official.Client, name, version string) *Server {
+	return &Server{
+		catalog: NewCatalog(),
+		client:  client,
+		name:    name,
+		version: version,
+	}
+}
+
+// --- JSON-RPC 2.0 wire types ------------------------------------------------
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"` // absent => notification
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+const (
+	codeMethodNotFound = -32601
+	codeInvalidParams  = -32602
+)
+
+// Serve reads newline-delimited JSON-RPC messages from in and writes responses
+// to out until in reaches EOF. Notifications (requests without an id) are
+// handled without producing a response, per the JSON-RPC spec.
+func (s *Server) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
+	r := bufio.NewReader(in)
+	enc := json.NewEncoder(out) // Encode appends '\n', giving newline framing.
+	for {
+		line, readErr := r.ReadBytes('\n')
+		if trimmed := bytes.TrimSpace(line); len(trimmed) > 0 {
+			if resp, ok := s.handle(ctx, trimmed); ok {
+				if err := enc.Encode(resp); err != nil {
+					return err
+				}
+			}
+		}
+		if readErr == io.EOF {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+}
+
+// handle processes one raw JSON-RPC message. It returns (response, true) for
+// requests and (_, false) for notifications, which take no response.
+func (s *Server) handle(ctx context.Context, raw []byte) (rpcResponse, bool) {
+	var req rpcRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		// Malformed frame with no recoverable id: drop it silently rather than
+		// guessing an id, matching lenient MCP host behaviour.
+		return rpcResponse{}, false
+	}
+	isNotification := len(req.ID) == 0
+
+	result, rerr := s.dispatch(ctx, req.Method, req.Params)
+
+	if isNotification {
+		return rpcResponse{}, false
+	}
+	resp := rpcResponse{JSONRPC: "2.0", ID: req.ID}
+	if rerr != nil {
+		resp.Error = rerr
+	} else {
+		resp.Result = result
+	}
+	return resp, true
+}
+
+// dispatch routes a method to its handler, returning either a result or an error.
+func (s *Server) dispatch(ctx context.Context, method string, params json.RawMessage) (any, *rpcError) {
+	switch method {
+	case "initialize":
+		return s.handleInitialize(params), nil
+	case "notifications/initialized", "notifications/cancelled":
+		return nil, nil // notifications: ignored
+	case "ping":
+		return map[string]any{}, nil
+	case "tools/list":
+		return s.handleToolsList(), nil
+	case "tools/call":
+		return s.handleToolsCall(ctx, params)
+	default:
+		return nil, &rpcError{Code: codeMethodNotFound, Message: "method not found: " + method}
+	}
+}
+
+func (s *Server) handleInitialize(params json.RawMessage) any {
+	// Echo the client's requested protocol version when present.
+	version := protocolVersion
+	var p struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if len(params) > 0 && json.Unmarshal(params, &p) == nil && p.ProtocolVersion != "" {
+		version = p.ProtocolVersion
+	}
+	return map[string]any{
+		"protocolVersion": version,
+		"capabilities":    map[string]any{"tools": map[string]any{}},
+		"serverInfo":      map[string]any{"name": s.name, "version": s.version},
+	}
+}
+
+// --- tools ------------------------------------------------------------------
+
+type toolDef struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	InputSchema any    `json:"inputSchema"`
+}
+
+func (s *Server) handleToolsList() any {
+	obj := func(props map[string]any, required ...string) map[string]any {
+		schema := map[string]any{"type": "object", "properties": props}
+		if len(required) > 0 {
+			schema["required"] = required
+		}
+		return schema
+	}
+	tools := []toolDef{
+		{
+			Name:        "list_operations",
+			Description: "List available Toss official API operations (id, method, path, summary). Optionally filter with a case-insensitive query. Call this first to discover operation ids.",
+			InputSchema: obj(map[string]any{
+				"query": map[string]any{"type": "string", "description": "case-insensitive substring filter over id/path/category/summary"},
+				"limit": map[string]any{"type": "integer", "description": "max results (default 200)"},
+			}),
+		},
+		{
+			Name:        "describe_operation",
+			Description: "Get the full parameter schema for one operation id (from list_operations).",
+			InputSchema: obj(map[string]any{
+				"operation": map[string]any{"type": "string", "description": "operation id"},
+			}, "operation"),
+		},
+		{
+			Name:        "call_operation",
+			Description: "Call a Toss official API operation by id with its parameters. Read-only operations only. Returns the JSON result payload.",
+			InputSchema: obj(map[string]any{
+				"operation": map[string]any{"type": "string", "description": "operation id"},
+				"params":    map[string]any{"type": "object", "description": "operation parameters (see describe_operation)"},
+			}, "operation"),
+		},
+	}
+	return map[string]any{"tools": tools}
+}
+
+// toolResult builds an MCP tools/call result carrying JSON-encoded text content.
+func toolResult(payload any, isError bool) (any, *rpcError) {
+	text, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: "encoding result: " + err.Error()}
+	}
+	return map[string]any{
+		"content": []map[string]any{{"type": "text", "text": string(text)}},
+		"isError": isError,
+	}, nil
+}
+
+// toolError builds an isError result with a plain message so the model sees it.
+func toolError(format string, a ...any) (any, *rpcError) {
+	return map[string]any{
+		"content": []map[string]any{{"type": "text", "text": fmt.Sprintf(format, a...)}},
+		"isError": true,
+	}, nil
+}
+
+func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (any, *rpcError) {
+	var call struct {
+		Name      string         `json:"name"`
+		Arguments map[string]any `json:"arguments"`
+	}
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &call); err != nil {
+			return nil, &rpcError{Code: codeInvalidParams, Message: "invalid tools/call params: " + err.Error()}
+		}
+	}
+	switch call.Name {
+	case "list_operations":
+		query, _ := call.Arguments["query"].(string)
+		limit := 0
+		if v, ok := call.Arguments["limit"].(float64); ok {
+			limit = int(v)
+		}
+		return toolResult(s.listOperationsPayload(query, limit), false)
+	case "describe_operation":
+		id, _ := call.Arguments["operation"].(string)
+		if id == "" {
+			return toolError("describe_operation requires the 'operation' parameter")
+		}
+		op, ok := s.catalog.Get(id)
+		if !ok {
+			return toolError("unknown operation %q (use list_operations)", id)
+		}
+		return toolResult(op, false)
+	case "call_operation":
+		id, _ := call.Arguments["operation"].(string)
+		if id == "" {
+			return toolError("call_operation requires the 'operation' parameter")
+		}
+		opArgs, _ := call.Arguments["params"].(map[string]any)
+		result, err := s.catalog.Call(ctx, s.client, id, opArgs)
+		if err != nil {
+			return toolError("%s", err.Error())
+		}
+		return toolResult(result, false)
+	default:
+		return nil, &rpcError{Code: codeMethodNotFound, Message: "unknown tool: " + call.Name}
+	}
+}
+
+// listItem is the compact per-operation shape returned by list_operations.
+type listItem struct {
+	ID       string   `json:"id"`
+	Method   string   `json:"method"`
+	Path     string   `json:"path"`
+	Category string   `json:"category"`
+	Summary  string   `json:"summary"`
+	Required []string `json:"required,omitempty"`
+}
+
+func (s *Server) listOperationsPayload(query string, limit int) any {
+	ops := s.catalog.List(query, limit)
+	items := make([]listItem, 0, len(ops))
+	for _, o := range ops {
+		items = append(items, listItem{
+			ID: o.ID, Method: o.Method, Path: o.Path,
+			Category: o.Category, Summary: o.Summary, Required: o.requiredNames(),
+		})
+	}
+	return map[string]any{"count": len(items), "operations": items}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -9,6 +9,7 @@ import (
 	"io"
 
 	"github.com/JungHoonGhae/tossinvest-cli/internal/official"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/trading"
 )
 
 // protocolVersion is the MCP protocol version this server defaults to when the
@@ -24,16 +25,18 @@ const protocolVersion = "2025-06-18"
 // grows materially.
 type Server struct {
 	catalog *Catalog
-	client  *official.Client
+	deps    *Deps
 	name    string
 	version string
 }
 
-// NewServer constructs a Server over the given authenticated client.
-func NewServer(client *official.Client, name, version string) *Server {
+// NewServer constructs a Server over the given authenticated client and trading
+// service. tradingSvc drives gated order-mutation operations; pass one built on
+// an OfficialBroker so writes never touch a WTS session.
+func NewServer(client *official.Client, tradingSvc *trading.Service, name, version string) *Server {
 	return &Server{
 		catalog: NewCatalog(),
-		client:  client,
+		deps:    &Deps{Client: client, Trading: tradingSvc},
 		name:    name,
 		version: version,
 	}
@@ -182,7 +185,7 @@ func (s *Server) handleToolsList() any {
 		},
 		{
 			Name:        "call_operation",
-			Description: "Call a Toss official API operation by id with its parameters. Read-only operations only. Returns the JSON result payload.",
+			Description: "Call a Toss official API operation by id with its parameters. Reads return the JSON payload. Write operations (place/cancel/modify order) are gated: without execute=true they return a dry-run preview with a confirm_token; pass execute=true plus confirm=<token> to submit (also requires config to enable trading).",
 			InputSchema: obj(map[string]any{
 				"operation": map[string]any{"type": "string", "description": "operation id"},
 				"params":    map[string]any{"type": "object", "description": "operation parameters (see describe_operation)"},
@@ -246,7 +249,7 @@ func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (a
 			return toolError("call_operation requires the 'operation' parameter")
 		}
 		opArgs, _ := call.Arguments["params"].(map[string]any)
-		result, err := s.catalog.Call(ctx, s.client, id, opArgs)
+		result, err := s.catalog.Call(ctx, s.deps, id, opArgs)
 		if err != nil {
 			return toolError("%s", err.Error())
 		}
@@ -263,6 +266,7 @@ type listItem struct {
 	Path     string   `json:"path"`
 	Category string   `json:"category"`
 	Summary  string   `json:"summary"`
+	Write    bool     `json:"write,omitempty"`
 	Required []string `json:"required,omitempty"`
 }
 
@@ -272,7 +276,7 @@ func (s *Server) listOperationsPayload(query string, limit int) any {
 	for _, o := range ops {
 		items = append(items, listItem{
 			ID: o.ID, Method: o.Method, Path: o.Path,
-			Category: o.Category, Summary: o.Summary, Required: o.requiredNames(),
+			Category: o.Category, Summary: o.Summary, Write: o.Write, Required: o.requiredNames(),
 		})
 	}
 	return map[string]any{"count": len(items), "operations": items}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,213 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/official"
+)
+
+// runServer feeds newline-delimited JSON-RPC request lines through Serve and
+// returns the decoded responses (one per line the server emitted).
+func runServer(t *testing.T, client *official.Client, lines ...string) []map[string]any {
+	t.Helper()
+	in := strings.NewReader(strings.Join(lines, "\n") + "\n")
+	var out bytes.Buffer
+	s := NewServer(client, "test", "0.0.0")
+	if err := s.Serve(context.Background(), in, &out); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	var resps []map[string]any
+	for _, raw := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if raw == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(raw), &m); err != nil {
+			t.Fatalf("decoding response %q: %v", raw, err)
+		}
+		resps = append(resps, m)
+	}
+	return resps
+}
+
+// dummyClient builds an official.Client pointed at an httptest server that
+// serves the token endpoint plus any provided path→body responses (dummy data).
+func dummyClient(t *testing.T, routes map[string]string) *official.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/oauth2/token" {
+			_, _ = w.Write([]byte(`{"access_token":"AT","expires_in":3600,"token_type":"Bearer"}`))
+			return
+		}
+		if body, ok := routes[r.URL.Path]; ok {
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return official.New(
+		official.Credentials{APIKey: "k", SecretKey: "s"},
+		filepath.Join(t.TempDir(), "t.json"),
+		official.WithBaseURL(srv.URL),
+		official.WithHTTPClient(srv.Client()),
+	)
+}
+
+func resultOf(t *testing.T, resp map[string]any) map[string]any {
+	t.Helper()
+	res, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("response has no result object: %v", resp)
+	}
+	return res
+}
+
+// toolText extracts the text of the first content block from a tools/call result.
+func toolText(t *testing.T, resp map[string]any) (string, bool) {
+	t.Helper()
+	res := resultOf(t, resp)
+	isErr, _ := res["isError"].(bool)
+	content, ok := res["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("result has no content: %v", res)
+	}
+	block := content[0].(map[string]any)
+	return block["text"].(string), isErr
+}
+
+func TestInitializeEchoesProtocolVersion(t *testing.T) {
+	c := dummyClient(t, nil)
+	resps := runServer(t, c,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}`,
+	)
+	if len(resps) != 1 {
+		t.Fatalf("want 1 response, got %d", len(resps))
+	}
+	res := resultOf(t, resps[0])
+	if res["protocolVersion"] != "2025-03-26" {
+		t.Errorf("protocolVersion = %v, want echoed 2025-03-26", res["protocolVersion"])
+	}
+	if _, ok := res["capabilities"].(map[string]any)["tools"]; !ok {
+		t.Errorf("capabilities missing tools: %v", res["capabilities"])
+	}
+}
+
+func TestNotificationProducesNoResponse(t *testing.T) {
+	c := dummyClient(t, nil)
+	resps := runServer(t, c,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"ping"}`,
+	)
+	// Only the ping (which has an id) should get a response.
+	if len(resps) != 1 {
+		t.Fatalf("want 1 response (ping only), got %d: %v", len(resps), resps)
+	}
+	if resps[0]["id"].(float64) != 2 {
+		t.Errorf("response id = %v, want 2", resps[0]["id"])
+	}
+}
+
+func TestToolsListExposesThreeCatalogTools(t *testing.T) {
+	c := dummyClient(t, nil)
+	resps := runServer(t, c, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	tools := resultOf(t, resps[0])["tools"].([]any)
+	got := map[string]bool{}
+	for _, tl := range tools {
+		got[tl.(map[string]any)["name"].(string)] = true
+	}
+	for _, want := range []string{"list_operations", "describe_operation", "call_operation"} {
+		if !got[want] {
+			t.Errorf("tools/list missing %q; got %v", want, got)
+		}
+	}
+	if len(tools) != 3 {
+		t.Errorf("want exactly 3 always-on tools, got %d", len(tools))
+	}
+}
+
+func TestListOperationsFiltersByQuery(t *testing.T) {
+	c := dummyClient(t, nil)
+	resps := runServer(t, c,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_operations","arguments":{"query":"orderbook"}}}`,
+	)
+	text, isErr := toolText(t, resps[0])
+	if isErr {
+		t.Fatalf("unexpected error result: %s", text)
+	}
+	var payload struct {
+		Count      int `json:"count"`
+		Operations []struct {
+			ID string `json:"id"`
+		} `json:"operations"`
+	}
+	if err := json.Unmarshal([]byte(text), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Count != 1 || payload.Operations[0].ID != "orderbook" {
+		t.Fatalf("query orderbook: got %+v", payload)
+	}
+}
+
+func TestDescribeUnknownOperationIsToolError(t *testing.T) {
+	c := dummyClient(t, nil)
+	resps := runServer(t, c,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"describe_operation","arguments":{"operation":"nope"}}}`,
+	)
+	text, isErr := toolText(t, resps[0])
+	if !isErr {
+		t.Fatalf("want isError for unknown operation, got: %s", text)
+	}
+	if !strings.Contains(text, "unknown operation") {
+		t.Errorf("error text = %q", text)
+	}
+}
+
+func TestCallOperationAccountsDispatches(t *testing.T) {
+	c := dummyClient(t, map[string]string{
+		"/api/v1/accounts": `{"result":[{"accountNo":"123-45","accountSeq":7,"accountType":"BROKERAGE"}]}`,
+	})
+	resps := runServer(t, c,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"call_operation","arguments":{"operation":"accounts"}}}`,
+	)
+	text, isErr := toolText(t, resps[0])
+	if isErr {
+		t.Fatalf("unexpected error: %s", text)
+	}
+	if !strings.Contains(text, "123-45") {
+		t.Errorf("account payload missing dummy data: %s", text)
+	}
+}
+
+func TestCallOperationMissingRequiredParam(t *testing.T) {
+	c := dummyClient(t, nil)
+	resps := runServer(t, c,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"call_operation","arguments":{"operation":"buying_power"}}}`,
+	)
+	text, isErr := toolText(t, resps[0])
+	if !isErr {
+		t.Fatalf("want isError for missing currency, got: %s", text)
+	}
+	if !strings.Contains(text, "currency") {
+		t.Errorf("error should name the missing param: %q", text)
+	}
+}
+
+func TestUnknownMethodReturnsRPCError(t *testing.T) {
+	c := dummyClient(t, nil)
+	resps := runServer(t, c, `{"jsonrpc":"2.0","id":9,"method":"does/not/exist"}`)
+	if _, ok := resps[0]["error"]; !ok {
+		t.Fatalf("want JSON-RPC error, got: %v", resps[0])
+	}
+	code := resps[0]["error"].(map[string]any)["code"].(float64)
+	if int(code) != codeMethodNotFound {
+		t.Errorf("code = %v, want %d", code, codeMethodNotFound)
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -10,16 +10,26 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/JungHoonGhae/tossinvest-cli/internal/config"
 	"github.com/JungHoonGhae/tossinvest-cli/internal/official"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/trading"
 )
 
-// runServer feeds newline-delimited JSON-RPC request lines through Serve and
-// returns the decoded responses (one per line the server emitted).
+// runServer feeds request lines through a server whose trading is fully
+// disabled (the default config posture).
 func runServer(t *testing.T, client *official.Client, lines ...string) []map[string]any {
+	t.Helper()
+	return runServerPolicy(t, client, config.Trading{}, lines...)
+}
+
+// runServerPolicy is like runServer but with an explicit trading policy, used to
+// exercise the write gate.
+func runServerPolicy(t *testing.T, client *official.Client, policy config.Trading, lines ...string) []map[string]any {
 	t.Helper()
 	in := strings.NewReader(strings.Join(lines, "\n") + "\n")
 	var out bytes.Buffer
-	s := NewServer(client, "test", "0.0.0")
+	tradingSvc := trading.NewService(policy, OfficialBroker{Client: client})
+	s := NewServer(client, tradingSvc, "test", "0.0.0")
 	if err := s.Serve(context.Background(), in, &out); err != nil {
 		t.Fatalf("Serve: %v", err)
 	}
@@ -197,6 +207,113 @@ func TestCallOperationMissingRequiredParam(t *testing.T) {
 	}
 	if !strings.Contains(text, "currency") {
 		t.Errorf("error should name the missing param: %q", text)
+	}
+}
+
+func TestListOperationsIncludesGatedWrites(t *testing.T) {
+	c := dummyClient(t, nil)
+	resps := runServer(t, c,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_operations","arguments":{"query":"place_order"}}}`,
+	)
+	text, _ := toolText(t, resps[0])
+	var payload struct {
+		Operations []struct {
+			ID    string `json:"id"`
+			Write bool   `json:"write"`
+		} `json:"operations"`
+	}
+	if err := json.Unmarshal([]byte(text), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Operations) != 1 || !payload.Operations[0].Write {
+		t.Fatalf("place_order should be listed as a write op: %+v", payload.Operations)
+	}
+}
+
+func TestPlaceOrderPreviewDoesNotExecute(t *testing.T) {
+	// No routes: a live POST would 404. Preview must not hit the network.
+	c := dummyClient(t, nil)
+	resps := runServer(t, c,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"call_operation","arguments":{"operation":"place_order","params":{"symbol":"AAPL","side":"buy","market":"us","quantity":1,"price":100,"currency_mode":"USD"}}}}`,
+	)
+	text, isErr := toolText(t, resps[0])
+	if isErr {
+		t.Fatalf("preview should not error: %s", text)
+	}
+	var preview struct {
+		Kind          string `json:"kind"`
+		ConfirmToken  string `json:"confirm_token"`
+		MutationReady bool   `json:"mutation_ready"`
+	}
+	if err := json.Unmarshal([]byte(text), &preview); err != nil {
+		t.Fatal(err)
+	}
+	if preview.Kind != "place" || preview.ConfirmToken == "" {
+		t.Fatalf("unexpected preview: %s", text)
+	}
+	if preview.MutationReady {
+		t.Errorf("mutation_ready must be false when config disables trading")
+	}
+}
+
+func TestPlaceOrderExecuteBlockedWhenDisabled(t *testing.T) {
+	c := dummyClient(t, nil) // disabled policy (default)
+	resps := runServer(t, c,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"call_operation","arguments":{"operation":"place_order","params":{"symbol":"AAPL","side":"buy","market":"us","quantity":1,"price":100,"currency_mode":"USD","execute":true,"confirm":"whatever"}}}}`,
+	)
+	text, isErr := toolText(t, resps[0])
+	if !isErr {
+		t.Fatalf("execute with trading disabled must be an error, got: %s", text)
+	}
+}
+
+func TestPlaceOrderExecuteSubmitsWhenEnabled(t *testing.T) {
+	c := dummyClient(t, map[string]string{
+		"/api/v1/accounts": `{"result":[{"accountNo":"123-45","accountSeq":7,"accountType":"BROKERAGE"}]}`,
+		"/api/v1/orders":   `{"result":{"orderId":"ORD-777"}}`,
+	})
+	policy := config.Trading{Place: true, AllowLiveOrderActions: true}
+
+	// Step 1: preview to obtain the confirm token.
+	preResp := runServerPolicy(t, c, policy,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"call_operation","arguments":{"operation":"place_order","params":{"symbol":"AAPL","side":"buy","market":"us","quantity":1,"price":100,"currency_mode":"USD"}}}}`,
+	)
+	preText, _ := toolText(t, preResp[0])
+	var preview struct {
+		ConfirmToken  string `json:"confirm_token"`
+		MutationReady bool   `json:"mutation_ready"`
+	}
+	if err := json.Unmarshal([]byte(preText), &preview); err != nil {
+		t.Fatal(err)
+	}
+	if !preview.MutationReady {
+		t.Fatalf("mutation_ready should be true with enabling policy: %s", preText)
+	}
+
+	// Step 2: execute with the token.
+	line := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"call_operation","arguments":{"operation":"place_order","params":{"symbol":"AAPL","side":"buy","market":"us","quantity":1,"price":100,"currency_mode":"USD","execute":true,"confirm":"` + preview.ConfirmToken + `"}}}}`
+	execResp := runServerPolicy(t, c, policy, line)
+	execText, isErr := toolText(t, execResp[0])
+	if isErr {
+		t.Fatalf("execute with valid token should succeed: %s", execText)
+	}
+	if !strings.Contains(execText, "ORD-777") {
+		t.Errorf("expected order id in result: %s", execText)
+	}
+}
+
+func TestPlaceOrderExecuteWrongTokenFails(t *testing.T) {
+	c := dummyClient(t, map[string]string{
+		"/api/v1/accounts": `{"result":[{"accountNo":"123-45","accountSeq":7,"accountType":"BROKERAGE"}]}`,
+		"/api/v1/orders":   `{"result":{"orderId":"ORD-777"}}`,
+	})
+	policy := config.Trading{Place: true, AllowLiveOrderActions: true}
+	resps := runServerPolicy(t, c, policy,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"call_operation","arguments":{"operation":"place_order","params":{"symbol":"AAPL","side":"buy","market":"us","quantity":1,"price":100,"currency_mode":"USD","execute":true,"confirm":"bad-token"}}}}`,
+	)
+	text, isErr := toolText(t, resps[0])
+	if !isErr {
+		t.Fatalf("execute with wrong confirm token must fail, got: %s", text)
 	}
 }
 

--- a/internal/mcp/writes.go
+++ b/internal/mcp/writes.go
@@ -1,0 +1,242 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/official"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/orderintent"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/trading"
+)
+
+// OfficialBroker adapts *official.Client to the trading.Broker interface using
+// only the official Open API — no WTS web session. It lets the shared
+// trading.Service (config gate + dry-run preview + confirm-token flow) drive
+// order mutations over the official path.
+//
+// GetOrderAvailableActions has no official-API equivalent (the hybrid broker
+// sources it from WTS), so it returns an empty set: the official cancel/modify
+// endpoints validate cancellability server-side and reject if not allowed.
+type OfficialBroker struct {
+	Client *official.Client
+}
+
+func (b OfficialBroker) PlacePendingOrder(ctx context.Context, intent orderintent.PlaceIntent) (trading.MutationResult, error) {
+	return b.Client.PlaceOrder(ctx, intent)
+}
+
+func (b OfficialBroker) CancelPendingOrder(ctx context.Context, intent orderintent.CancelIntent) (trading.MutationResult, error) {
+	return b.Client.CancelOrder(ctx, intent.OrderID)
+}
+
+func (b OfficialBroker) AmendPendingOrder(ctx context.Context, intent orderintent.AmendIntent) (trading.MutationResult, error) {
+	return b.Client.ModifyOrder(ctx, intent)
+}
+
+func (b OfficialBroker) GetOrderAvailableActions(_ context.Context, _ string) (map[string]any, error) {
+	return map[string]any{}, nil
+}
+
+// argFloat coerces an optional numeric argument to float64.
+func argFloat(args map[string]any, name string) (float64, error) {
+	v, ok := args[name]
+	if !ok {
+		return 0, nil
+	}
+	f, ok := v.(float64)
+	if !ok {
+		return 0, fmt.Errorf("parameter %q must be a number", name)
+	}
+	return f, nil
+}
+
+// argFloatPtr returns a *float64 that is nil when the argument is absent,
+// distinguishing "not provided" from "zero" (needed for partial amends).
+func argFloatPtr(args map[string]any, name string) (*float64, error) {
+	if _, ok := args[name]; !ok {
+		return nil, nil
+	}
+	f, err := argFloat(args, name)
+	if err != nil {
+		return nil, err
+	}
+	return &f, nil
+}
+
+// executeArgs pulls the shared execute/confirm parameters common to all writes.
+//
+// The two-step flow mirrors `tossctl order … --execute --confirm <token>`:
+//   - execute omitted/false → return a dry-run Preview (with confirm_token).
+//   - execute true          → submit the mutation, requiring the confirm token
+//     and the config gates (per-action + allow_live_order_actions).
+func executeArgs(args map[string]any) (execute bool, confirm string, err error) {
+	if execute, err = argBool(args, "execute"); err != nil {
+		return false, "", err
+	}
+	if confirm, err = argString(args, "confirm"); err != nil {
+		return false, "", err
+	}
+	return execute, confirm, nil
+}
+
+var executeParams = []Param{
+	{Name: "execute", Type: "boolean", Desc: "false/omitted = dry-run preview; true = submit the live order"},
+	{Name: "confirm", Type: "string", Desc: "confirm_token from the preview (required when execute=true)"},
+}
+
+// writeOperations returns the catalog of state-changing order operations.
+// They are gated by config (trading.* toggles + allow_live_order_actions) and
+// routed through the official Open API only.
+func writeOperations() []Operation {
+	return []Operation{
+		{
+			ID: "place_order", Method: "POST", Path: "/api/v1/orders",
+			Category: "order", Summary: "Place a new order (US/KR, limit or US fractional market). Gated; preview unless execute=true.",
+			Write: true,
+			Params: append([]Param{
+				{Name: "symbol", Type: "string", Required: true},
+				{Name: "side", Type: "string", Required: true, Desc: `"buy" or "sell"`},
+				{Name: "market", Type: "string", Desc: `"us" or "kr" (auto-routed from KR codes; default us)`},
+				{Name: "order_type", Type: "string", Desc: `"limit" (default) or "market"`},
+				{Name: "quantity", Type: "number", Desc: "share count (required unless fractional buy)"},
+				{Name: "price", Type: "number", Desc: "limit price (required for limit orders)"},
+				{Name: "amount", Type: "number", Desc: "order amount for fractional US buy"},
+				{Name: "currency_mode", Type: "string", Desc: `"KRW" (default) or "USD" for US price input`},
+				{Name: "fractional", Type: "boolean", Desc: "US fractional market order"},
+			}, executeParams...),
+			handler: placeHandler,
+		},
+		{
+			ID: "cancel_order", Method: "POST", Path: "/api/v1/orders/{orderId}/cancel",
+			Category: "order", Summary: "Cancel a pending order. Gated; preview unless execute=true.",
+			Write: true,
+			Params: append([]Param{
+				{Name: "order_id", Type: "string", Required: true},
+				{Name: "symbol", Type: "string", Required: true},
+			}, executeParams...),
+			handler: cancelHandler,
+		},
+		{
+			ID: "modify_order", Method: "POST", Path: "/api/v1/orders/{orderId}/modify",
+			Category: "order", Summary: "Modify a pending order's quantity/price. Gated; preview unless execute=true.",
+			Write: true,
+			Params: append([]Param{
+				{Name: "order_id", Type: "string", Required: true},
+				{Name: "quantity", Type: "number", Desc: "new quantity (optional)"},
+				{Name: "price", Type: "number", Desc: "new limit price (optional; omit for market)"},
+			}, executeParams...),
+			handler: modifyHandler,
+		},
+	}
+}
+
+func placeHandler(ctx context.Context, d *Deps, args map[string]any) (any, error) {
+	symbol, err := argString(args, "symbol")
+	if err != nil {
+		return nil, err
+	}
+	side, err := argString(args, "side")
+	if err != nil {
+		return nil, err
+	}
+	market, err := argString(args, "market")
+	if err != nil {
+		return nil, err
+	}
+	orderType, err := argString(args, "order_type")
+	if err != nil {
+		return nil, err
+	}
+	currencyMode, err := argString(args, "currency_mode")
+	if err != nil {
+		return nil, err
+	}
+	quantity, err := argFloat(args, "quantity")
+	if err != nil {
+		return nil, err
+	}
+	price, err := argFloat(args, "price")
+	if err != nil {
+		return nil, err
+	}
+	amount, err := argFloat(args, "amount")
+	if err != nil {
+		return nil, err
+	}
+	fractional, err := argBool(args, "fractional")
+	if err != nil {
+		return nil, err
+	}
+	intent, err := orderintent.NormalizePlace(orderintent.PlaceInput{
+		Symbol:       symbol,
+		Market:       market,
+		Side:         side,
+		OrderType:    orderType,
+		Quantity:     quantity,
+		Price:        price,
+		Amount:       amount,
+		CurrencyMode: currencyMode,
+		Fractional:   fractional,
+	})
+	if err != nil {
+		return nil, err
+	}
+	execute, confirm, err := executeArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	if !execute {
+		return d.Trading.PreviewPlace(intent), nil
+	}
+	return d.Trading.Place(ctx, intent, trading.ExecuteOptions{Execute: true, Confirm: confirm})
+}
+
+func cancelHandler(ctx context.Context, d *Deps, args map[string]any) (any, error) {
+	orderID, err := argString(args, "order_id")
+	if err != nil {
+		return nil, err
+	}
+	symbol, err := argString(args, "symbol")
+	if err != nil {
+		return nil, err
+	}
+	intent, err := orderintent.NormalizeCancel(orderID, symbol)
+	if err != nil {
+		return nil, err
+	}
+	execute, confirm, err := executeArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	if !execute {
+		return d.Trading.PreviewCancel(intent), nil
+	}
+	return d.Trading.Cancel(ctx, intent, trading.ExecuteOptions{Execute: true, Confirm: confirm})
+}
+
+func modifyHandler(ctx context.Context, d *Deps, args map[string]any) (any, error) {
+	orderID, err := argString(args, "order_id")
+	if err != nil {
+		return nil, err
+	}
+	quantity, err := argFloatPtr(args, "quantity")
+	if err != nil {
+		return nil, err
+	}
+	price, err := argFloatPtr(args, "price")
+	if err != nil {
+		return nil, err
+	}
+	intent, err := orderintent.NormalizeAmend(orderID, quantity, price)
+	if err != nil {
+		return nil, err
+	}
+	execute, confirm, err := executeArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	if !execute {
+		return d.Trading.PreviewAmend(intent), nil
+	}
+	return d.Trading.Amend(ctx, intent, trading.ExecuteOptions{Execute: true, Confirm: confirm})
+}

--- a/internal/official/asset_reads.go
+++ b/internal/official/asset_reads.go
@@ -113,6 +113,7 @@ func (c *Client) Holdings(ctx context.Context, symbol string) ([]domain.Position
 //     WTS dailyProfitLossRate.
 //
 //   - ProductCode, MarketCode: not available from /holdings; left empty.
+//
 //   - USD-specific fields (AveragePriceUSD etc.): not individually provided;
 //     left zero (official uses a single-currency HoldingsItem).
 func adaptHoldings(items []apiHoldingsItem) []domain.Position {

--- a/internal/official/asset_reads_test.go
+++ b/internal/official/asset_reads_test.go
@@ -19,7 +19,7 @@ func TestAdaptHoldingsUnit(t *testing.T) {
 			Quantity:             "100",
 			LastPrice:            "72000",
 			AveragePurchasePrice: "65000",
-			MarketValue:          struct {
+			MarketValue: struct {
 				Amount          string `json:"amount"`
 				AmountAfterCost string `json:"amountAfterCost"`
 				PurchaseAmount  string `json:"purchaseAmount"`

--- a/internal/official/calendar_reads.go
+++ b/internal/official/calendar_reads.go
@@ -1,0 +1,36 @@
+package official
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// MarketCalendar fetches trading-hours calendar info for a market.
+//
+// Endpoint: GET /api/v1/market-calendar/{country} ("KR" | "US")
+// Query:    date (optional) "YYYY-MM-DD"; defaults to today on the server.
+// Response: {previous,today,next}BusinessDay with per-session open/close times
+// (KST). KR and US return structurally different session shapes.
+//
+// ponytail: the payload is returned as a decoded map rather than typed structs.
+// Nothing in the codebase computes over the calendar shape (it is surfaced
+// verbatim as JSON to MCP callers), so faithful typing would be pure boilerplate
+// with two divergent KR/US schemas. Add typed structs if a consumer ever needs
+// to reason about specific fields.
+func (c *Client) MarketCalendar(ctx context.Context, country, date string) (map[string]any, error) {
+	country = strings.ToUpper(strings.TrimSpace(country))
+	if country != "KR" && country != "US" {
+		return nil, fmt.Errorf("market calendar country must be KR or US, got %q", country)
+	}
+	q := url.Values{}
+	if date != "" {
+		q.Set("date", date)
+	}
+	var out map[string]any
+	if err := c.get(ctx, "/api/v1/market-calendar/"+country, q, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/official/calendar_reads_test.go
+++ b/internal/official/calendar_reads_test.go
@@ -1,0 +1,49 @@
+package official
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+func TestMarketCalendarIntegration(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth2/token":
+			_, _ = w.Write([]byte(`{"access_token":"AT","expires_in":3600,"token_type":"Bearer"}`))
+		case "/api/v1/market-calendar/KR":
+			if got := r.URL.Query().Get("date"); got != "2026-03-25" {
+				t.Errorf("date query = %q, want 2026-03-25", got)
+			}
+			_, _ = w.Write([]byte(`{"result":{"today":{"date":"2026-03-25"}}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := New(
+		Credentials{APIKey: "k", SecretKey: "s"},
+		filepath.Join(t.TempDir(), "t.json"),
+		WithBaseURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+	)
+
+	got, err := c.MarketCalendar(context.Background(), "kr", "2026-03-25")
+	if err != nil {
+		t.Fatal(err)
+	}
+	today, ok := got["today"].(map[string]any)
+	if !ok || today["date"] != "2026-03-25" {
+		t.Fatalf("unexpected calendar payload: %v", got)
+	}
+}
+
+func TestMarketCalendarRejectsBadCountry(t *testing.T) {
+	c := New(Credentials{APIKey: "k"}, filepath.Join(t.TempDir(), "t.json"))
+	if _, err := c.MarketCalendar(context.Background(), "JP", ""); err == nil {
+		t.Fatal("expected error for unsupported country")
+	}
+}

--- a/internal/official/market_reads.go
+++ b/internal/official/market_reads.go
@@ -80,6 +80,7 @@ func (c *Client) ExchangeRate(ctx context.Context, base, quote string) (domain.E
 //     rate field (buying exchange rate) serves the same purpose.
 //
 //   - Name: not provided by /exchange-rate; left empty.
+//
 //   - basisPoint, rateChangeType, validFrom, validUntil: informational only;
 //     not mapped to domain (no corresponding domain fields).
 func adaptExchangeRate(raw apiExchangeRate) domain.ExchangeRate {

--- a/internal/official/stock_reads.go
+++ b/internal/official/stock_reads.go
@@ -28,15 +28,15 @@ import (
 //	leverageFactor  string (decimal, nullable)
 //	koreanMarketDetail object (KR only, nullable)
 type apiStockInfo struct {
-	Symbol         string `json:"symbol"`
-	Name           string `json:"name"`
-	EnglishName    string `json:"englishName"`
-	Market         string `json:"market"`
-	Currency       string `json:"currency"`
-	Status         string `json:"status"`
-	SecurityType   string `json:"securityType"`
-	IsCommonShare  bool   `json:"isCommonShare"`
-	IsinCode       string `json:"isinCode"`
+	Symbol        string `json:"symbol"`
+	Name          string `json:"name"`
+	EnglishName   string `json:"englishName"`
+	Market        string `json:"market"`
+	Currency      string `json:"currency"`
+	Status        string `json:"status"`
+	SecurityType  string `json:"securityType"`
+	IsCommonShare bool   `json:"isCommonShare"`
+	IsinCode      string `json:"isinCode"`
 }
 
 // Stocks fetches basic stock metadata for a batch of symbols.
@@ -74,7 +74,9 @@ func (c *Client) Stocks(ctx context.Context, symbols []string) ([]domain.Quote, 
 //
 //   - Last, Change, Volume, Open/High/Low etc.: not available from /stocks.
 //     Call /prices or /prices+/stocks in combination for full quote.
+//
 //   - Market (display name): not available; MarketCode is the enum value.
+//
 //   - ProductCode, ReferencePrice etc.: not in /stocks.
 func adaptStocks(raw []apiStockInfo) []domain.Quote {
 	out := make([]domain.Quote, 0, len(raw))


### PR DESCRIPTION
## 무엇
공식 Toss Open API를 **MCP(Model Context Protocol) 서버**로 노출하는 `tossctl mcp` 커맨드를 추가합니다. stdin/stdout(JSON-RPC 2.0)에서 동작하며 Claude Code·Claude Desktop·Codex 등 MCP 호스트에 `tossctl mcp`로 등록해 씁니다. **공식 API로 가능한 범위 전부** — 조회 + 주문 실행(매수/매도·취소·정정) — 를 노출하며, WTS 웹 세션은 경유하지 않습니다.

## 왜 catalog 방식
20여 개 API를 개별 MCP 툴로 등록하면 모든 오퍼레이션 스키마가 모델 상시 컨텍스트에 상주해 비용·노이즈가 커집니다. KIS_MCP_Server의 catalog 모드(`list-kis-api-specs`/`get-kis-api-spec`/`call-kis-api`)를 참조해, 앞단에 **고정 3툴만** 노출하고 뒤에서 dispatch합니다:

- `list_operations` — 오퍼레이션 목록(id·요약·write 여부), `query` 필터
- `describe_operation` — 단일 오퍼레이션 파라미터 스키마
- `call_operation` — id+파라미터로 dispatch

상시 컨텍스트 = 딱 3개 툴 스키마.

## 범위
공식 Open API의 **조회·거래 엔드포인트 100% 커버**(스펙 20 path, oauth 토큰은 내부 처리):

**조회 16개** — accounts·buying_power·holdings·orders·order·sellable_quantity·prices·stocks·orderbook·trades·candles·price_limits·warnings·exchange_rate·commissions·market_calendar. 대부분 기존 `official.Client` 타입 메서드에 dispatch하며, 유일한 미구현이던 `market-calendar`(KR/US)는 이 PR에서 official.Client에 추가했습니다.

**주문 실행 3개(게이트드 write)** — place_order·cancel_order·modify_order

## 주문 안전 모델 (CLI와 동일 + KIS 원칙)
주문은 새 경로를 만들지 않고 기존 `trading.Service`(config 게이트 + dry-run preview + execute/confirm 토큰)를 **그대로 재사용**합니다. CLI `tossctl order`와 동일한 흐름:

- **config 게이트** — `trading.place/sell/cancel/amend` + `allow_live_order_actions` 를 켜야 실제 주문 (기본 전부 비활성). KIS의 `_ensure_trading_enabled` 원칙과 동일한 opt-in
- **2단계** — `execute` 미지정/false → **Preview**(confirm_token·경고 반환, 네트워크 미접촉). `execute:true` + `confirm:<token>` → 제출
- **official-only** — `OfficialBroker` 가 `official.Client` 를 `trading.Broker` 로 어댑트해 공식 API 경로만 사용. `GetOrderAvailableActions` 는 공식 대응이 없어 no-op(서버측이 취소/정정 가능성 검증)

## 구현
- `internal/mcp/` — 최소 JSON-RPC 2.0 stdio 루프(initialize/tools.list/tools.call, notification 무응답), catalog 레지스트리, 3툴 핸들러, `OfficialBroker`
- handler 시그니처를 `*Deps{Client, Trading}` 로 일반화 (읽기=Client, 쓰기=Trading)
- `cmd/tossctl/mcp.go` — 자격증명·config 로드 후 official-only `trading.Service` 주입, stdio 서버 실행 (`SilenceUsage` 로 stdout 스트림 오염 방지)
- 의존성 추가 없음(cobra만). MCP stdio 프로토콜 부분집합 직접 구현

## 테스트
- JSON-RPC 프레이밍(protocolVersion echo, notification 무응답, unknown method → -32601)
- tools/list 정확히 3툴, list_operations query 필터, write 표시
- 읽기 dispatch(httptest 더미 데이터), 필수 파라미터 누락
- 주문: preview 무접촉·비활성 시 execute 차단·enable+토큰 happy path(주문 제출)·잘못된 토큰 실패
- `go test ./...` 전체 통과, `go vet` 클린, gofmt 클린

## 호스트 설정 예시
```json
{ "mcpServers": { "tossinvest": { "command": "tossctl", "args": ["mcp"] } } }
```

## 후속
- 공식 OpenAPI 안정화 시 레지스트리를 spec에서 생성(discovery 기반 동적 커맨드)
