### PR TITLE
fix(mcp): tools/call 결과에 크기 상한 적용

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -229,16 +229,132 @@ func (s *Server) handleToolsList() any {
 	return map[string]any{"tools": tools}
 }
 
+// maxResultBytes caps the JSON text a single tools/call result may carry. Some
+// reads (news_briefing, sectors) return tens of thousands of characters, which
+// blows the MCP client's token budget — the client then drops the whole result,
+// so the model gets nothing. Trimming to a cap beats returning nothing.
+const maxResultBytes = 30000
+
 // toolResult builds an MCP tools/call result carrying JSON-encoded text content.
+//
+// ponytail: the size cap lives here because every tool (list/describe/call)
+// routes through this one function; per-operation limits would repeat the guard
+// once per handler. Bump maxResultBytes or add per-op paging if a caller needs
+// the full payload.
 func toolResult(payload any, isError bool) (any, *rpcError) {
 	text, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
 		return nil, &rpcError{Code: codeInvalidParams, Message: "encoding result: " + err.Error()}
 	}
+	if len(text) > maxResultBytes {
+		var v any
+		if json.Unmarshal(text, &v) == nil {
+			if trimmed, terr := json.MarshalIndent(shrinkToCap(v), "", "  "); terr == nil {
+				text = trimmed
+			}
+		}
+	}
 	return map[string]any{
 		"content": []map[string]any{{"type": "text", "text": string(text)}},
 		"isError": isError,
 	}, nil
+}
+
+// --- result size cap ---------------------------------------------------------
+
+// omittedKey marks the placeholder element shrinkToCap appends to a trimmed
+// array, so a truncated list can never be mistaken for a complete one.
+const omittedKey = "_omitted_items"
+
+// shrinkToCap repeatedly trims the largest array in a decoded JSON value until
+// the re-encoded value fits maxResultBytes, appending an explicit placeholder to
+// every array it trims. Returns the value unchanged when it already fits or when
+// there is nothing left to trim (e.g. one huge string).
+func shrinkToCap(v any) any {
+	holder := map[string]any{"v": v} // gives the root a setter
+	for {
+		text, err := json.MarshalIndent(holder["v"], "", "  ")
+		if err != nil || len(text) <= maxResultBytes {
+			return holder["v"]
+		}
+		var (
+			best     []any
+			bestSet  func(any)
+			bestSize int
+		)
+		walkSlices(holder, nil, func(s []any, set func(any)) {
+			if keepable(s) == 0 {
+				return
+			}
+			enc, err := json.MarshalIndent(s, "", "  ")
+			if err != nil || len(enc) <= bestSize {
+				return
+			}
+			best, bestSet, bestSize = s, set, len(enc)
+		})
+		if bestSet == nil {
+			return holder["v"]
+		}
+		bestSet(trim(best, bestSize, len(text)-maxResultBytes))
+	}
+}
+
+// keepable reports how many real (non-placeholder) elements an array holds.
+func keepable(s []any) int {
+	if n := len(s); n > 0 {
+		if m, ok := s[n-1].(map[string]any); ok {
+			if _, ok := m[omittedKey]; ok {
+				return n - 1
+			}
+		}
+	}
+	return len(s)
+}
+
+// trim drops elements from the tail of s — roughly enough to shed `excess` bytes
+// given the array encodes to `size` bytes — and records the total number dropped
+// so far in a trailing placeholder. It always drops at least one element, so
+// shrinkToCap's loop terminates; overshooting the cap only costs another pass.
+func trim(s []any, size, excess int) []any {
+	n, dropped := keepable(s), 0
+	if n < len(s) {
+		if c, ok := s[len(s)-1].(map[string]any)[omittedKey].(float64); ok {
+			dropped = int(c)
+		}
+	}
+	keep := n * (size - excess) / size
+	if keep >= n {
+		keep = n - 1
+	}
+	if keep < 0 {
+		keep = 0
+	}
+	dropped += n - keep
+	out := make([]any, 0, keep+1)
+	out = append(out, s[:keep]...)
+	return append(out, map[string]any{
+		omittedKey: dropped,
+		"_note":    fmt.Sprintf("%d items omitted: result exceeded the %d-byte MCP limit. Narrow the request (see describe_operation params) or use the CLI for the full list.", dropped, maxResultBytes),
+	})
+}
+
+// walkSlices visits every array in a decoded JSON value, passing a setter that
+// replaces it in its parent.
+func walkSlices(v any, set func(any), visit func([]any, func(any))) {
+	switch t := v.(type) {
+	case []any:
+		if set != nil {
+			visit(t, set)
+		}
+		for i := range t {
+			walkSlices(t[i], func(nv any) { t[i] = nv }, visit)
+		}
+	case map[string]any:
+		for k := range t {
+			k := k
+			walkSlices(t[k], func(nv any) { t[k] = nv }, visit)
+		}
+	}
 }
 
 // toolError builds an isError result with a plain message so the model sees it.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -10,8 +10,10 @@ import (
 	"strings"
 	"testing"
 
+	tossclient "github.com/JungHoonGhae/tossinvest-cli/internal/client"
 	"github.com/JungHoonGhae/tossinvest-cli/internal/config"
 	"github.com/JungHoonGhae/tossinvest-cli/internal/official"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/session"
 	"github.com/JungHoonGhae/tossinvest-cli/internal/trading"
 )
 
@@ -326,5 +328,80 @@ func TestUnknownMethodReturnsRPCError(t *testing.T) {
 	code := resps[0]["error"].(map[string]any)["code"].(float64)
 	if int(code) != codeMethodNotFound {
 		t.Errorf("code = %v, want %d", code, codeMethodNotFound)
+	}
+}
+
+// TestToolResultCapsOversizedPayload verifies an oversized read (a synthetic
+// dummy news briefing, well past maxResultBytes) comes back under the cap, still
+// as valid JSON, and says out loud that items were dropped — a silent truncation
+// would let the model read a partial list as complete.
+func TestToolResultCapsOversizedPayload(t *testing.T) {
+	items := make([]map[string]any, 0, 40)
+	for i := 0; i < 40; i++ {
+		news := make([]map[string]any, 0, 40)
+		for j := 0; j < 40; j++ {
+			news = append(news, map[string]any{
+				"title":      strings.Repeat("더미 헤드라인 ", 6),
+				"agencyName": "더미통신",
+				"source":     "https://example.invalid/dummy",
+				"createdAt":  "2026-01-01T00:00:00",
+			})
+		}
+		items = append(items, map[string]any{
+			"category": map[string]any{"type": "DUMMY_THEME", "keywords": []string{"더미", "합성"}},
+			"news":     news,
+		})
+	}
+	body, err := json.Marshal(map[string]any{"result": map[string]any{"createdAt": "2026-01-01T00:00:00", "items": items}})
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	wts := tossclient.New(tossclient.Config{
+		InfoBaseURL: srv.URL,
+		Session:     &session.Session{Cookies: map[string]string{"SESSION": "s"}},
+	})
+	resps := driveWTS(t, wts,
+		initLine,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"call_operation","arguments":{"operation":"news_briefing"}}}`,
+	)
+	res, _ := resps[1]["result"].(map[string]any)
+	if isErr, _ := res["isError"].(bool); isErr {
+		t.Fatalf("unexpected tool error: %v", res)
+	}
+	content, _ := res["content"].([]any)
+	text, _ := content[0].(map[string]any)["text"].(string)
+
+	if len(text) > maxResultBytes {
+		t.Errorf("result is %d bytes, want <= %d", len(text), maxResultBytes)
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(text), &decoded); err != nil {
+		t.Fatalf("capped result is not valid JSON: %v", err)
+	}
+	if !strings.Contains(text, omittedKey) || !strings.Contains(text, "items omitted") {
+		t.Errorf("capped result must state that items were dropped, got %q", text[:200])
+	}
+}
+
+// TestToolResultKeepsSmallPayload verifies a payload under the cap is passed
+// through byte-for-byte (no placeholder, no reordering).
+func TestToolResultKeepsSmallPayload(t *testing.T) {
+	payload := map[string]any{"items": []any{map[string]any{"symbol": "005930"}, map[string]any{"symbol": "000660"}}}
+	want, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	res, rerr := toolResult(payload, false)
+	if rerr != nil {
+		t.Fatalf("toolResult: %v", rerr)
+	}
+	got := res.(map[string]any)["content"].([]map[string]any)[0]["text"].(string)
+	if got != string(want) {
+		t.Errorf("small payload was modified:\n got %s\nwant %s", got, want)
 	}
 }


### PR DESCRIPTION
## 문제

MCP `call_operation` 이 일부 오퍼레이션에서 응답이 너무 커 클라이언트가 토큰 한도 초과로 결과를 통째로 못 받는다. CLI 는 포맷터가 요약해서 정상으로 보였다.

| op | 응답 크기 |
|---|---|
| `news_briefing` | 71,931자 |
| `sectors` | 72,299자 |

## 원인

`internal/mcp/server.go` 의 `toolResult` 가 핸들러 반환값을 `json.MarshalIndent` 로 그대로 직렬화하고 상한이 없었다. WTS 핸들러는 도메인 구조체를 통째로 반환하는데 `NewsBriefing.Items[].News[]` 와 재귀적인 `Sector.SubSectors[]` 트리가 unbounded 다.

## 해결

오퍼레이션마다 고치지 않고 `toolResult` 한 곳에 30,000바이트 상한을 뒀다. `list_operations` · `describe_operation` · `call_operation` 이 모두 여길 거치므로 앞으로 추가될 오퍼레이션도 자동으로 커버된다.

상한 초과 시 가장 큰 배열부터 초과분에 비례해 잘라내되, **조용히 자르지 않고 명시**한다 — 부분 데이터를 전체로 오해하면 잘못된 결론이 나오기 때문:

```json
{ "_omitted_items": 25,
  "_note": "25 items omitted: result exceeded the 30000-byte MCP limit. Narrow the request (see describe_operation params) or use the CLI for the full list." }
```

배열만 트리밍해 JSON 구조·스키마는 그대로 유지된다. 오퍼레이션별 페이지네이션은 25개 op 에 파라미터를 더하는 비용 대비 이득이 적어 택하지 않았다 (`completed_orders`·`transactions` 는 이미 페이징 있음).

## 측정

| op | before | after |
|---|---|---|
| `news_briefing` | 71,931 | **17,450** |
| `sectors` | 72,299 | **27,459** |
| `ai_signals` | 1,044 | 1,044 (그대로) |

## 테스트

- `TestToolResultCapsOversizedPayload` — httptest 로 합성 브리핑(40×40) 을 태워 상한 이하 · 유효 JSON · 잘림 명시를 검증
- `TestToolResultKeepsSmallPayload` — 상한 이하 응답이 바이트 단위로 동일함을 검증

`go build ./...` · `go test ./...` 20/20 통과.

## 알려진 한계

중첩 payload 는 요소별 크기 편차 때문에 상한보다 다소 여유 있게 잘린다. 필요해지면 keep count 이진 탐색이 개선 경로 (코드에 주석).