### PR TITLE
refactor(output): JSON 렌더링을 writeJSON 헬퍼 하나로 통합

### DIFF
--- a/internal/output/account.go
+++ b/internal/output/account.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -16,9 +15,7 @@ import (
 func WriteAccounts(w io.Writer, format Format, accounts []domain.Account, primaryKey string) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(map[string]any{
+		return writeJSON(w, map[string]any{
 			"primary_key": primaryKey,
 			"accounts":    accounts,
 		})
@@ -67,9 +64,7 @@ func WriteAccounts(w io.Writer, format Format, accounts []domain.Account, primar
 func WriteAccountSummary(w io.Writer, format Format, summary domain.AccountSummary) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(summary)
+		return writeJSON(w, summary)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		if err := writer.Write([]string{"metric", "value"}); err != nil {
@@ -137,9 +132,7 @@ func WriteAccountSummary(w io.Writer, format Format, summary domain.AccountSumma
 func WriteAccountPrime(w io.Writer, format Format, p domain.PrimeStatus) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(p)
+		return writeJSON(w, p)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		if err := writer.Write([]string{"metric", "non_prime", "prime", "benefit"}); err != nil {

--- a/internal/output/accumulation.go
+++ b/internal/output/accumulation.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -16,9 +15,7 @@ import (
 func WriteAccumulationPlans(w io.Writer, format Format, p domain.AccumulationPlans) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(p)
+		return writeJSON(w, p)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		header := []string{

--- a/internal/output/chart.go
+++ b/internal/output/chart.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -49,9 +48,7 @@ func WriteChart(w io.Writer, format Format, chart domain.Chart) error {
 }
 
 func writeChartJSON(w io.Writer, chart domain.Chart) error {
-	encoder := json.NewEncoder(w)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(chart)
+	return writeJSON(w, chart)
 }
 
 func writeChartCSV(w io.Writer, chart domain.Chart) error {

--- a/internal/output/conditional.go
+++ b/internal/output/conditional.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -16,9 +15,7 @@ import (
 func WriteConditionalOrders(w io.Writer, format Format, l domain.ConditionalOrderList) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(l)
+		return writeJSON(w, l)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"id", "type", "status", "symbol", "quantity", "order_type", "expire_date"}); err != nil {
@@ -56,9 +53,7 @@ func WriteConditionalOrders(w io.Writer, format Format, l domain.ConditionalOrde
 func WriteConditionalOrder(w io.Writer, format Format, o domain.ConditionalOrder) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(o)
+		return writeJSON(w, o)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"leg", "cond_type", "status", "trigger_price", "order_price", "target_profit_rate"}); err != nil {

--- a/internal/output/config.go
+++ b/internal/output/config.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -15,9 +14,7 @@ import (
 func WriteConfigStatus(w io.Writer, format Format, status config.Status) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(status)
+		return writeJSON(w, status)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		if err := writer.Write([]string{

--- a/internal/output/doctor.go
+++ b/internal/output/doctor.go
@@ -1,7 +1,6 @@
 package output
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -12,9 +11,7 @@ import (
 func WriteDoctorReport(w io.Writer, format Format, report doctor.Report) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(report)
+		return writeJSON(w, report)
 	case FormatCSV:
 		return fmt.Errorf("csv output is not supported for doctor")
 	case FormatTable:
@@ -65,9 +62,7 @@ func WriteDoctorReport(w io.Writer, format Format, report doctor.Report) error {
 func WriteAuthDoctorReport(w io.Writer, format Format, report doctor.AuthReport) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(report)
+		return writeJSON(w, report)
 	case FormatCSV:
 		return fmt.Errorf("csv output is not supported for auth doctor")
 	case FormatTable:

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -1,7 +1,9 @@
 package output
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -22,4 +24,13 @@ func ParseFormat(value string) (Format, error) {
 	default:
 		return "", fmt.Errorf("unsupported output format %q; expected one of: table, json, csv", value)
 	}
+}
+
+// writeJSON renders v as the CLI's canonical JSON: two-space indent, one
+// trailing newline (Encode adds it). Every FormatJSON branch goes through
+// here, so the indent is decided once rather than per formatter.
+func writeJSON(w io.Writer, v any) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(v)
 }

--- a/internal/output/lending.go
+++ b/internal/output/lending.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -15,9 +14,7 @@ import (
 func WriteLendingExpected(w io.Writer, format Format, l domain.LendingExpected) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(l)
+		return writeJSON(w, l)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		if err := writer.Write([]string{"product_code", "name", "amount_usd"}); err != nil {

--- a/internal/output/marketdata.go
+++ b/internal/output/marketdata.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -15,9 +14,7 @@ import (
 func WriteTrades(w io.Writer, format Format, list domain.TradeList) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(list)
+		return writeJSON(w, list)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"time", "price", "volume", "trade_type", "cumulative_volume"}); err != nil {
@@ -60,9 +57,7 @@ func WriteTrades(w io.Writer, format Format, list domain.TradeList) error {
 func WritePriceLimits(w io.Writer, format Format, pl domain.PriceLimits) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(pl)
+		return writeJSON(w, pl)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"date", "upper_limit", "lower_limit"}); err != nil {
@@ -92,9 +87,7 @@ func WritePriceLimits(w io.Writer, format Format, pl domain.PriceLimits) error {
 func WriteStockWarnings(w io.Writer, format Format, sw domain.StockWarnings) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(sw)
+		return writeJSON(w, sw)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"type", "title", "text", "level"}); err != nil {
@@ -141,9 +134,7 @@ func WriteStockWarnings(w io.Writer, format Format, sw domain.StockWarnings) err
 func WriteTradingHours(w io.Writer, format Format, th domain.TradingHours) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(th)
+		return writeJSON(w, th)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"market", "session", "date", "start_time", "end_time"}); err != nil {
@@ -191,9 +182,7 @@ func WriteTradingHours(w io.Writer, format Format, th domain.TradingHours) error
 func WriteExchangeRates(w io.Writer, format Format, er domain.ExchangeRates) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(er)
+		return writeJSON(w, er)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"code", "name", "base", "close"}); err != nil {
@@ -225,9 +214,7 @@ func WriteExchangeRates(w io.Writer, format Format, er domain.ExchangeRates) err
 func WriteScreenerPresets(w io.Writer, format Format, sp domain.ScreenerPresets) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(sp)
+		return writeJSON(w, sp)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"id", "name", "description"}); err != nil {
@@ -263,9 +250,7 @@ func WriteScreenerPresets(w io.Writer, format Format, sp domain.ScreenerPresets)
 func WriteScreenerResult(w io.Writer, format Format, sr domain.ScreenerResult) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(sr)
+		return writeJSON(w, sr)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"product_code", "name", "close", "change", "change_rate"}); err != nil {
@@ -304,9 +289,7 @@ func WriteScreenerResult(w io.Writer, format Format, sr domain.ScreenerResult) e
 func WriteAISignals(w io.Writer, format Format, sg domain.AISignals) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(sg)
+		return writeJSON(w, sg)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"asset_name", "title", "keyword", "fluctuation", "stock_code"}); err != nil {
@@ -346,9 +329,7 @@ func WriteAISignals(w io.Writer, format Format, sg domain.AISignals) error {
 func WriteTradingFlows(w io.Writer, format Format, tf domain.TradingFlows) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(tf)
+		return writeJSON(w, tf)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"date", "net_individuals", "net_foreigner", "net_institution"}); err != nil {
@@ -401,9 +382,7 @@ func signedInt(v float64) string {
 func WriteMarketIndices(w io.Writer, format Format, mi domain.MarketIndices) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(mi)
+		return writeJSON(w, mi)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"code", "name", "nation", "latest", "base", "change", "change_rate"}); err != nil {
@@ -451,9 +430,7 @@ func WriteMarketIndices(w io.Writer, format Format, mi domain.MarketIndices) err
 func WriteIndexQuote(w io.Writer, format Format, q domain.IndexQuote) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(q)
+		return writeJSON(w, q)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"code", "name", "open", "high", "low", "close", "change", "change_rate", "high_52w", "low_52w"}); err != nil {
@@ -490,9 +467,7 @@ func WriteIndexQuote(w io.Writer, format Format, q domain.IndexQuote) error {
 func WriteStockRanking(w io.Writer, format Format, sr domain.StockRanking) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(sr)
+		return writeJSON(w, sr)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"rank", "symbol", "name", "market", "product_code"}); err != nil {
@@ -542,9 +517,7 @@ func sessionTime(s string) string {
 func WriteOrderBook(w io.Writer, format Format, ob domain.OrderBook) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(ob)
+		return writeJSON(w, ob)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"side", "level", "price", "volume"}); err != nil {
@@ -600,9 +573,7 @@ func WriteOrderBook(w io.Writer, format Format, ob domain.OrderBook) error {
 func WriteSellableQuantity(w io.Writer, format Format, sq domain.SellableQuantity) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(sq)
+		return writeJSON(w, sq)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"product_code", "symbol", "sellable_quantity"}); err != nil {
@@ -629,9 +600,7 @@ func WriteSellableQuantity(w io.Writer, format Format, sq domain.SellableQuantit
 func WriteCommission(w io.Writer, format Format, c domain.Commission) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(c)
+		return writeJSON(w, c)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"product_code", "symbol", "commission_rate", "tax_rate"}); err != nil {
@@ -664,9 +633,7 @@ func formatPercent(rate float64) string {
 func WriteInvestorRankings(w io.Writer, format Format, ir domain.InvestorRankings) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(ir)
+		return writeJSON(w, ir)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"investor_type", "rank", "product_code", "name", "net_buy_amount", "close"}); err != nil {
@@ -702,9 +669,7 @@ func WriteInvestorRankings(w io.Writer, format Format, ir domain.InvestorRanking
 func WriteEarningCalls(w io.Writer, format Format, ec domain.EarningCalls) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(ec)
+		return writeJSON(w, ec)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"live_at", "company_name", "company_code", "title", "status", "category"}); err != nil {
@@ -753,9 +718,7 @@ func divAmt(a domain.DividendAmount) string {
 func WriteDividends(w io.Writer, format Format, d domain.Dividends) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(d)
+		return writeJSON(w, d)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"month", "total_krw", "total_usd"}); err != nil {
@@ -807,9 +770,7 @@ func WriteDividends(w io.Writer, format Format, d domain.Dividends) error {
 func WriteCommunityRanking(w io.Writer, format Format, r domain.CommunityRanking) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(r)
+		return writeJSON(w, r)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"rank", "nickname", "user_profile_id", "description", "profit_amount_krw", "profit_rate", "following_count", "following_increase"}); err != nil {
@@ -865,9 +826,7 @@ func WriteCommunityRanking(w io.Writer, format Format, r domain.CommunityRanking
 func WriteThemeRankings(w io.Writer, format Format, r domain.ThemeRankings) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(r)
+		return writeJSON(w, r)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"ranking", "tics_id", "title", "change_rate", "rise_company_count", "total_count"}); err != nil {
@@ -913,9 +872,7 @@ func WriteSectors(w io.Writer, format Format, sectors domain.Sectors) error {
 	list := sectors.Items
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(sectors)
+		return writeJSON(w, sectors)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"id", "title", "company_count", "one_day_rate", "one_month_rate", "one_year_rate"}); err != nil {
@@ -955,9 +912,7 @@ func WriteSectors(w io.Writer, format Format, sectors domain.Sectors) error {
 func WriteNewsBriefing(w io.Writer, format Format, b domain.NewsBriefing) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(b)
+		return writeJSON(w, b)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"category", "title", "agency", "created_at"}); err != nil {
@@ -1001,9 +956,7 @@ func WriteNewsBriefing(w io.Writer, format Format, b domain.NewsBriefing) error 
 func WriteRanking(w io.Writer, format Format, r domain.Ranking) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(r)
+		return writeJSON(w, r)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"rank", "symbol", "currency", "last_price", "base_price", "change_rate", "trading_volume", "trading_amount"}); err != nil {
@@ -1051,9 +1004,7 @@ func WriteRanking(w io.Writer, format Format, r domain.Ranking) error {
 func WriteMarketIndicatorPrices(w io.Writer, format Format, p domain.MarketIndicatorPrices) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(p)
+		return writeJSON(w, p)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"symbol", "last_price", "timestamp"}); err != nil {
@@ -1086,9 +1037,7 @@ func WriteMarketIndicatorPrices(w io.Writer, format Format, p domain.MarketIndic
 func WriteMarketIndicatorCandles(w io.Writer, format Format, c domain.MarketIndicatorCandles) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(c)
+		return writeJSON(w, c)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"timestamp", "open", "high", "low", "close", "volume"}); err != nil {
@@ -1138,9 +1087,7 @@ func WriteMarketIndicatorCandles(w io.Writer, format Format, c domain.MarketIndi
 func WriteInvestorTrading(w io.Writer, format Format, it domain.InvestorTrading) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(it)
+		return writeJSON(w, it)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"date", "individual_net", "foreigner_net", "institution_net", "other_net"}); err != nil {

--- a/internal/output/orders.go
+++ b/internal/output/orders.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -22,9 +21,7 @@ func WriteCompletedOrders(w io.Writer, format Format, orders []domain.Order) err
 func WriteOrder(w io.Writer, format Format, order domain.Order) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(order)
+		return writeJSON(w, order)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		if err := writer.Write([]string{"id", "resolved_from_id", "symbol", "name", "market", "side", "status", "quantity", "filled_quantity", "price", "average_execution_price", "order_date", "submitted_at"}); err != nil {
@@ -113,9 +110,7 @@ func WriteOrder(w io.Writer, format Format, order domain.Order) error {
 func writeOrderList(w io.Writer, format Format, title, emptyMessage string, orders []domain.Order) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(orders)
+		return writeJSON(w, orders)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		if err := writer.Write([]string{"id", "symbol", "name", "market", "side", "status", "quantity", "filled_quantity", "price", "average_execution_price", "order_date", "submitted_at"}); err != nil {

--- a/internal/output/portfolio.go
+++ b/internal/output/portfolio.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -14,9 +13,7 @@ import (
 func WritePositions(w io.Writer, format Format, positions []domain.Position) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(positions)
+		return writeJSON(w, positions)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		if err := writer.Write([]string{"product_code", "symbol", "name", "market_type", "market_code", "quantity", "average_price", "current_price", "market_value", "unrealized_pnl", "profit_rate", "daily_profit_loss", "daily_profit_rate", "average_price_usd", "current_price_usd", "market_value_usd", "unrealized_pnl_usd", "profit_rate_usd", "daily_profit_loss_usd", "daily_profit_rate_usd"}); err != nil {
@@ -61,9 +58,7 @@ func WritePositions(w io.Writer, format Format, positions []domain.Position) err
 func WriteAllocation(w io.Writer, format Format, markets map[string]domain.AccountMarketSummary) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(markets)
+		return writeJSON(w, markets)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		if err := writer.Write([]string{"market", "total_asset_amount", "principal_amount", "evaluated_profit_amount", "profit_rate"}); err != nil {

--- a/internal/output/profit.go
+++ b/internal/output/profit.go
@@ -1,7 +1,6 @@
 package output
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -13,9 +12,7 @@ import (
 func WriteProfitOverview(w io.Writer, format Format, p domain.ProfitOverview) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(p)
+		return writeJSON(w, p)
 	default: // table (CSV would be awkward for this nested shape; table only)
 		usd := func(d domain.DualCurrency) string {
 			if d.USD == nil {

--- a/internal/output/quote.go
+++ b/internal/output/quote.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -26,9 +25,7 @@ func WriteQuote(w io.Writer, format Format, quote domain.Quote) error {
 }
 
 func writeQuoteJSON(w io.Writer, quote domain.Quote) error {
-	encoder := json.NewEncoder(w)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(quote)
+	return writeJSON(w, quote)
 }
 
 func writeQuoteCSV(w io.Writer, quote domain.Quote) error {
@@ -145,9 +142,7 @@ func WriteQuotes(w io.Writer, format Format, quotes []domain.Quote) error {
 func WriteQuotesWithCharts(w io.Writer, format Format, quotes []domain.Quote, charts []domain.Chart) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(quotes)
+		return writeJSON(w, quotes)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		if err := writer.Write([]string{

--- a/internal/output/trading.go
+++ b/internal/output/trading.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -14,9 +13,7 @@ import (
 func WriteTradingPreview(w io.Writer, format Format, preview trading.Preview) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(preview)
+		return writeJSON(w, preview)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		if err := writer.Write([]string{"kind", "confirm_token", "canonical", "warnings"}); err != nil {
@@ -64,9 +61,7 @@ func WriteTradingPreview(w io.Writer, format Format, preview trading.Preview) er
 func WriteMutationResult(w io.Writer, format Format, result trading.MutationResult) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(result)
+		return writeJSON(w, result)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		if err := writer.Write([]string{"kind", "status", "order_id", "original_order_id", "current_order_id", "symbol", "market", "quantity", "filled_quantity", "price", "average_execution_price", "order_date"}); err != nil {

--- a/internal/output/transactions.go
+++ b/internal/output/transactions.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -15,9 +14,7 @@ import (
 func WriteTransactions(w io.Writer, format Format, items []domain.Transaction) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(items)
+		return writeJSON(w, items)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		if err := writer.Write([]string{
@@ -116,9 +113,7 @@ func WriteTransactions(w io.Writer, format Format, items []domain.Transaction) e
 func WriteTransactionsOverview(w io.Writer, format Format, overview domain.TransactionOverview) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(overview)
+		return writeJSON(w, overview)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		if err := writer.Write([]string{"section", "date", "krw", "usd", "note"}); err != nil {

--- a/internal/output/transfer_income.go
+++ b/internal/output/transfer_income.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -16,9 +15,7 @@ import (
 func WriteOverseasTransferIncome(w io.Writer, format Format, t domain.OverseasTransferIncome) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(t)
+		return writeJSON(w, t)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		header := []string{"symbol", "name", "sell_quantity", "sell_amount", "buy_amount", "expense", "profit_loss", "settlement_date", "settled"}

--- a/internal/output/watchlist.go
+++ b/internal/output/watchlist.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -13,9 +12,7 @@ import (
 func WriteWatchlist(w io.Writer, format Format, items []domain.WatchlistItem) error {
 	switch format {
 	case FormatJSON:
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(items)
+		return writeJSON(w, items)
 	case FormatCSV:
 		writer := csv.NewWriter(w)
 		if err := writer.Write([]string{"group", "symbol", "name", "currency", "base", "last"}); err != nil {
@@ -91,9 +88,7 @@ func WriteWatchlist(w io.Writer, format Format, items []domain.WatchlistItem) er
 func WriteWatchlistGroups(w io.Writer, format Format, groups []domain.WatchlistGroup) error {
 	switch format {
 	case FormatJSON:
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		return enc.Encode(groups)
+		return writeJSON(w, groups)
 	case FormatCSV:
 		cw := csv.NewWriter(w)
 		if err := cw.Write([]string{"id", "name", "type", "item_count"}); err != nil {


### PR DESCRIPTION
아키텍처 리뷰(`/improve-codebase-architecture`)에서 나온 최고 가성비 항목.

## 문제

`internal/output` 의 `FormatJSON` 분기 **51곳**이 아래를 각자 복붙하고 있었다 — 공유 헬퍼 없음:

```go
encoder := json.NewEncoder(w)
encoder.SetIndent("", "  ")
return encoder.Encode(x)
```

인덴트 규칙이 51군데 흩어져 있어서 바꾸려면 전부 손봐야 하는 상태.

## 변경

`format.go` 에 `writeJSON(w io.Writer, v any) error` 를 두고 51개 호출부를 한 줄로 축약. `encoding/json` import 도 16개 파일에서 제거됐다.

**table/CSV/human 분기는 건드리지 않았다** — 컬럼 선택·i18n·컬러링 등 타입별 실제 로직이라 얕지 않다. 일반화하면 오히려 로직이 흩어진다.

## 검증

- **출력 무변화 증명**: 리팩터 전후 리비전에서 동일한 스냅샷 테스트를 돌려 대표 7개 `WriteX` 의 `FormatJSON` 출력을 바이트 단위로 비교 → 완전 동일 (스냅샷 테스트는 검증 후 제거)
- `make test` 전체 통과, `go vet ./...` 통과, `gofmt` 클린
- 남은 `json.NewEncoder` 는 `format.go` 의 헬퍼 1곳뿐

net **-107 lines** (62 insertions, 169 deletions).

https://claude.ai/code/session_015CLrLGFKyKziG4mCjaTCmT