### PR TITLE
refactor(official): 토큰/401-재시도 흐름을 send() 하나로 통합

### DIFF
--- a/internal/official/client.go
+++ b/internal/official/client.go
@@ -173,22 +173,18 @@ func (c *Client) postAcct(ctx context.Context, path string, body any, out any) e
 }
 
 // deleteAcct performs an authenticated DELETE with the account header, mirroring
-// getWithHeaders' token/401-retry/unwrap flow (there is no generic doWithHeaders).
-func (c *Client) deleteAcct(ctx context.Context, path string, out any) error {
-	seq, err := c.ensureAccountSeq(ctx)
-	if err != nil {
-		return err
-	}
-	rawURL := c.base + path
-	makeReq := func(tok string) (*http.Request, error) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodDelete, rawURL, nil)
-		if err != nil {
-			return nil, fmt.Errorf("%w: %s", ErrTransport, err)
-		}
-		req.Header.Set("Authorization", "Bearer "+tok)
-		req.Header.Set("X-Tossinvest-Account", strconv.Itoa(seq))
-		return req, nil
-	}
+// send runs the authenticated-request flow every verb shares: acquire a token,
+// build the request, retry ONCE with a refreshed token on 401, classify non-2xx,
+// and unwrap the `result` envelope into out (out may be nil).
+//
+// Callers supply makeReq because that is the only part that differs between
+// verbs — method, body, query, and per-request headers. Keeping the retry here
+// means the auth policy is decided in one place; it used to be hand-repeated in
+// getWithHeaders, postWithHeaders and deleteAcct, where it could silently drift.
+//
+// makeReq must be callable twice: the retry rebuilds the request so the new
+// token is applied (and so a consumed body reader is not reused).
+func (c *Client) send(ctx context.Context, makeReq func(tok string) (*http.Request, error), out any) error {
 	tok, err := c.tm.token(ctx)
 	if err != nil {
 		return err
@@ -202,6 +198,7 @@ func (c *Client) deleteAcct(ctx context.Context, path string, out any) error {
 		return err
 	}
 	if code == http.StatusUnauthorized {
+		// Force-refresh the token and retry once.
 		tok, err = c.tm.refresh(ctx)
 		if err != nil {
 			return err
@@ -219,6 +216,25 @@ func (c *Client) deleteAcct(ctx context.Context, path string, out any) error {
 		return classifyStatus(code, body)
 	}
 	return unwrapAndDecode(body, out)
+}
+
+// getWithHeaders' token/401-retry/unwrap flow.
+func (c *Client) deleteAcct(ctx context.Context, path string, out any) error {
+	seq, err := c.ensureAccountSeq(ctx)
+	if err != nil {
+		return err
+	}
+	rawURL := c.base + path
+	makeReq := func(tok string) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodDelete, rawURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrTransport, err)
+		}
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("X-Tossinvest-Account", strconv.Itoa(seq))
+		return req, nil
+	}
+	return c.send(ctx, makeReq, out)
 }
 
 // getWithHeaders performs an authenticated GET request to path (relative to
@@ -244,42 +260,7 @@ func (c *Client) getWithHeaders(ctx context.Context, path string, q url.Values, 
 		return req, nil
 	}
 
-	tok, err := c.tm.token(ctx)
-	if err != nil {
-		return err
-	}
-
-	req, err := makeReq(tok)
-	if err != nil {
-		return err
-	}
-
-	code, body, err := c.doRequest(req)
-	if err != nil {
-		return err
-	}
-
-	if code == http.StatusUnauthorized {
-		// Force-refresh the token and retry once.
-		tok, err = c.tm.refresh(ctx)
-		if err != nil {
-			return err
-		}
-		req, err = makeReq(tok)
-		if err != nil {
-			return err
-		}
-		code, body, err = c.doRequest(req)
-		if err != nil {
-			return err
-		}
-	}
-
-	if code < 200 || code >= 300 {
-		return classifyStatus(code, body)
-	}
-
-	return unwrapAndDecode(body, out)
+	return c.send(ctx, makeReq, out)
 }
 
 // post performs an authenticated POST request to path (relative to BaseURL).
@@ -317,39 +298,5 @@ func (c *Client) postWithHeaders(ctx context.Context, path string, body any, ext
 		return req, nil
 	}
 
-	tok, err := c.tm.token(ctx)
-	if err != nil {
-		return err
-	}
-
-	req, err := makeReq(tok)
-	if err != nil {
-		return err
-	}
-
-	code, respBody, doErr := c.doRequest(req)
-	if doErr != nil {
-		return doErr
-	}
-
-	if code == http.StatusUnauthorized {
-		tok, err = c.tm.refresh(ctx)
-		if err != nil {
-			return err
-		}
-		req, err = makeReq(tok)
-		if err != nil {
-			return err
-		}
-		code, respBody, doErr = c.doRequest(req)
-		if doErr != nil {
-			return doErr
-		}
-	}
-
-	if code < 200 || code >= 300 {
-		return classifyStatus(code, respBody)
-	}
-
-	return unwrapAndDecode(respBody, out)
+	return c.send(ctx, makeReq, out)
 }

--- a/internal/official/client_test.go
+++ b/internal/official/client_test.go
@@ -161,3 +161,57 @@ func TestGetNon2xxReturnsClassifiedError(t *testing.T) {
 		t.Fatalf("expected ShouldFallback=true for server error, got false; err=%v", err)
 	}
 }
+
+// TestDeleteAcctRetriesOn401 locks the DELETE leg of the shared send() flow.
+// Before send() existed each verb hand-rolled its own token/401-retry loop and
+// only the GET one was covered, so a divergence in the DELETE loop would have
+// gone unnoticed. It also asserts the account header still rides along, since
+// that is the part deleteAcct adds on top of send().
+func TestDeleteAcctRetriesOn401(t *testing.T) {
+	var calls int
+	var gotAccount string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth2/token":
+			_, _ = w.Write([]byte(`{"access_token":"AT","expires_in":3600,"token_type":"Bearer"}`))
+		case "/api/v1/accounts":
+			_, _ = w.Write([]byte(`{"result":{"accounts":[{"accountNo":"1","accountSeq":7}]}}`))
+		case "/api/v1/orders/abc":
+			if r.Method != http.MethodDelete {
+				t.Errorf("method = %q, want DELETE", r.Method)
+			}
+			calls++
+			if calls == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			gotAccount = r.Header.Get("X-Tossinvest-Account")
+			if r.Header.Get("Authorization") != "Bearer AT" {
+				t.Errorf("Authorization = %q", r.Header.Get("Authorization"))
+			}
+			_, _ = w.Write([]byte(`{"result":{"cancelled":true}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := New(Credentials{APIKey: "k", SecretKey: "s"}, filepath.Join(t.TempDir(), "t.json"),
+		WithBaseURL(srv.URL), WithHTTPClient(srv.Client()), WithAccountSeq(7))
+
+	var out struct {
+		Cancelled bool `json:"cancelled"`
+	}
+	if err := c.deleteAcct(context.Background(), "/api/v1/orders/abc", &out); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected one retry after 401, calls=%d", calls)
+	}
+	if !out.Cancelled {
+		t.Fatal("envelope not unwrapped")
+	}
+	if gotAccount != "7" {
+		t.Fatalf("X-Tossinvest-Account = %q, want 7", gotAccount)
+	}
+}


### PR DESCRIPTION
2회차 아키텍처 리뷰 후보 2.

## 문제

`getWithHeaders` · `postWithHeaders` · `deleteAcct` 가 **동일한 흐름을 각자 손으로 반복**하고 있었다:

> 토큰 획득 → 요청 생성 → `doRequest` → **401 이면 갱신 후 1회 재시도** → non-2xx 분류 → `result` 봉투 해제

코드 주석이 스스로 인정하고 있었다 (`client.go:176`):

```go
// deleteAcct performs an authenticated DELETE with the account header, mirroring
// getWithHeaders' token/401-retry/unwrap flow (there is no generic doWithHeaders).
```

**401 재시도는 인증 정책**이라 세 곳으로 갈라지면 조용히 틀어진다. PUT/PATCH 가 필요해지면 네 번째 복제본이 생길 자리였다.

## 변경

세 함수의 차이는 `makeReq`(메서드·바디·쿼리·헤더)뿐이라, **그 클로저를 받는 `send()` 로 꼬리만 추출**했다:

```go
func (c *Client) send(ctx context.Context, makeReq func(tok string) (*http.Request, error), out any) error
```

요청 조립은 각 함수에 그대로 남겨 호출부 가독성을 유지한다. 진입점 5개(`get`/`getAcct`/`post`/`postAcct`/`deleteAcct`)의 시그니처는 그대로.

`c.doRequest` 호출 지점: **6곳 → 2곳**(둘 다 `send` 내부).

## 테스트 — 공백 하나를 메웠다

**DELETE 의 401 재시도는 그동안 무테스트였다** (GET 경로만 잠겨 있었음). `TestDeleteAcctRetriesOn401` 추가 — 재시도 횟수·봉투 해제·`X-Tossinvest-Account` 헤더를 함께 확인.

실효성 확인: `send` 에서 재시도 분기를 무력화하면 **GET·DELETE 테스트가 모두 실패**한다. 즉 이제 하나의 seam 을 통해 두 경로가 함께 잠긴다.

`make test` 전체 통과, `make lint` 통과. **동작 변화 없음**, net **-53 lines**.

https://claude.ai/code/session_015CLrLGFKyKziG4mCjaTCmT