### PR TITLE
feat(accumulate): 주식모으기 설정 조회 (accumulate list/status)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ tossctl 사용자 관점의 변경 이력입니다. 각 버전에서 "무엇을 
 
 ## [Unreleased]
 
+### 새 기능
+- **`accumulate list`, `accumulate status <symbol>`** — 주식모으기(정기 자동매수) 설정을 조회합니다. 계좌에 설정된 전체 플랜 또는 특정 종목의 플랜을 보여주며, Active/Paused 상태, 매수 금액·수량, 주기, 완료 회차를 포함합니다. 웹앱(WTS) 전용이라 웹 세션(`tossctl auth login`)이 필요합니다. MCP 에서도 `accumulation_plans`·`accumulation_status` 오퍼레이션으로 노출됩니다. (#101)
+
 ## [0.24.1] - 2026-07-17
 
 ### Fixed

--- a/README.en.md
+++ b/README.en.md
@@ -178,6 +178,7 @@ The Toss Securities official Open API is currently **rolling out in stages to pr
 | **Earnings calendar** | `market earnings` (`--major` for curated majors) | ❌ | ✅ |
 | **Dividend report** | `portfolio dividends` (annual total · region · monthly, `--by-payment-date` tax) | ❌ | ✅ |
 | **Expected lending income** | `lending expected` (projected share-lending income: monthly/yearly USD + per-stock) | ❌ | ✅ |
+| **🆕 Stock accumulation plans** | `accumulate list`, `accumulate status <symbol>` (recurring auto-buy settings: Active/Paused, amount/frequency, completed rounds) | ❌ | ✅ |
 | **Community rankings** | `community rankings --type influencer\|profit\|followers` | ❌ | ✅ |
 | **Sector movements** | `market sectors [id]` (industry tree, 1d·1m·1y returns) | ❌ | ✅ |
 | **🆕 Theme fluctuation ranking** | `market themes` (today's top-moving themes, rising-stock counts) | ❌ | ✅ |

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
   <h1>tossinvest-cli</h1>
   <p><strong>토스증권에 연결하는 가장 유연한 방법. CLI 로, MCP 서버로, 어떤 AI 에이전트로든 — 공식 API는 물론 웹앱에만 있던 기능까지 하나로.</strong></p>
   <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot — 어떤 AI 에이전트로든 <code>tossctl</code> 하나로 토스증권 계좌·시세·거래를 다룹니다. <strong>MCP 서버(<code>tossctl mcp</code>)로 붙이거나 터미널에서 직접</strong>, <strong>공식 키 없이 바로 또는 연결 시 자동 라우팅.</strong></p>
-  <p><sub>수급 · 시장지수 · AI 시그널 · 조건검색 · 관심종목 관리 · 거래내역 ledger · 실시간 푸시 · 원화 소수점 주문 · dry-run preview 등 WTS 전용 기능 21가지 — <strong>공식 Open API 지원 범위도 물론 100% 포함합니다.</strong> <a href="#지원-범위">전체 비교표 ↓</a></sub></p>
-  <p><sub><em>The most flexible way to connect Toss Securities — via CLI, via MCP, from any AI agent. 100% of the official Open API, plus 21 features only the web app had.</em></sub></p>
+  <p><sub>수급 · 시장지수 · AI 시그널 · 조건검색 · 관심종목 관리 · 거래내역 ledger · 실시간 푸시 · 원화 소수점 주문 · dry-run preview 등 WTS 전용 기능 22가지 — <strong>공식 Open API 지원 범위도 물론 100% 포함합니다.</strong> <a href="#지원-범위">전체 비교표 ↓</a></sub></p>
+  <p><sub><em>The most flexible way to connect Toss Securities — via CLI, via MCP, from any AI agent. 100% of the official Open API, plus 22 features only the web app had.</em></sub></p>
 </div>
 
 <p align="center">
@@ -178,7 +178,7 @@ Waiting for approval in the Toss app on your phone...
 ## 지원 범위
 
 > **tossctl 은 토스 공식 Open API 의 조회·거래 범위를 100% 커버하고, 그 너머까지 다룹니다.**
-> 공식 [Open API 문서](https://developers.tossinvest.com/docs)의 모든 엔드포인트(계좌·잔고·시세·호가·체결·캔들·상하한가·매도가능수량·수수료·주문 등)에 대응하며, 추가로 수급·시장지수·AI 시그널·조건검색·관심종목 관리·거래내역 ledger·실시간 푸시·원화 소수점 주문·dry-run preview 등 **21개가 공식 Open API에 없는 tossctl 고유 범위**입니다.
+> 공식 [Open API 문서](https://developers.tossinvest.com/docs)의 모든 엔드포인트(계좌·잔고·시세·호가·체결·캔들·상하한가·매도가능수량·수수료·주문 등)에 대응하며, 추가로 수급·시장지수·AI 시그널·조건검색·관심종목 관리·거래내역 ledger·실시간 푸시·원화 소수점 주문·dry-run preview 등 **22개가 공식 Open API에 없는 tossctl 고유 범위**입니다.
 
 <p align="center">
   <img src="docs/assets/api-comparison.svg" alt="tossctl vs 공식 Open API(예정) 커버리지 비교 — tossctl 이 상위집합" width="840" />
@@ -225,6 +225,7 @@ Waiting for approval in the Toss app on your phone...
 | **실적(어닝콜) 일정** | `market earnings` (`--major` 주요 기업 큐레이션) | ❌ | ✅ |
 | **배당 내역** | `portfolio dividends` (연간 총액·지역·월별, `--by-payment-date` 세금) | ❌ | ✅ |
 | **예상 대여수익** | `lending expected` (주식대여 예상 수익: 월/연 USD + 종목별) | ❌ | ✅ |
+| **🆕 주식모으기 조회** | `accumulate list`, `accumulate status <symbol>` (정기 자동매수 설정: Active/Paused, 금액·주기, 완료 회차) | ❌ | ✅ |
 | **Prime 구독 상태·혜택** | `account prime` (수수료·이자 3단 비교: 일반/Prime/내 적용) | ❌ | ✅ |
 | **커뮤니티 랭킹** | `community rankings --type influencer\|profit\|followers` | ❌ | ✅ |
 | **업종별 등락** | `market sectors [id]` (대분류·하위 업종, 1일·1개월·1년) | ❌ | ✅ |

--- a/cmd/tossctl/accumulate.go
+++ b/cmd/tossctl/accumulate.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"github.com/JungHoonGhae/tossinvest-cli/internal/i18n"
+	"github.com/JungHoonGhae/tossinvest-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newAccumulateCmd(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "accumulate",
+		Short: i18n.T("accumulate.short"),
+	}
+
+	cmd.AddCommand(&cobra.Command{
+		Use:         "list",
+		Short:       i18n.T("accumulate.list.short"),
+		Long:        i18n.T("accumulate.list.long"),
+		Annotations: map[string]string{"source": "wts"},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			app, err := newAppContext(opts)
+			if err != nil {
+				return err
+			}
+			plans, err := app.client.ListAccumulationPlans(cmd.Context())
+			if err != nil {
+				return userFacingCommandError(err)
+			}
+			return output.WriteAccumulationPlans(cmd.OutOrStdout(), app.format, plans)
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:         "status <symbol>",
+		Short:       i18n.T("accumulate.status.short"),
+		Long:        i18n.T("accumulate.status.long"),
+		Args:        cobra.ExactArgs(1),
+		Annotations: map[string]string{"source": "wts"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := newAppContext(opts)
+			if err != nil {
+				return err
+			}
+			plans, err := app.client.GetAccumulationPlansByStock(cmd.Context(), args[0])
+			if err != nil {
+				return userFacingCommandError(err)
+			}
+			return output.WriteAccumulationPlans(cmd.OutOrStdout(), app.format, plans)
+		},
+	})
+
+	return cmd
+}

--- a/cmd/tossctl/root.go
+++ b/cmd/tossctl/root.go
@@ -141,6 +141,7 @@ func newRootCmd() *cobra.Command {
 		newAccountCmd(opts),
 		newPortfolioCmd(opts),
 		newLendingCmd(opts),
+		newAccumulateCmd(opts),
 		newOrdersCmd(opts),
 		newTransactionsCmd(opts),
 		newWatchlistCmd(opts),

--- a/docs/reverse-engineering/wts-endpoints.json
+++ b/docs/reverse-engineering/wts-endpoints.json
@@ -1,11 +1,11 @@
 {
   "source": "tossinvest.com web bundles",
-  "build_id": "3_fXC776dOZp_ZZKhp6qR",
+  "build_id": "gMdbJqLz1CzePoxetm-D2",
   "chunk_count": 25,
   "total": 935,
   "counts": {
-    "implemented": 70,
-    "candidate": 368,
+    "implemented": 72,
+    "candidate": 366,
     "excluded": 497,
     "candidate_next": 20,
     "meaningful": 438
@@ -1041,7 +1041,7 @@
       "first_seen": "2026-06-19"
     },
     "/api/v1/growth/autotrade/plan/stock": {
-      "status": "candidate",
+      "status": "implemented",
       "first_seen": "2026-06-19"
     },
     "/api/v1/growth/autotrade/schedule": {
@@ -1168,7 +1168,7 @@
     },
     "/api/v1/lending/revenue/account/expected": {
       "status": "implemented",
-      "first_seen": "2026-07-20"
+      "first_seen": "2026-07-21"
     },
     "/api/v1/lending/revenue/account/payment": {
       "status": "candidate",
@@ -3244,7 +3244,7 @@
       "first_seen": "2026-06-19"
     },
     "/api/v2/autotrade/plan/find": {
-      "status": "candidate",
+      "status": "implemented",
       "first_seen": "2026-06-19"
     },
     "/api/v2/comments": {
@@ -4290,5 +4290,5 @@
       "first_seen": "2026-06-19"
     }
   },
-  "updated_at": "2026-07-20"
+  "updated_at": "2026-07-21"
 }

--- a/internal/client/accumulation.go
+++ b/internal/client/accumulation.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/domain"
+)
+
+type accumulationPlanRaw struct {
+	ID                    int64   `json:"id"`
+	Symbol                string  `json:"symbol"`
+	StockCode             string  `json:"stockCode"`
+	StockName             string  `json:"stockName"`
+	CountryCode           string  `json:"countryCode"`
+	Currency              string  `json:"currency"`
+	PlanType              string  `json:"planType"`
+	Iteration             string  `json:"iteration"`
+	IterateTarget         int     `json:"iterateTarget"`
+	InvestAmt             float64 `json:"investAmt"`
+	InvestQty             float64 `json:"investQty"`
+	TradeStatus           string  `json:"tradeStatus"`
+	IsPaused              bool    `json:"isPaused"`
+	InvestStartDate       string  `json:"investStartDate"`
+	InvestEndDate         string  `json:"investEndDate"`
+	ProceededRound        int     `json:"proceededRound"`
+	SucceededRound        int     `json:"succeededRound"`
+	TotalExecutedAmount   float64 `json:"totalExecutedAmount"`
+	TotalExecutedQuantity float64 `json:"totalExecutedQuantity"`
+	CreatedAt             string  `json:"createdAt"`
+	UpdatedAt             string  `json:"updatedAt"`
+}
+
+func (r accumulationPlanRaw) toDomain() domain.AccumulationPlan {
+	return domain.AccumulationPlan{
+		ID:                    r.ID,
+		Symbol:                r.Symbol,
+		StockCode:             r.StockCode,
+		StockName:             r.StockName,
+		CountryCode:           r.CountryCode,
+		Currency:              r.Currency,
+		PlanType:              r.PlanType,
+		Iteration:             r.Iteration,
+		IterateTarget:         r.IterateTarget,
+		InvestAmount:          r.InvestAmt,
+		InvestQuantity:        r.InvestQty,
+		TradeStatus:           r.TradeStatus,
+		IsPaused:              r.IsPaused,
+		InvestStartDate:       r.InvestStartDate,
+		InvestEndDate:         r.InvestEndDate,
+		ProceededRound:        r.ProceededRound,
+		SucceededRound:        r.SucceededRound,
+		TotalExecutedAmount:   r.TotalExecutedAmount,
+		TotalExecutedQuantity: r.TotalExecutedQuantity,
+		CreatedAt:             r.CreatedAt,
+		UpdatedAt:             r.UpdatedAt,
+	}
+}
+
+// ListAccumulationPlans fetches every "stock accumulation" (주식모으기)
+// recurring-buy plan on the account, across all stocks and statuses
+// (including paused). WTS-only.
+func (c *Client) ListAccumulationPlans(ctx context.Context) (domain.AccumulationPlans, error) {
+	if err := c.requireSession(); err != nil {
+		return domain.AccumulationPlans{}, err
+	}
+	var env quoteEnvelope[[]accumulationPlanRaw]
+	endpoint := c.apiBaseURL + "/api/v2/autotrade/plan/find"
+	if err := c.getJSON(ctx, endpoint, &env); err != nil {
+		return domain.AccumulationPlans{}, err
+	}
+	out := domain.AccumulationPlans{FetchedAt: time.Now()}
+	for _, raw := range env.Result {
+		out.Plans = append(out.Plans, raw.toDomain())
+	}
+	return out, nil
+}
+
+// GetAccumulationPlansByStock fetches the accumulation plan(s) for a single
+// stock (accepts a plain ticker like "005930"/"AAPL" or a Toss product code
+// like "A005930" — resolved the same way `quote get` resolves symbols) — a
+// stock can have plan history, so this returns a list. WTS-only.
+func (c *Client) GetAccumulationPlansByStock(ctx context.Context, symbol string) (domain.AccumulationPlans, error) {
+	if err := c.requireSession(); err != nil {
+		return domain.AccumulationPlans{}, err
+	}
+	productCode, err := c.resolveProductCode(ctx, symbol)
+	if err != nil {
+		return domain.AccumulationPlans{}, err
+	}
+	var env quoteEnvelope[[]accumulationPlanRaw]
+	endpoint := c.certBaseURL + "/api/v1/growth/autotrade/plan/stock/" + productCode
+	if err := c.getJSON(ctx, endpoint, &env); err != nil {
+		return domain.AccumulationPlans{}, err
+	}
+	out := domain.AccumulationPlans{FetchedAt: time.Now()}
+	for _, raw := range env.Result {
+		out.Plans = append(out.Plans, raw.toDomain())
+	}
+	return out, nil
+}

--- a/internal/client/accumulation_test.go
+++ b/internal/client/accumulation_test.go
@@ -1,0 +1,88 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/session"
+)
+
+func TestListAccumulationPlans(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/autotrade/plan/find" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		// dummy data — never real account values
+		_, _ = w.Write([]byte(`{"result":[{"id":1,"symbol":"DUMMY","stockCode":"A000000","stockName":"Dummy Corp","countryCode":"KR","currency":"KRW","planType":"AMOUNT","iteration":"DAILY","iterateTarget":1,"investAmt":10000,"investQty":0,"tradeStatus":"PROGRESS","isPaused":false,"investStartDate":"2026-01-01","investEndDate":"9999-12-31","proceededRound":3,"succeededRound":3,"totalExecutedAmount":30000,"totalExecutedQuantity":1.5,"createdAt":"2026-01-01T00:00:00","updatedAt":"2026-01-04T00:00:00"}]}`))
+	}))
+	defer srv.Close()
+
+	c := New(Config{
+		APIBaseURL: srv.URL,
+		Session:    &session.Session{Cookies: map[string]string{"SESSION": "s"}},
+	})
+
+	got, err := c.ListAccumulationPlans(context.Background())
+	if err != nil {
+		t.Fatalf("ListAccumulationPlans: %v", err)
+	}
+	if len(got.Plans) != 1 {
+		t.Fatalf("want 1 plan, got %d", len(got.Plans))
+	}
+	p := got.Plans[0]
+	if p.Symbol != "DUMMY" || p.StockName != "Dummy Corp" || p.IsPaused {
+		t.Errorf("plan: %+v", p)
+	}
+	if p.PlanType != "AMOUNT" || p.Iteration != "DAILY" || p.InvestAmount != 10000 {
+		t.Errorf("schedule fields: %+v", p)
+	}
+	if p.SucceededRound != 3 || p.TotalExecutedAmount != 30000 {
+		t.Errorf("progress fields: %+v", p)
+	}
+}
+
+func TestListAccumulationPlansNoSession(t *testing.T) {
+	c := New(Config{})
+	if _, err := c.ListAccumulationPlans(context.Background()); err == nil {
+		t.Fatal("want error without a session")
+	}
+}
+
+func TestGetAccumulationPlansByStock(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/growth/autotrade/plan/stock/A005930" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		// dummy data — never real account values
+		_, _ = w.Write([]byte(`{"result":[{"id":2,"symbol":"005930","stockCode":"A005930","stockName":"Dummy Electronics","countryCode":"KR","currency":"KRW","planType":"QUANTITY","iteration":"WEEKLY","iterateTarget":2,"investAmt":0,"investQty":1,"isPaused":true}]}`))
+	}))
+	defer srv.Close()
+
+	c := New(Config{
+		CertBaseURL: srv.URL,
+		Session:     &session.Session{Cookies: map[string]string{"SESSION": "s"}},
+	})
+
+	// "005930" normalizes to the product code "A005930" and already looks
+	// like one, so no search round-trip is needed — this exercises that path.
+	got, err := c.GetAccumulationPlansByStock(context.Background(), "005930")
+	if err != nil {
+		t.Fatalf("GetAccumulationPlansByStock: %v", err)
+	}
+	if len(got.Plans) != 1 {
+		t.Fatalf("want 1 plan, got %d", len(got.Plans))
+	}
+	p := got.Plans[0]
+	if p.StockCode != "A005930" || !p.IsPaused || p.PlanType != "QUANTITY" || p.InvestQuantity != 1 {
+		t.Errorf("plan: %+v", p)
+	}
+}
+
+func TestGetAccumulationPlansByStockNoSession(t *testing.T) {
+	c := New(Config{})
+	if _, err := c.GetAccumulationPlansByStock(context.Background(), "A005930"); err == nil {
+		t.Fatal("want error without a session")
+	}
+}

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -800,3 +800,36 @@ type ConditionalOrderRef struct {
 	ID            string `json:"id"`
 	ClientOrderID string `json:"client_order_id,omitempty"`
 }
+
+// AccumulationPlan is one "stock accumulation" (주식모으기) recurring-buy
+// plan — a scheduled automatic purchase of a fixed amount or quantity.
+// IsPaused is the plan's active/disabled state. WTS-only.
+type AccumulationPlan struct {
+	ID                    int64   `json:"id"`
+	Symbol                string  `json:"symbol"`
+	StockCode             string  `json:"stock_code"`
+	StockName             string  `json:"stock_name"`
+	CountryCode           string  `json:"country_code"`
+	Currency              string  `json:"currency"`
+	PlanType              string  `json:"plan_type"` // AMOUNT | QUANTITY
+	Iteration             string  `json:"iteration"` // e.g. DAILY, WEEKLY, MONTHLY
+	IterateTarget         int     `json:"iterate_target"`
+	InvestAmount          float64 `json:"invest_amount"`
+	InvestQuantity        float64 `json:"invest_quantity"`
+	TradeStatus           string  `json:"trade_status"` // e.g. PROGRESS
+	IsPaused              bool    `json:"is_paused"`
+	InvestStartDate       string  `json:"invest_start_date"`
+	InvestEndDate         string  `json:"invest_end_date"`
+	ProceededRound        int     `json:"proceeded_round"`
+	SucceededRound        int     `json:"succeeded_round"`
+	TotalExecutedAmount   float64 `json:"total_executed_amount"`
+	TotalExecutedQuantity float64 `json:"total_executed_quantity"`
+	CreatedAt             string  `json:"created_at"`
+	UpdatedAt             string  `json:"updated_at"`
+}
+
+// AccumulationPlans is the account's full list of accumulation plans.
+type AccumulationPlans struct {
+	Plans     []AccumulationPlan `json:"plans"`
+	FetchedAt time.Time          `json:"fetched_at"`
+}

--- a/internal/i18n/en.json
+++ b/internal/i18n/en.json
@@ -415,5 +415,10 @@
   "watchlist.short": "Read and manage the watchlist",
   "lending.short": "Securities lending queries",
   "lending.expected.short": "Projected share-lending income (per stock, monthly/yearly USD)",
-  "lending.expected.long": "Show projected income from lending out your holdings (대주): monthly and yearly estimates in USD plus a per-stock breakdown. Works even for accounts without an active lending agreement (shows zeros). WTS-only."
+  "lending.expected.long": "Show projected income from lending out your holdings (대주): monthly and yearly estimates in USD plus a per-stock breakdown. Works even for accounts without an active lending agreement (shows zeros). WTS-only.",
+  "accumulate.short": "Stock accumulation recurring-buy plan queries",
+  "accumulate.list.short": "List every accumulation plan on the account (all stocks, all statuses)",
+  "accumulate.list.long": "Show every stock-accumulation (주식모으기) plan on the account — recurring automatic buys — including which are Active vs Paused, the amount/quantity and frequency, and how many rounds have completed. WTS-only.",
+  "accumulate.status.short": "Show the accumulation plan(s) for one stock",
+  "accumulate.status.long": "Show the stock-accumulation (주식모으기) plan(s) for a single stock, including whether it's Active or Paused. Accepts a ticker (e.g. 005930, AAPL) or a Toss product code. WTS-only."
 }

--- a/internal/i18n/ko.json
+++ b/internal/i18n/ko.json
@@ -415,5 +415,10 @@
   "watchlist.short": "관심종목 조회 및 관리",
   "lending.short": "Securities lending queries",
   "lending.expected.short": "Projected share-lending income (per stock, monthly/yearly USD)",
-  "lending.expected.long": "보유 종목의 주식대여(대주)로 예상되는 수익을 조회합니다. 월간·연간 예상액(USD)과 종목별 내역을 보여주며, 대차 약정이 없는 계좌에서도 조회할 수 있습니다(0으로 표시). 웹앱(WTS) 전용 기능입니다."
+  "lending.expected.long": "보유 종목의 주식대여(대주)로 예상되는 수익을 조회합니다. 월간·연간 예상액(USD)과 종목별 내역을 보여주며, 대차 약정이 없는 계좌에서도 조회할 수 있습니다(0으로 표시). 웹앱(WTS) 전용 기능입니다.",
+  "accumulate.short": "주식모으기(정기 자동매수) 조회",
+  "accumulate.list.short": "계좌의 모든 모으기 설정 조회 (전 종목·전 상태)",
+  "accumulate.list.long": "계좌에 설정된 모든 주식모으기(정기 자동매수) 플랜을 보여줍니다 — Active/Paused 상태, 매수 금액·수량, 주기, 완료 회차를 포함합니다. 웹앱(WTS) 전용 기능입니다.",
+  "accumulate.status.short": "특정 종목의 모으기 설정 조회",
+  "accumulate.status.long": "특정 종목의 주식모으기(정기 자동매수) 플랜과 Active/Paused 상태를 보여줍니다. 티커(예: 005930, AAPL) 또는 토스 상품코드를 입력할 수 있습니다. 웹앱(WTS) 전용 기능입니다."
 }

--- a/internal/monitor/probes_test.go
+++ b/internal/monitor/probes_test.go
@@ -25,6 +25,7 @@ func TestProbesRegistryStableNames(t *testing.T) {
 		"earning-call-home":        true,
 		"community-rankings":       true,
 		"lending-expected":         true,
+		"accumulation-plans":       true,
 		"news-briefing":            true,
 		"sectors-tics":             true,
 		"theme-rankings":           true,

--- a/internal/ops/wts_operations.go
+++ b/internal/ops/wts_operations.go
@@ -205,6 +205,28 @@ func wtsOperations() []Operation {
 			},
 		},
 		{
+			ID: "accumulation_plans", Method: "GET", Path: "wts:autotrade/plan/find", Backend: "wts",
+			Category: "portfolio", Summary: "All stock-accumulation (주식모으기) recurring-buy plans on the account — which stocks, Active vs Paused, amount/quantity, frequency, rounds completed. WTS-only.",
+			Probe: &ProbeSpec{Name: "accumulation-plans", Method: "GET",
+				URL:   probeAPI + "/api/v2/autotrade/plan/find",
+				Check: statusAndPath("result", "array")},
+			handler: func(ctx context.Context, d *Deps, _ map[string]any) (any, error) {
+				return d.WTS.ListAccumulationPlans(ctx)
+			},
+		},
+		{
+			ID: "accumulation_status", Method: "GET", Path: "wts:autotrade/plan/stock", Backend: "wts",
+			Category: "portfolio", Summary: "Stock-accumulation (주식모으기) plan(s) for one stock — Active vs Paused, amount/quantity, frequency. WTS-only.",
+			Params: []Param{{Name: "symbol", Type: "string", Required: true, Desc: "ticker (e.g. 005930, AAPL) or Toss product code"}},
+			handler: func(ctx context.Context, d *Deps, args map[string]any) (any, error) {
+				symbol, err := argString(args, "symbol")
+				if err != nil {
+					return nil, err
+				}
+				return d.WTS.GetAccumulationPlansByStock(ctx, symbol)
+			},
+		},
+		{
 			ID: "dividends", Method: "GET", Path: "wts:portfolio/dividends", Backend: "wts",
 			Category: "portfolio", Summary: "Annual dividend history (received/scheduled, by region, monthly). WTS-only.",
 			Params: []Param{

--- a/internal/output/accumulation.go
+++ b/internal/output/accumulation.go
@@ -1,0 +1,75 @@
+package output
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/domain"
+)
+
+// WriteAccumulationPlans renders "stock accumulation" (주식모으기) plans.
+// JSON/CSV are language-invariant; the table view shows Active/Paused status
+// plainly (the feature IsPaused is inverted for readability).
+func WriteAccumulationPlans(w io.Writer, format Format, p domain.AccumulationPlans) error {
+	switch format {
+	case FormatJSON:
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(p)
+	case FormatCSV:
+		writer := csv.NewWriter(w)
+		header := []string{
+			"symbol", "stock_name", "status", "plan_type", "iteration",
+			"invest_amount", "invest_quantity", "currency",
+			"succeeded_round", "invest_start_date",
+		}
+		if err := writer.Write(header); err != nil {
+			return err
+		}
+		for _, plan := range p.Plans {
+			row := []string{
+				plan.Symbol, plan.StockName, accumulationStatus(plan),
+				plan.PlanType, plan.Iteration,
+				strconv.FormatFloat(plan.InvestAmount, 'f', -1, 64),
+				strconv.FormatFloat(plan.InvestQuantity, 'f', -1, 64),
+				plan.Currency,
+				strconv.Itoa(plan.SucceededRound), plan.InvestStartDate,
+			}
+			if err := writer.Write(row); err != nil {
+				return err
+			}
+		}
+		writer.Flush()
+		return writer.Error()
+	default: // table
+		if len(p.Plans) == 0 {
+			_, err := fmt.Fprintln(w, "(no accumulation plans)")
+			return err
+		}
+		for _, plan := range p.Plans {
+			amount := plan.InvestQuantity
+			unit := "주"
+			if plan.PlanType == "AMOUNT" {
+				amount = plan.InvestAmount
+				unit = plan.Currency
+			}
+			if _, err := fmt.Fprintf(w, "  %-6s %-18s %-8s %-8s every %-8s %.2f %s (%d회 완료)\n",
+				plan.Symbol, plan.StockName, accumulationStatus(plan), plan.PlanType,
+				plan.Iteration, amount, unit, plan.SucceededRound,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func accumulationStatus(p domain.AccumulationPlan) string {
+	if p.IsPaused {
+		return "Paused"
+	}
+	return "Active"
+}

--- a/internal/output/accumulation_test.go
+++ b/internal/output/accumulation_test.go
@@ -1,0 +1,80 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/domain"
+)
+
+func dummyAccumulationPlans() domain.AccumulationPlans {
+	return domain.AccumulationPlans{
+		Plans: []domain.AccumulationPlan{
+			{
+				Symbol: "DUMMY", StockName: "Dummy Corp", Currency: "KRW",
+				PlanType: "AMOUNT", Iteration: "DAILY",
+				InvestAmount: 10000, IsPaused: false, SucceededRound: 3,
+				InvestStartDate: "2026-01-01",
+			},
+			{
+				Symbol: "PAWS", StockName: "Paused Inc", Currency: "USD",
+				PlanType: "QUANTITY", Iteration: "WEEKLY",
+				InvestQuantity: 1, IsPaused: true, SucceededRound: 0,
+				InvestStartDate: "2026-02-01",
+			},
+		},
+	}
+}
+
+func TestWriteAccumulationPlansJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteAccumulationPlans(&buf, FormatJSON, dummyAccumulationPlans()); err != nil {
+		t.Fatalf("WriteAccumulationPlans JSON error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"symbol": "DUMMY"`) {
+		t.Errorf("missing DUMMY symbol in JSON: %s", out)
+	}
+	if !strings.Contains(out, `"is_paused": true`) {
+		t.Errorf("missing is_paused:true in JSON: %s", out)
+	}
+}
+
+func TestWriteAccumulationPlansTableShowsStatus(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteAccumulationPlans(&buf, FormatTable, dummyAccumulationPlans()); err != nil {
+		t.Fatalf("WriteAccumulationPlans table error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Active") {
+		t.Errorf("expected Active status in table: %s", out)
+	}
+	if !strings.Contains(out, "Paused") {
+		t.Errorf("expected Paused status in table: %s", out)
+	}
+}
+
+func TestWriteAccumulationPlansTableEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteAccumulationPlans(&buf, FormatTable, domain.AccumulationPlans{}); err != nil {
+		t.Fatalf("WriteAccumulationPlans empty error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "no accumulation plans") {
+		t.Errorf("expected empty-state message, got %q", buf.String())
+	}
+}
+
+func TestWriteAccumulationPlansCSV(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteAccumulationPlans(&buf, FormatCSV, dummyAccumulationPlans()); err != nil {
+		t.Fatalf("WriteAccumulationPlans CSV error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 { // header + 2 rows
+		t.Fatalf("want 3 CSV lines, got %d: %q", len(lines), buf.String())
+	}
+	if !strings.HasPrefix(lines[0], "symbol,stock_name,status") {
+		t.Errorf("unexpected CSV header: %q", lines[0])
+	}
+}

--- a/tools/update_new_markers.py
+++ b/tools/update_new_markers.py
@@ -25,6 +25,8 @@ FILES = ["README.md", "README.en.md"]
 # Longest keys are matched first so e.g. "market ranking" never matches a
 # "community rankings" row. Date = CHANGELOG version date of first appearance.
 FEATURE_DATES = {
+    "accumulate list": "2026-07-21",
+    "accumulate status": "2026-07-21",
     "portfolio dividends": "2026-06-19",
     "community rankings": "2026-06-19",
     "market sectors": "2026-06-19",

--- a/tools/wts_endpoints.py
+++ b/tools/wts_endpoints.py
@@ -71,6 +71,8 @@ IMPLEMENTED = [
     r"^/api/v1/tics/all$",                                        # market sectors
     r"^/api/v1/tics/rankings$",                                   # market themes
     r"^/api/v1/index-prices$",                                    # market index <code> (지수 상세)
+    r"^/api/v2/autotrade/plan/find$",                             # accumulate list
+    r"^/api/v1/growth/autotrade/plan/stock$",                     # accumulate status
 ]
 
 # recommended: candidates worth implementing next (data/discovery features that


### PR DESCRIPTION
## 무엇

주식모으기(정기 자동매수) 설정 조회. Discussion #101 요청 대응.

```
tossctl accumulate list              # 계좌의 모든 플랜 (전 종목, 전 상태)
tossctl accumulate status <symbol>   # 특정 종목의 플랜
```

Active/Paused 상태, 매수 금액·수량, 주기(DAILY 등), 완료 회차를 보여줍니다.

## 근거

공식 문서가 없는 WTS 웹앱 기능이라, 프로덕션 JS 번들을 정적 분석해 실제 엔드포인트를 확보했습니다:

- `GET wts-api.tossinvest.com/api/v2/autotrade/plan/find` — 전체 플랜
- `GET wts-cert-api.tossinvest.com/api/v1/growth/autotrade/plan/stock/{code}` — 종목별 플랜

두 엔드포인트 모두 실계좌로 라이브 검증했습니다(값은 커밋하지 않음 — 계약 테스트는 합성 더미 데이터).

## 스코프 밖 (의도적)

설정 변경(`POST .../plan/modify`)은 이번에 넣지 않았습니다. 정적 분석만으로는 요청 바디를 확실히 재구성하지 못했고, 라이브로 호출해 확인하면 실계좌 설정이 바뀌는 위험이 있어 이번엔 보류했습니다. Discussion 의 핵심 요청("뭔지, Active/Disable 인지")은 Read 로 충족됩니다.

## 체크리스트

- [x] `internal/ops` 레지스트리 등록 → MCP 자동 노출 (`accumulation_plans`, `accumulation_status`)
- [x] monitor probe 추가 (list 쪽, 대표 1개 — probes_test.go 25→26)
- [x] `tools/wts_endpoints.py` IMPLEMENTED 패턴 추가 (해당 엔드포인트 candidate→implemented)
- [x] README(ko/en) 비교표 행 + 헤드라인 기능 수 동기화, 🆕 마커
- [x] CHANGELOG Unreleased
- [x] 계약 테스트(httptest, 더미 데이터) — client/output 레이어
- [x] 실계좌 데이터 유출 여부 diff 전체 재검사
