### PR TITLE
fix(config): EnabledActions·AnyMutationEnabled 에 conditional 반영

### DIFF
--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -48,6 +48,9 @@ func (t Trading) EnabledActions() []string {
 	if t.Amend {
 		enabled = append(enabled, "amend")
 	}
+	if t.Conditional {
+		enabled = append(enabled, "conditional")
+	}
 	return enabled
 }
 
@@ -62,8 +65,12 @@ func (d DangerousAutomation) EnabledActions() []string {
 // AnyMutationEnabled reports whether any order-mutation toggle is on.
 // Used to decide whether trading-mutation commands are useful
 // (vs. being a no-op because no action gate is open).
+//
+// Conditional counts: it gates live conditional-order place/cancel/modify
+// (cmd/tossctl/conditional_gate.go), so a config with only Conditional on still
+// has a live mutation path open.
 func (t Trading) AnyMutationEnabled() bool {
-	return t.Place || t.Cancel || t.Amend
+	return t.Place || t.Cancel || t.Amend || t.Conditional
 }
 
 type UpdateCheck struct {

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -176,6 +176,48 @@ func TestEnabledActionsExcludesSellWhenFalse(t *testing.T) {
 	}
 }
 
+// trading.conditional gates live conditional-order place/cancel/modify
+// (cmd/tossctl/conditional_gate.go). It must be reported like any other
+// mutation toggle: `tossctl doctor` and `tossctl config show` both derive their
+// "is trading locked down?" answer from these two helpers, so omitting
+// Conditional made them claim everything was disabled while conditional orders
+// could execute live.
+func TestEnabledActionsIncludesConditional(t *testing.T) {
+	trading := Trading{Conditional: true}
+	enabled := trading.EnabledActions()
+	found := false
+	for _, action := range enabled {
+		if action == "conditional" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected EnabledActions to include 'conditional', got %v", enabled)
+	}
+}
+
+func TestEnabledActionsExcludesConditionalWhenFalse(t *testing.T) {
+	trading := Trading{Place: true, Conditional: false}
+	for _, action := range trading.EnabledActions() {
+		if action == "conditional" {
+			t.Fatalf("expected EnabledActions to exclude 'conditional' when false, got %v", trading.EnabledActions())
+		}
+	}
+}
+
+func TestAnyMutationEnabledCountsConditional(t *testing.T) {
+	// Conditional alone is enough to mean "a mutation path is open".
+	trading := Trading{Conditional: true}
+	if !trading.AnyMutationEnabled() {
+		t.Fatal("expected AnyMutationEnabled to be true when only conditional is on")
+	}
+
+	if (Trading{}).AnyMutationEnabled() {
+		t.Fatal("expected AnyMutationEnabled to be false when every toggle is off")
+	}
+}
+
 func TestLoadFlagsKRAsLegacyField(t *testing.T) {
 	// trading.kr was removed in v0.5.2 — a config that still carries it must
 	// load fine (the value is ignored) and surface "trading.kr" as a legacy


### PR DESCRIPTION
2회차 아키텍처 리뷰에서 발견한 **안전 오보 버그**.

## 증상

`trading.conditional` 은 라이브 조건주문 place/cancel/modify 를 여는 **실제 게이트**다 (`cmd/tossctl/conditional_gate.go:20`). 그런데 `Trading.EnabledActions()` 와 `AnyMutationEnabled()` 가 이 필드를 세지 않아, 조건주문만 켠 config 에서 진단이 거짓을 말했다.

```json
{"trading": {"conditional": true, "allow_live_order_actions": true}}
```

바이너리로 확인한 실제 출력 (`tossctl doctor --config-dir <격리>`):

```
수정 전: [info] trading_config: config file exists, but all trading actions are disabled
                Edit config.json to explicitly allow the actions you want to use.

수정 후: [ok]   trading_config: one or more trading actions are enabled in config
                conditional
```

**왜 위험한가** — 거래가 잠겨 있는지 확인하려고 `tossctl doctor` 를 돌린 사용자가 "전부 비활성"을 보고 안심한다. 실제로는 조건주문이 라이브인데도. `tossctl config show` 도 같은 헬퍼를 쓴다 (`internal/output/config.go:85`).

## 수정

```go
// EnabledActions()
+ if t.Conditional { enabled = append(enabled, "conditional") }

// AnyMutationEnabled()
- return t.Place || t.Cancel || t.Amend
+ return t.Place || t.Cancel || t.Amend || t.Conditional
```

## 테스트

회귀 테스트 3개 추가. **수정 전에 red 인 것을 먼저 확인**했다:

```
--- FAIL: TestEnabledActionsIncludesConditional
    expected EnabledActions to include 'conditional', got []
--- FAIL: TestAnyMutationEnabledCountsConditional
    expected AnyMutationEnabled to be true when only conditional is on
```

`make test` 전체 통과, `make lint` 통과.

## 근본 원인 (별건)

안전 정책이 두 곳에 복제돼 있다 — 일반 주문은 `trading.Service.guard`, 조건주문은 cmd-private `conditionalGate`. 한쪽에만 `Conditional` 이 반영돼 이 버그가 생겼다. 게이트 통합은 **조건주문을 MCP 에 노출할 때** 하는 게 맞다고 판단해 별도 이슈로 남긴다 — 지금은 복제본이 2개라 통합 이득이 작고, 그때 안 하면 3개가 된다.

https://claude.ai/code/session_015CLrLGFKyKziG4mCjaTCmT