### PR TITLE
ci: deploy-docs pnpm 수정 (corepack enable)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,6 +34,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
+      - name: Enable pnpm (project uses pnpm@10 via packageManager)
+        run: corepack enable
       - name: Install Vercel CLI
         run: npm i -g vercel@latest
       - name: Pull Vercel env (production)


### PR DESCRIPTION
이전 run 이 `spawn pnpm ENOENT` 로 실패. 프로젝트가 pnpm@10(packageManager)을 쓰는데 러너에 pnpm 이 없어서 `vercel build` 의 의존성 설치가 깨짐. `corepack enable` 스텝 추가로 pnpm 활성화.

https://claude.ai/code/session_019WXTv2F8GTgbrNLCDW9BVZ