### PR TITLE
docs(site): 네비 GitHub 배지 정리 + 랜딩 MCP(CLI+MCP 병행) 반영

### DIFF
--- a/website-fumadocs/app/[lang]/(home)/layout.tsx
+++ b/website-fumadocs/app/[lang]/(home)/layout.tsx
@@ -1,12 +1,12 @@
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
-import { baseOptions, linkItems } from '@/components/layouts/shared';
+import { baseOptions, linkItems, githubItem } from '@/components/layouts/shared';
 
 export default async function Layout({ params, children }: LayoutProps<'/[lang]'>) {
   const { lang } = await params;
   return (
     <HomeLayout
       {...baseOptions()}
-      links={linkItems(lang)}
+      links={[...linkItems(lang), githubItem()]}
       // 랜딩은 디자인 소스(MZ8Ua)에 맞춰 항상 다크 — 토글은 동작하지 않으므로 숨긴다.
       // (테마 토글은 docs 레이아웃에서는 그대로 동작)
       themeSwitch={{ enabled: false }}

--- a/website-fumadocs/app/[lang]/(home)/page.tsx
+++ b/website-fumadocs/app/[lang]/(home)/page.tsx
@@ -47,7 +47,7 @@ const content = {
       points: [
         { k: 'WTS 기능 21개', v: '토스 WTS엔 있지만 공식 API엔 없는 수급·지수·AI 시그널·스크리너·배당 등 21개. 앱에서만 쓰던 기능을 터미널로.' },
         { k: '공식 Open API 전부 100% 커버', v: '공식 Open API가 여는 범위를 빠짐없이 100% 포함합니다. 공식 키를 연결하면 OAuth 경로로 더 안정적으로 동작합니다.' },
-        { k: '에이전트 연동', v: '모든 명령이 JSON으로 출력되어 AI 에이전트와 바로 연동됩니다.' },
+        { k: '에이전트 연동 — CLI + MCP 둘 다', v: 'CLI는 JSON 출력으로, MCP 서버(tossctl mcp)는 툴로. 두 방식 모두 지원해 Claude·Codex·Cursor 등 어떤 AI 에이전트에든 바로 붙습니다.' },
         { k: '공식 Open API는 약 4%', v: '공식 Open API는 토스 WTS 기능 ~440개 중 약 4%만 엽니다. tossctl은 그 너머까지 다룹니다.' },
       ],
     },
@@ -136,7 +136,7 @@ const content = {
     features: [
       { label: 'DATA', title: '넓은 조회', desc: '계좌·시세·호가·체결·수급·지수·업종·배당·거래내역을 명령 한 줄로 조회합니다.' },
       { label: 'SAFETY', title: '안전한 거래', desc: '거래는 기본으로 꺼져 있고, 주문 전 미리보기와 두 번의 확인을 거칩니다. 실수로 주문이 나가지 않습니다.' },
-      { label: 'AGENTS', title: '에이전트 친화', desc: '모든 결과를 AI가 그대로 읽는 형식으로 내보내 에이전트와 바로 연동됩니다.' },
+      { label: 'AGENTS', title: 'CLI + MCP 둘 다', desc: 'CLI(JSON 출력)로도, MCP 서버(tossctl mcp)로도 붙습니다. 두 방식 모두 지원 — Claude·Codex·Cursor 등 어떤 에이전트에든 그대로 연동됩니다.' },
       { label: 'INTELLIGENCE', title: '토스 AI 기능', desc: '공식 API에는 없는 AI 시그널·뉴스 브리핑·조건검색·커뮤니티 랭킹을 제공합니다.' },
       { label: 'REALTIME', title: '실시간 푸시', desc: '주문·체결·보유 변동을 실시간으로 받아봅니다.' },
       { label: 'AUTOMATION', title: '자동화 우선', desc: '표·파일·실시간 등 원하는 형식으로 내보내 스크립트와 자동화에 바로 연결합니다.' },
@@ -163,7 +163,7 @@ const content = {
       points: [
         { k: '21 WTS-only features', v: "Flows, indices, AI signals, screener, dividends: 21 Toss WTS features the official API doesn't expose. App-only, now in your terminal." },
         { k: '100% of official API covered', v: "tossctl covers the official API's whole area 100%. Add an official key and it routes through OAuth (more stable, auto-renewing)." },
-        { k: 'Agents included', v: 'Every command answers in JSON, so people and agents use it the same way.' },
+        { k: 'Agents — CLI + MCP', v: 'The CLI answers in JSON; the MCP server (tossctl mcp) exposes tools. Both are supported, so Claude, Codex, Cursor and any agent plug in right away.' },
         { k: 'Official ≈ 4%', v: 'Of ~440 Toss WTS features, the official Open API opens only about 4% — tossctl covers the rest too.' },
       ],
     },
@@ -252,7 +252,7 @@ const content = {
     features: [
       { label: 'DATA', title: 'Broad reads', desc: 'Accounts, quotes, orderbook, ticks, flows, indices, sectors, dividends, ledger, in one command.' },
       { label: 'SAFETY', title: 'Safe trading', desc: 'Trading is off by default, with an order preview and two confirmations before anything runs. No accidental orders.' },
-      { label: 'AGENTS', title: 'Agent-friendly', desc: 'Every result comes back in a format AI reads directly, so agents like Claude, Codex, and Cursor connect right away.' },
+      { label: 'AGENTS', title: 'CLI + MCP, both', desc: 'Connect via the CLI (JSON output) or the MCP server (tossctl mcp) — both supported, so agents like Claude, Codex, and Cursor plug in right away.' },
       { label: 'INTELLIGENCE', title: 'Toss AI features', desc: 'AI signals, news briefing, screener, community rankings, none of which the official API has.' },
       { label: 'REALTIME', title: 'Real-time push', desc: 'See order, fill, and holdings changes the moment they happen.' },
       { label: 'AUTOMATION', title: 'Automation-first', desc: 'Export as a table, file, or live feed, drop it straight into scripts and automation.' },

--- a/website-fumadocs/app/[lang]/docs/layout.tsx
+++ b/website-fumadocs/app/[lang]/docs/layout.tsx
@@ -1,6 +1,6 @@
 import { source } from '@/lib/source';
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
-import { baseOptions, linkItems, logoIcon } from '@/components/layouts/shared';
+import { baseOptions, linkItems, logoIcon, githubBadge } from '@/components/layouts/shared';
 import { getSection } from '@/lib/source/navigation';
 
 export default async function Layout({ params, children }: LayoutProps<'/[lang]/docs'>) {
@@ -20,6 +20,7 @@ export default async function Layout({ params, children }: LayoutProps<'/[lang]/
             <span className="font-medium max-md:hidden">tossctl</span>
           </span>
         ),
+        children: githubBadge,
       }}
       sidebar={{
         tabs: {

--- a/website-fumadocs/components/layouts/shared.tsx
+++ b/website-fumadocs/components/layouts/shared.tsx
@@ -30,17 +30,13 @@ async function humanizeStars(stars: number): Promise<string> {
   return `${Math.floor(stars / 1000)}K`;
 }
 
-async function SafeGithubInfo({
-  owner,
-  repo,
-  token,
-  className,
-}: {
-  owner: string;
-  repo: string;
-  token?: string;
-  className?: string;
-}) {
+// Compact GitHub badge for the right-hand nav toolbar: icon + star count only
+// (no owner/repo text — that broke visually and crowded the logo). A GitHub API
+// failure must never 500 the site (this renders in the shared nav), so failures
+// are swallowed and we fall back to just the icon.
+async function GithubBadge({ className }: { className?: string }) {
+  const { user: owner, repo } = gitConfig;
+  const token = process.env.GITHUB_TOKEN;
   let stars: string | null = null;
   try {
     const headers = new Headers({ 'Content-Type': 'application/json' });
@@ -54,7 +50,7 @@ async function SafeGithubInfo({
       stars = await humanizeStars(data.stargazers_count);
     }
   } catch {
-    // network error, rate limit, etc. — render without the star count below
+    // network error, rate limit, etc. — render icon only
   }
 
   return (
@@ -62,24 +58,38 @@ async function SafeGithubInfo({
       href={`https://github.com/${owner}/${repo}`}
       rel="noreferrer noopener"
       target="_blank"
+      aria-label={`GitHub — ${owner}/${repo}`}
       className={
-        'flex flex-col gap-1.5 rounded-lg p-2 text-sm text-fd-foreground/80 transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground lg:flex-row lg:items-center ' +
+        'inline-flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-sm text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground ' +
         (className ?? '')
       }
     >
-      <p className="flex items-center gap-2 truncate">
-        <Github className="size-3.5" />
-        {owner}/{repo}
-      </p>
+      <Github className="size-4 shrink-0" />
       {stars !== null && (
-        <p className="flex items-center gap-1 text-xs text-fd-muted-foreground">
+        <span className="flex items-center gap-0.5 text-xs tabular-nums">
           <Star className="size-3" />
           {stars}
-        </p>
+        </span>
       )}
     </a>
   );
 }
+
+// HomeLayout: a `secondary` custom link item so it sits in the right-hand nav
+// toolbar (next to theme/language), not crammed against the logo on the left.
+export function githubItem(): LinkItemType {
+  return {
+    type: 'custom',
+    on: 'nav',
+    secondary: true,
+    children: <GithubBadge />,
+  };
+}
+
+// DocsLayout has no right-hand toolbar in the top bar (search/theme live in the
+// sidebar), so the compact badge goes in nav.children next to the logo — now
+// icon + stars only, no repo name.
+export const githubBadge = <GithubBadge className="max-md:hidden" />;
 
 // i18n UI translations (ko default + en). `provider(locale)` feeds RootProvider.
 export const { provider } = defineI18nUI(i18n, {
@@ -234,14 +244,6 @@ export function baseOptions(): BaseLayoutProps {
     i18n: true,
     nav: {
       title: logo,
-      children: (
-        <SafeGithubInfo
-          owner={gitConfig.user}
-          repo={gitConfig.repo}
-          token={process.env.GITHUB_TOKEN}
-          className="max-lg:hidden"
-        />
-      ),
     },
   };
 }


### PR DESCRIPTION
## 변경 요약

### 1) 네비게이션 GitHub 배지 정리
- `owner/repo` 텍스트(깨져 보이던 부분) 제거 → **GitHub 아이콘 + 스타 수만** 표기.
- **홈(HomeLayout):** `secondary` 링크 아이템으로 옮겨 **우측 툴바(언어/테마 토글 옆)** 에 배치 — 로고와 붙어있던 문제 해결.
- **docs(DocsLayout):** 상단바에 우측 툴바가 없어(검색·테마는 사이드바) 로고 옆 compact 배지로 유지.

### 2) 랜딩 페이지에 MCP 반영 (기존엔 MCP 언급 0)
- thesis 포인트 + AGENTS 피처 카드에 **"CLI + MCP 둘 다 지원"** 을 강조 (ko/en).

## 검증
- 라이브(수동 prod 배포)에서 스크린샷 확인: 홈 우측 `☆435`, docs 로고 옆 compact 배지, 랜딩 "에이전트 연동 — CLI + MCP 둘 다" 카드 렌더 정상.
- `npm run build` 성공(55/55 페이지).

> 참고: Vercel 자동배포가 끊겨 있어(별도 이슈) prod 는 `npx vercel --prod` 로 이미 수동 반영됨. 이 PR 은 소스 동기화용.

https://claude.ai/code/session_019WXTv2F8GTgbrNLCDW9BVZ