### PR TITLE
ci: docs 사이트 Vercel 자동배포 워크플로

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,50 @@
+name: deploy-docs
+
+# Vercel 프로젝트의 Git 연동이 끊겨 있어 push-트리거 자동배포가 동작하지 않는다.
+# 이 워크플로가 website-fumadocs/ 변경 시 Vercel CLI 로 prod 배포를 대신 수행한다.
+# Runner 는 전체 repo 를 체크아웃하므로 루트 CHANGELOG.md(sync-changelog)도 접근 가능 —
+# Vercel 원격 빌드의 root-checkout 스코핑 문제(website-fumadocs 만 보이는)도 우회된다.
+#
+# 필요 시크릿: VERCEL_TOKEN (repo Settings → Secrets → Actions).
+# org/project ID 는 식별자일 뿐 비밀이 아니므로 env 로 직접 둔다.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website-fumadocs/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: true
+
+env:
+  VERCEL_ORG_ID: team_CtzfxSzn9SBrxQ3b8JTZY17w
+  VERCEL_PROJECT_ID: prj_dhiFk0eo3umo3IIIqHBsE04YW9mi
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website-fumadocs
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Install Vercel CLI
+        run: npm i -g vercel@latest
+      - name: Pull Vercel env (production)
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+      - name: Build
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --prod --token="$VERCEL_TOKEN"
+      - name: Deploy (prebuilt) to production
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"


### PR DESCRIPTION
Vercel 프로젝트의 Git 연동이 끊겨(현재 `link` 없음) push-트리거 자동배포가 5일+ 동작하지 않던 문제를 GitHub Action 으로 해결합니다.

- `website-fumadocs/**` 변경이 main 에 들어오면 `vercel pull → build → deploy --prebuilt --prod` 실행.
- Runner 가 **전체 repo 를 체크아웃**하므로 루트 `CHANGELOG.md`(sync-changelog) 접근 가능 → Vercel 원격 빌드의 root-checkout 스코핑 이슈도 자연히 우회.
- 토큰은 env 로만 참조(인젝션 없음). org/project ID 는 식별자라 env 직접, **비밀은 `VERCEL_TOKEN` 하나**.

## 머지 후 필요한 1회 설정
repo Settings → Secrets and variables → Actions → `VERCEL_TOKEN` 추가.
Vercel 대시보드 → Account Settings → Tokens 에서 발급(프로젝트 스코프 권장).

https://claude.ai/code/session_019WXTv2F8GTgbrNLCDW9BVZ