### PR TITLE
docs(analysis): 2026-07-15 API 변경 분석 (openapi v1.2.4 / WTS 카탈로그)

### DIFF
--- a/docs/reverse-engineering/change-analysis/2026-07-15.md
+++ b/docs/reverse-engineering/change-analysis/2026-07-15.md
@@ -1,0 +1,40 @@
+# API 변경 분석 — 2026-07-15
+
+모니터 워크플로우가 최근 26시간 내 감지한 두 소스의 변경을 분석한 결과입니다.
+
+## 1. 공식 Open API spec (`docs/migration/openapi.latest.json`)
+
+- 커밋: `779ea22` `docs(migration): openapi-snapshot 자동 갱신`
+- 버전: `1.2.2` → `1.2.4`
+- 신규/삭제 엔드포인트: **없음**
+
+### 변경 내용
+
+`GET /api/v1/market-indicators/{symbol}/candles` (시장 지표 캔들 조회)의 설명 문서만 갱신되었습니다.
+
+- 분봉(`interval=1m`)은 지수(`KOSPI`, `KOSDAQ`)만 지원하고, 국채(`KR_BOND_2Y`~`KR_BOND_30Y`)는 일봉(`1d`)만 지원한다는 제약이 명문화됨.
+- 국채 심볼에 `1m`을 요청하면 `400 invalid-request` (`allowedValues: ["1d"]`)가 반환된다는 예시(`bondMinuteNotSupported`)가 추가됨.
+- 스키마·파라미터·응답 구조 자체의 변경은 없음. 기존에도 서버가 이렇게 동작했을 가능성이 높고, 문서가 실제 동작을 뒤늦게 반영한 것으로 보임 (breaking change 아님).
+
+### tossctl 커버리지 대조
+
+- 구현: `internal/official/market_reads.go:441` `Client.MarketIndicatorCandles`. `interval`을 그대로 쿼리 파라미터로 전달하며 심볼-주기 조합에 대한 클라이언트 측 검증은 하지 않음 → 서버 400 응답에 전적으로 의존. 문서가 새로 명문화한 제약과 모순되는 잘못된 가정은 코드에 없음.
+- CLI: `cmd/tossctl/market.go:334` `indicator-candles` 커맨드, `--interval` 플래그 기본값 `1d`, 도움말은 `"candle interval (1m|1d)"`로 국채 제약을 언급하지 않음 (`internal/i18n/en.json:103`, `ko.json:103` 동일).
+- MCP: `internal/mcp/operations.go`에 이 엔드포인트에 대응하는 오퍼레이션 자체가 없음 (등록된 `candles` 오퍼레이션은 종목 캔들용 별개 엔드포인트). 에이전트에게 잘못된 설명을 노출하고 있지는 않음 — 애초에 노출이 안 됨.
+- 테스트: `internal/official/market_reads_test.go:444`는 `symbol=KOSPI, interval=1d` 조합만 검증. `1m` 요청이나 국채 심볼, 400 에러 경로에 대한 테스트/프로브 없음.
+
+### 분류: (a) no-op — 조치 불필요 (문서 보강)
+
+### 권장 후속 조치 (선택적, 낮은 우선순위)
+
+1. `internal/official/market_reads_test.go`에 `1m + 국채` → 400, `1m + 지수` → 성공 케이스 테스트 추가 고려.
+2. `--interval` 플래그/i18n 도움말에 "국채는 1d만 지원" 문구 추가하면 불필요한 API 왕복을 줄일 수 있음.
+3. `market-indicators` 엔드포인트 자체가 MCP에 노출되어 있지 않으므로, 필요 시 별도로 MCP 오퍼레이션 추가 여부는 사람이 판단.
+
+## 2. WTS 엔드포인트 카탈로그 (`docs/reverse-engineering/wts-endpoints.json`)
+
+- 최근 26시간 내 커밋: `73aa39d` (사람이 작성한 `feat(lending)` 커밋, `lending expected` 기능 구현과 함께 카탈로그의 `/api/v1/lending/revenue/account/expected` 항목을 `candidate` → `implemented`로 갱신), `cee54b5` (`wts-monitor` 봇의 정기 갱신).
+- `wts-monitor` 봇 커밋(`cee54b5`)의 실질 diff는 `updated_at` 타임스탬프 변경뿐이며, 엔드포인트 경로 신규/삭제는 없음 (26시간 윈도우 전체를 비교해도 경로 집합 변동 없음).
+- `73aa39d`는 이미 사람이 구현을 완료하고 카탈로그를 갱신한 커밋으로, 별도 분석/후속 조치가 필요한 모니터 감지 변경이 아님.
+
+### 분류: (a) no-op — 실질적인 카탈로그 변경 없음, 조치 불필요


### PR DESCRIPTION
## 변경 사항

최근 26시간 내 감지된 두 API 변경 소스를 분석한 문서를 추가합니다.

1. **공식 Open API spec** (`docs/migration/openapi.latest.json`, `1.2.2 → 1.2.4`): `GET /api/v1/market-indicators/{symbol}/candles`의 설명 문서 갱신. 분봉(`1m`)은 지수(KOSPI/KOSDAQ)만 지원하고 국채는 일봉(`1d`)만 지원한다는 기존 서버 제약이 명문화되었으며, 신규/삭제 엔드포인트는 없음.
2. **WTS 엔드포인트 카탈로그**: `wts-monitor` 봇 커밋은 `updated_at` 타임스탬프만 변경(실질 diff 없음). 같은 기간의 `feat(lending)` 커밋은 이미 사람이 구현을 완료한 것으로, 카탈로그의 `implemented` 반영일 뿐 별도 조치 불필요.

커버리지 대조 결과 두 변경 모두 **(a) no-op** — 즉시 조치가 필요한 breaking 변경이나 신규 기능 후보는 없습니다. 테스트 커버리지 보강 등 낮은 우선순위의 선택적 후속 조치만 문서에 기록했습니다.

기존 코드는 수정하지 않았습니다 — 분석 문서 1건만 추가합니다.

## 영향 범위

- [x] 문서

## 테스트

- [ ] `make test` 통과 (코드 변경 없어 해당 없음)
- [x] 수동 확인 완료 (spec diff 및 카탈로그 diff 직접 대조)

## 체크리스트

- [x] 기존 동작을 깨뜨리지 않음
- [ ] 거래 관련 변경인 경우 안전장치(config gate, confirm token 등) 유지 확인 (해당 없음)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KckZcdCdQwV37fXky4aM1J)_