### PR TITLE
docs(analysis): 공식 Open API spec 변경(1.2.2→1.2.4) 분석

### DIFF
--- a/docs/reverse-engineering/change-analysis/2026-07-16.md
+++ b/docs/reverse-engineering/change-analysis/2026-07-16.md
@@ -1,0 +1,35 @@
+# API 변경 분석 — 2026-07-16
+
+## 감지된 변경
+
+- 소스: `docs/migration/openapi.latest.json` (공식 Open API spec)
+- 커밋: `779ea22` "docs(migration): openapi-snapshot 자동 갱신" (2026-07-15 11:36 UTC, daily-monitor 봇)
+- 버전: `1.2.2` → `1.2.4`
+- WTS 카탈로그(`docs/reverse-engineering/wts-endpoints.json`)는 최근 26시간 내 변경 없음.
+
+## 변경 내용
+
+신규/삭제 엔드포인트 없음. 기존 엔드포인트의 문서(description)만 보강됨.
+
+`GET /api/v1/market-indicators/{symbol}/candles` (`operationId: getMarketIndicatorCandles`):
+
+- `interval` 파라미터 설명에 제약 조건 명시: 분봉(`1m`)은 지수(`KOSPI`·`KOSDAQ`)만 지원하고, 국채(`KR_BOND_*`)는 일봉(`1d`)만 지원.
+- 국채 분봉 요청 시 `400 invalid-request` (`field: interval`, `allowedValues: ["1d"]`) 응답 예시(`bondMinuteNotSupported`)가 신규 추가됨.
+- `Market Indicators` 태그 그룹 설명에도 동일 제약이 각주로 추가됨.
+
+이 제약은 이전부터 서버 측에 존재했을 가능성이 높고(스펙 버전만 패치 범프), 이번 변경은 문서화 보강으로 판단됨. 엔드포인트 경로, 요청/응답 스키마, 다른 에러 코드 등은 변경 없음.
+
+## tossctl 커버리지 대조
+
+`internal/official/market_reads.go`의 `MarketIndicatorCandles` (경로 `/api/v1/market-indicators/{symbol}/candles`, 441행)는 `interval` 값을 검증 없이 그대로 쿼리 파라미터로 전달하는 얇은 패스스루 구현이다. `internal/official/errors.go`는 API 에러 응답을 코드별 분기 없이 일반화된 형태로 전파한다.
+
+즉, 국채 심볼에 `1m`을 요청하면 이미 서버가 `400 invalid-request`를 반환하고 CLI는 이를 그대로 사용자에게 노출한다 — 별도 코드 수정 없이도 정상 동작한다. `internal/mcp/operations.go`에도 해당 엔드포인트에 클라이언트 측 interval 검증 로직은 없음(확인함).
+
+## 분류
+
+**(a) no-op** — 문서 보강(에러 예시 추가, 파라미터 설명 명확화)일 뿐 API 계약 변경이 아님. tossctl 구현에 영향 없음.
+
+## 권장 후속 조치
+
+- 코드 변경 불필요.
+- 선택 사항: CLI 도움말(`--interval` 플래그 설명)이나 MCP 툴 설명에 "국채는 일봉만 지원"이라는 제약을 미리 안내하면 사용자가 400 에러를 겪기 전에 알 수 있어 UX가 개선됨 — 우선순위 낮음, 사람 판단 필요.


### PR DESCRIPTION
## 변경 사항

daily-monitor 봇이 갱신한 공식 Open API spec(`docs/migration/openapi.latest.json`, 1.2.2→1.2.4)의 변경 내용을 분석한 문서를 추가한다. `market-indicators/{symbol}/candles` 엔드포인트의 `interval` 파라미터 문서가 보강됐다(국채는 일봉만 지원한다는 제약 명시, 관련 에러 예시 추가). 신규/삭제 엔드포인트는 없다.

tossctl의 `MarketIndicatorCandles` 구현(`internal/official/market_reads.go`)은 interval 검증 없는 패스스루라 이번 변경의 영향을 받지 않는다 — **no-op**으로 분류. 코드 변경은 없으며 분석 문서만 추가한다.

## 영향 범위

- [ ] 조회 (읽기 전용)
- [ ] 거래 (mutation)
- [ ] 설치 / CI
- [x] 문서

## 테스트

- [ ] `make test` 통과
- [x] 수동 확인 완료 (코드 변경 없음, 문서 신규 작성만)

## 체크리스트

- [x] 기존 동작을 깨뜨리지 않음
- [ ] 거래 관련 변경인 경우 안전장치(config gate, confirm token 등) 유지 확인


---
_Generated by [Claude Code](https://claude.ai/code/session_01XA9B7iURESdUkLy8hz3JyY)_