### PR TITLE
chore: make lint 타겟 추가 + CI 에서 포맷 검사

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,9 @@ jobs:
       - name: Run Go tests
         run: go test ./...
 
-      - name: go vet
-        run: go vet ./...
+      # gofmt + go vet, same target contributors run locally.
+      - name: Lint
+        run: make lint
 
       - name: Build CLI
         run: make build

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS := -X github.com/JungHoonGhae/tossinvest-cli/internal/version.Version=$(
 	-X github.com/JungHoonGhae/tossinvest-cli/internal/version.Commit=$(COMMIT) \
 	-X github.com/JungHoonGhae/tossinvest-cli/internal/version.Date=$(DATE)
 
-.PHONY: build run test fmt tidy clean
+.PHONY: build run test lint fmt tidy clean
 
 build:
 	mkdir -p bin
@@ -17,6 +17,18 @@ run:
 
 test:
 	go test ./...
+
+# lint is gofmt + vet only — no extra tooling to install. `gofmt -l` lists
+# unformatted files without changing them, so the check fails loudly instead of
+# silently reformatting; run `make fmt` to fix.
+lint:
+	@unformatted=$$(gofmt -l ./cmd ./internal); \
+	if [ -n "$$unformatted" ]; then \
+		echo "gofmt: 아래 파일이 포맷되지 않았습니다 — \`make fmt\` 를 실행하세요:"; \
+		echo "$$unformatted" | sed 's/^/  /'; \
+		exit 1; \
+	fi
+	go vet ./...
 
 fmt:
 	gofmt -w ./cmd ./internal

--- a/internal/client/chart_test.go
+++ b/internal/client/chart_test.go
@@ -40,14 +40,14 @@ func TestDeriveSecurityType(t *testing.T) {
 		productCode string
 		want        string
 	}{
-		{"A005930", "kr-s"},   // 삼성전자 — A + 6 digits
-		{"A294400", "kr-s"},   // KODEX 인버스
-		{"AAPL", "us-s"},      // 미국 티커 — A 로 시작하지만 영문 포함
-		{"TSLA", "us-s"},      // A 로 시작 안 함
-		{"MSFT", "us-s"},      // A 로 시작 안 함
-		{"A", "us-s"},         // 너무 짧음 → kr 휴리스틱 실패 → us
-		{"A12345", "us-s"},    // A + 5 digits — 너무 짧음 (>=7 요구)
-		{"A1234567", "kr-s"},  // A + 7 digits → kr
+		{"A005930", "kr-s"},  // 삼성전자 — A + 6 digits
+		{"A294400", "kr-s"},  // KODEX 인버스
+		{"AAPL", "us-s"},     // 미국 티커 — A 로 시작하지만 영문 포함
+		{"TSLA", "us-s"},     // A 로 시작 안 함
+		{"MSFT", "us-s"},     // A 로 시작 안 함
+		{"A", "us-s"},        // 너무 짧음 → kr 휴리스틱 실패 → us
+		{"A12345", "us-s"},   // A + 5 digits — 너무 짧음 (>=7 요구)
+		{"A1234567", "kr-s"}, // A + 7 digits → kr
 		{"US00000000000", "us-s"},
 	}
 	for _, c := range cases {

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -17,8 +17,6 @@ func (e *StatusError) Error() string {
 	return fmt.Sprintf("unexpected status %d for %s", e.StatusCode, e.Endpoint)
 }
 
-
-
 // AuthError intentionally does not carry the response body: 401/403 bodies
 // from wts-api / wts-cert-api can echo CSRF diagnostics or session-identifying
 // fragments, and no caller reads it — only status + endpoint are surfaced to

--- a/internal/client/marketdata_test.go
+++ b/internal/client/marketdata_test.go
@@ -11,10 +11,10 @@ func TestInvestModeFor(t *testing.T) {
 		code             string
 		wantView, wantIM string
 	}{
-		{"A005930", "krx_all", "krx"},   // KR stock
-		{"A114800", "krx_all", "krx"},   // KR ETF
+		{"A005930", "krx_all", "krx"},           // KR stock
+		{"A114800", "krx_all", "krx"},           // KR ETF
 		{"US20220809012", "unified", "unified"}, // US stock code
-		{"AAPL", "unified", "unified"},  // US ticker
+		{"AAPL", "unified", "unified"},          // US ticker
 	}
 	for _, c := range cases {
 		gv, gi := investModeFor(c.code)

--- a/internal/client/probe.go
+++ b/internal/client/probe.go
@@ -11,9 +11,9 @@ import (
 // ProbeResult captures a single endpoint-family health probe. Meant for
 // diagnostics (e.g. `tossctl doctor --report`) — not for production code paths.
 type ProbeResult struct {
-	Family     string        `json:"family"`               // wts-api | wts-cert-api | wts-info-api
-	Endpoint   string        `json:"endpoint"`             // URL path only (no host)
-	StatusCode int           `json:"status_code"`          // 0 if transport error
+	Family     string        `json:"family"`      // wts-api | wts-cert-api | wts-info-api
+	Endpoint   string        `json:"endpoint"`    // URL path only (no host)
+	StatusCode int           `json:"status_code"` // 0 if transport error
 	Duration   time.Duration `json:"duration_ns"`
 	Error      string        `json:"error,omitempty"`      // transport error only
 	AuthError  bool          `json:"auth_error,omitempty"` // 401/403 — session/UA problems

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -74,7 +74,7 @@ type UpdateCheck struct {
 // Credential secrets are stored in a separate file (see paths.CredentialsFile).
 type OpenAPI struct {
 	Enabled  bool   `json:"enabled"`
-	Prefer   string `json:"prefer"`   // auto | wts | openapi
+	Prefer   string `json:"prefer"` // auto | wts | openapi
 	Fallback bool   `json:"fallback"`
 }
 

--- a/internal/onboarding/onboarding.go
+++ b/internal/onboarding/onboarding.go
@@ -6,7 +6,7 @@ import "github.com/JungHoonGhae/tossinvest-cli/internal/i18n"
 
 // State represents the current authentication state of the user.
 type State struct {
-	HasSession      bool
+	HasSession       bool
 	HasOfficialCreds bool
 }
 


### PR DESCRIPTION
아키텍처 리뷰 작업 중 발견한 결함 정리.

## 문제

- `CLAUDE.md` 의 Build & Test 는 `make lint` 를 안내하는데 **Makefile 에 그 타겟이 없었다**.
- CI 는 `go test` · `go vet` · `make build` 만 돌고 **gofmt 를 전혀 검사하지 않았다**.
- 그 결과 미포맷 파일 6개가 main 에 방치.

## 변경

**`make lint`** — `gofmt -l` + `go vet` 으로만 구성. golangci-lint 는 미설치·미설정이라 새 의존성을 들이는 대신 이미 쓰던 두 도구를 묶었다. `gofmt -l` 은 파일을 바꾸지 않고 목록만 내므로, 조용히 리포맷하는 대신 어떤 파일이 문제인지 알려주며 실패한다:

```
$ make lint
gofmt: 아래 파일이 포맷되지 않았습니다 — `make fmt` 를 실행하세요:
  internal/client/errors.go
  ...
make: *** [lint] Error 1
```

**CI** — `go vet` 스텝을 `make lint` 로 교체. 로컬과 CI 가 같은 명령을 돌아 다시 어긋나지 않는다.

**미포맷 6개 파일 정리** — 전부 공백·주석 정렬 차이라 동작 변화 없음 (`internal/client/{chart_test,errors,marketdata_test,probe}.go`, `internal/config/service.go`, `internal/onboarding/onboarding.go`).

`CLAUDE.md` 는 손대지 않았다 — 문서가 이미 맞는 말을 하고 있었고, 이제 코드가 문서를 따라갔다.

## 검증

- 포맷 전 `make lint` 가 6개 파일을 지목하며 exit 1 (타겟이 실제로 잡아낸다는 확인)
- 포맷 후 `make lint` PASS, `make test` 전체 통과, `make build` OK

https://claude.ai/code/session_015CLrLGFKyKziG4mCjaTCmT