### PR TITLE
feat(tools): 첫 로드 POST 바디 캡처 도구 — RE 워크플로의 막힌 단계 해소

### DIFF
--- a/docs/research/2026-07-25-unbrowse.md
+++ b/docs/research/2026-07-25-unbrowse.md
@@ -1,0 +1,209 @@
+# unbrowse 조사 (1차 자료 기반)
+
+조사일: 2026-07-25 · 대상: <https://github.com/unbrowse-ai/unbrowse> (v11.2.0, MIT)
+근거는 전부 레포 원문 / npm 배포 아티팩트 / GitHub API 에서 직접 확인. 블로그·요약글 미사용.
+
+## 요약
+
+unbrowse 는 "브라우저 대신 사이트의 내부(shadow) API 를 재사용하자"는 에이전트용 액션 레이어다.
+실제 브라우저를 한 번 몰아 트래픽을 HAR 로 캡처 → 재사용 가능한 route contract 로 만들고,
+다음부터는 브라우저 없이 그 요청을 직접 replay 한다. CLI + MCP + TS SDK + Agent Skill 형태이고
+런타임은 Node/Bun 번들 + Zig 브로커(`kuri`) + Go `utls-proxy` 프리빌트 바이너리(npm tarball 38MB,
+설치 후 vendor 만 94MB)다. 문제 정의 자체는 우리 RE 워크플로와 정확히 같은 자리에 있지만,
+**우리가 이미 해결한 단계(번들에서 경로 추출 → 카탈로그)를 훨씬 무겁게 다시 하고,
+정작 우리가 막혀 있는 단계(SPA 첫 로드 POST 바디 캡처)는 저쪽도 미해결 오픈 이슈다.**
+게다가 resolve/execute 는 호스티드 서비스 + API 키 + credit 과금이 걸려 있고,
+증권 계좌 세션이 들어 있는 브라우저를 서드파티 22MB 번들과 네이티브 바이너리가 운전하게 된다.
+
+## 결론 / 권고
+
+**불필요 (도입하지 않음).** 이득이 있는 단계는 "브라우저 캡처" 하나뿐인데 그 부분이
+unbrowse 에서 가장 불안정한 영역(미해결 epic #108, kuri SIGSEGV #105/#69, SPA/서비스워커 캡처 미완 #62/#98)이고,
+비용은 Node 22.5+ 런타임 + 132MB 프리빌트 바이너리 + 호스티드 API 키/크레딧 + 증권 세션 노출이다.
+Go 단일 바이너리 + stdlib-only Python 스크립트로 굴러가는 현 구조에 맞지 않는다.
+
+한 줄 예외: 언젠가 "SPA 첫 로드 POST 바디"만 잡으면 되는 상황이 다시 오면,
+unbrowse 를 도입하는 게 아니라 **그 아이디어(관리형 Chrome 을 처음부터 CDP 네트워크 인터셉트 하에 띄우기)만
+`/browse` 쪽에서 재현**하면 된다. 아래 "관련성" 절 참고.
+
+---
+
+## 1. 정확히 무엇인가
+
+- 한 문장: "사이트의 first-party API 라우트를 실제 브라우징에서 학습해, 이후에는 브라우저를 몰지 않고
+  그 라우트를 직접 replay 하는 에이전트용 액션 레이어."
+  (`README.md` 3–5행: "Unbrowse is the action layer for AI agents. It learns a site's first-party API
+  routes from real browsing, then replays known routes directly instead of driving a browser for every task.")
+- 형태: 전부 다. CLI(`unbrowse`), Agent Skill(`SKILL.md`), MCP 서버(`unbrowse setup --mcp`), TypeScript SDK
+  (`unbrowse/sdk`) — "same runtime underneath" (`SKILL.md` "Surfaces" 표).
+- 언어/런타임: TypeScript (GitHub `language: "TypeScript"`). 배포 런타임은 Bun 번들이지만 실행은 Node ≥ 22.5
+  (`node:sqlite` 필요) — npm `package/bin/unbrowse.js` 상단 주석.
+  네이티브 의존: `vendor/kuri/*`(Zig 로 작성된 CDP/HAR 브로커, issue #69 "bridge.zig"), `vendor/utls-proxy/*`(Go, TLS fingerprint).
+- 문제 정의: `docs/concepts/shadow-apis.md` — "Every website an agent visits is already an API; the browser is just the client."
+- 자체 논문: [arXiv:2604.00694](https://arxiv.org/abs/2604.00694) "Internal APIs Are All You Need"
+  (Tham, Mac Gregor Garcia, Hahn, 2026-04-01). **주의**: `SKILL.md` 는 이를 "peer-reviewed" 라고 표현하는데
+  arXiv 프리프린트는 peer review 가 아니다. 벤치마크(94 도메인, 3.6× mean / 5.4× median vs Playwright)는
+  저자 자체 측정이다 (`README.md`, `docs/benchmarks.md`).
+
+## 2. 어떻게 동작하나
+
+- 3단 하강: 로컬 route 캐시 → 호스티드 shared route graph → 브라우저 캡처.
+  (`docs/architecture/OVERVIEW.md` 의 request lifecycle 다이어그램; `SKILL.md` "local skill cache (<200ms),
+  then the shared route graph (sub-second), then one browser capture for a new site")
+- 캡처: 실제 Chrome/Chromium 을 CDP 로 몰고(`kuri` 브로커), 그때 발생한 네트워크를 HAR 로 수동적으로 인덱싱.
+  브라우저는 "로그인/동의/CAPTCHA/UI-only" 용으로만 남긴다 (`docs/for-agents/when-it-uses-a-browser.md`).
+  Chrome 설치가 전제 (`SKILL.md`: "Browser-backed commands (`fetch`, `go`, `capture`, `auth`) need Chrome/Chromium installed").
+- Replay: 캡처된 요청 shape(호스트/메서드/URL 템플릿/파라미터)을 저장했다가 HTTP 로 직접 호출.
+- 인증 세션: **브라우저 프로필 재사용 + 로컬 보관** 방식. `unbrowse auth <login_url>` 로 사이트 정상 로그인 플로우를
+  로컬 브라우저에서 완료하고, 세션 자료는 로컬에 남아 매칭되는 사이트 요청에만 주입된다
+  (`docs/architecture/AUTH.md` "Site authentication"). 로컬 상태는 `~/.unbrowse/profiles/`, `~/.unbrowse/vault/`
+  (`docs/architecture/CLI.md` "Local state"). 우리처럼 외부에서 쿠키를 주입하는 공식 경로는 문서에서 **확인 못 함**.
+- 공유 경계: 쿠키/베어러/인증된 응답 바디는 로컬, 퍼블리시되는 건 sanitized route shape 뿐이며
+  "explicit publish checkpoint" 에서만 나간다 (`docs/architecture/PRIVACY.md`).
+- 옵트인 residential proxy: `UNBROWSE_KURI_PROXY=auto` + IPRoyal 자격증명이면 관리형 Chrome/HTTP 전송이
+  전부 residential proxy 를 탄다. **기본 off** (`docs/public/primitives/02-residential-proxy-fallback.md`).
+- 백엔드 호출처: 번들에 `https://beta-api.unbrowse.ai` 문자열 21회
+  (npm `package/runtime/cli.js` grep).
+
+## 3. 성숙도
+
+| 항목 | 값 | 출처 |
+|---|---|---|
+| 공개 레포 첫 커밋 | 2026-05-31 ("Public preview — open-core surface") | `git log --reverse` |
+| GitHub 레포 생성 | 2026-01-27 / npm 최초 배포 2026-02-19 | `gh api repos/...` `created_at`, `npm view time.created` |
+| 최근 커밋 | 2026-07-24 (v11.2.0 docs sync) | `git log -1` |
+| Stars / forks | 732 / 63 | `gh api repos/...` |
+| 릴리즈 | 30개 태그, 최신 v11.2.0 (2026-07-24). 릴리즈 주기 매우 빠름(7/20 하루 3회) | `gh release list` |
+| 컨트리뷰터 | 3명 (lekt9 13, getfoundry-app 6, mseep-ai 1) — 사실상 1인 | `gh api .../contributors` |
+| 공개 커밋 수 | 48개, 대부분 "docs: sync public surface for vX" | `git log` |
+| 오픈 이슈 | 27개 | `gh issue list` |
+| 테스트 | 공개 레포에는 어댑터 shape 테스트만 (`packages/*/test/shape.test.ts`). 런타임 테스트 없음(소스가 없으므로) | `git ls-files` |
+
+**중요**: 공개 레포에 CLI/런타임 **소스가 없다**. 224개 파일 중 TS/JS 48개가 전부 어댑터 shim
+(`axios-shim`, `py-requests`, `langchain-js` 등 27종)과 `extraction-core`, 나머지는 docs.
+실제 런타임은 npm 에 **빌드 산출물**(`runtime/cli.js`, 22MB unminified Bun 번들)로만 배포된다.
+`docs/OPEN-SOURCE-NOTICE.md` 는 "The Unbrowse client boundary is MIT licensed and auditable in this
+repository" 라고 쓰지만, 실제로 감사 대상은 npm 의 번들이지 레포의 소스가 아니다
+(`package/bin/unbrowse.js` 주석이 "The source IS the runtime" 라고 이 점을 인정). 호스티드 route graph /
+ranking / credit ledger / 웹앱은 비공개 운영 서비스.
+
+오픈 이슈 성격 (실제 결함 위주, 자기 홍보성 아님):
+- #108 epic: capture pipeline reliability (#62 #98 #50 #74 #52 통합) — **캡처가 아직 신뢰 구간이 아님**
+- #105 / #69: kuri SIGSEGV during HAR flush / HAR 0 entries (bridge.zig 버그)
+- #62: 서비스워커 캐시가 네트워크 인터셉션 우회 (SPA)
+- #98: SPA lazy-load API 호출 대기 미구현
+- #123: v8.1.1 macOS x64 에서 kuri 바이너리가 placeholder stub 이라 동작 안 함 + `runtime/mcp.js` 누락
+- #127 (2026-07-22): `setup` 이 `"server": {"started": true, ...:6969}` 라고 보고하는데 실제로 아무것도 listen 안 함
+- #76 / #52: Windows 기동 실패
+
+판정: **실험/초기 프로덕트**. 버전 번호(v11)는 성숙도가 아니라 릴리즈 속도의 결과다.
+
+## 4. 라이선스
+
+- SPDX: **MIT** (`LICENSE`, "Copyright (c) 2025 Unbrowse AI"; `gh api` `license.spdx_id: "MIT"`).
+- 상업적 사용 제약 없음 — 단, MIT 가 덮는 건 클라이언트 경계뿐. route graph/ranking/credit 은 운영 서비스이며
+  이용에는 계정·API 키·크레딧이 걸린다 (`docs/OPEN-SOURCE-NOTICE.md`, `docs/for-agents/credits.md`).
+- npm 패키지의 `LICENSE` 는 36KB (번들 의존성 라이선스 합본).
+
+## 5. 의존성 · 설치 · 비용
+
+- 설치: `npm install -g unbrowse@11.2.0` + `unbrowse setup`. tarball 38MB, 해제 후
+  `runtime/` 22MB + `vendor/` 94MB (프리빌트 `kuri` 5플랫폼, `utls-proxy` 4플랫폼). Chrome/Chromium 별도 필요.
+- 런타임 요구: Node ≥ 22.5 (`node:sqlite`).
+- npm 선언 의존성은 가벼움(fastify, cheerio, ws, nanoid, bs58, dotenv, keytar optional) — 무거운 건 vendored 바이너리.
+- 외부 서비스: **필요.** `ubr_` API 키 = 계정 필수, "Metered executions deduct credits",
+  잔액 부족 시 HTTP 402 (`docs/architecture/AUTH.md`, `docs/for-agents/credits.md`).
+  resolve/search 는 "free 또는 metered — 서비스가 정한다"로만 적혀 있어 **정확한 단가·무료 한도는 레포 문서에서 확인 못 함.**
+- 텔레메트리: 설치 비콘은 **기본 OFF**, `UNBROWSE_TELEMETRY=1` 일 때만 전송 (`scripts/postinstall-ping.mjs` 소스 확인).
+
+---
+
+## 우리 프로젝트와의 관련성
+
+### 캡처 워크플로(`docs/reverse-engineering/capture-workflow.md`) 를 대체/개선하나?
+
+단계별로:
+
+| 우리 단계 | unbrowse 로 개선되나 | 근거 |
+|---|---|---|
+| 0. 세션 주입 (`session.json` 쿠키 → 브라우저) | **아니오.** unbrowse 는 `unbrowse auth <login_url>` 로 자기 프로필에 로그인하는 모델. 외부 쿠키를 주입하는 공개 경로 미확인. 토스는 앱 인증 플로우라 별도 로그인 UX 를 하나 더 얹는 셈 | `docs/architecture/AUTH.md` |
+| 1. 후보 발굴 (JS 번들에서 `/api/vN/...` 추출) | **아니오, 오히려 후퇴.** 우리는 `tools/wts_endpoints.py`(stdlib only, CI 무의존)가 buildId→`_buildManifest.js`→청크 전부 파싱해 전수 카탈로그를 만든다. unbrowse 는 "실제로 발생한 요청"만 학습하므로 **호출되지 않은 엔드포인트는 영원히 안 보인다.** 전수성이 정반대 | `tools/wts_endpoints.py` docstring vs `docs/concepts/shadow-apis.md` |
+| 2. 라이브 프로브 (Promise.all + 타임아웃 fetch) | **아니오.** 지금도 `/browse` 한 번으로 18개 병렬 프로브가 된다. unbrowse 의 resolve/execute 는 여기에 API 키·크레딧·랭킹 서비스를 끼워 넣을 뿐 | `capture-workflow.md` §2 |
+| 3. **POST 바디 알아내기** | **여기만 가능성 있음, 그러나 미검증.** 우리가 막힌 이유는 (a) `/browse` 의 goto 가 세션을 재생성해 `addInitScript` 가 안 붙고 (b) React Query 캐시 때문에 재요청이 안 뜨는 것. unbrowse 는 `kuri` 가 **관리형 Chrome 을 처음부터 직접 띄워** CDP 로 붙고 HAR 로 수동 기록하므로 첫 로드 요청을 놓치지 않을 구조다. 다만 정확히 이 영역이 미해결 epic — 서비스워커 우회(#62), SPA lazy-load 미대기(#98), HAR flush SIGSEGV / 0 entries(#105, #69) | `capture-workflow.md` "막힌 방법" vs issues #62/#98/#105/#69/#108 |
+| 4. 웹 UI 유무 판정 (모바일 전용 분류) | **아니오.** 라우트 열어서 화면 뜨는지 보는 판정 — `/browse` goto 로 이미 충분 | `capture-workflow.md` §4 |
+| 5. 구현 (Go domain/client/output/ops) | **무관** | — |
+
+정리: **3번 한 칸**만 이론적 이득이 있고, 그마저도 저쪽이 아직 못 고친 부분이다.
+그리고 그 이득의 본질은 unbrowse 제품이 아니라 "goto 로 세션 재생성하지 말고, CDP 로 Chrome 을 직접 띄운 뒤
+`Network.enable` 상태에서 첫 내비게이션을 하라"는 **한 줄짜리 아이디어**다.
+`capture-workflow.md` 도 이미 "순수 CDP 세션이면 될 수 있음"이라고 같은 결론을 적어 뒀다.
+132MB 런타임을 들이는 대신 그 경로를 직접 시도하는 게 훨씬 싸다.
+
+추가로 **증권 계좌 세션이라는 점**을 따로 봐야 한다. 라이브 캡처 시 실계좌 세션이 들어 있는 브라우저를
+서드파티 22MB 번들 + Zig/Go 프리빌트 바이너리가 운전하게 된다.
+
+다만 이 리스크는 **문서상으로는 상당 부분 방어되어 있다** — 과장하지 않고 적어 둔다:
+
+- 퍼블리시는 자동이 아니다. `captured → indexed → published` 라이프사이클이 있고
+  "Publishing to the shared graph is **not automatic**", "`publish` - re-index locally, then explicitly
+  share/publish" (`SKILL.md`).
+- 라우트는 sanitize 된다 — "Captured routes are sanitized (pointer-not-payload) and credential fields are
+  never persisted in the route" (`SKILL.md`).
+- 끄는 스위치도 있다 — `unbrowse settings --auto-publish off` (`SKILL.md`).
+
+그래서 남는 실제 우려는 두 가지로 좁혀진다:
+
+1. **`--auto-publish off` 라는 설정이 존재한다는 것은 auto-publish 모드가 있다는 뜻인데, 그 기본값을
+   레포 문서에서 찾지 못했다** (`docs/architecture/CLI.md` 에 언급 없음). 기본이 on 이면 "명시적 퍼블리시"
+   서술과 어긋난다. **확인 못 함.**
+2. 크레딧이 재사용을 **보상**하는 구조라(`docs/for-agents/credits.md`: "Contributors can earn credits when
+   maintained routes are reused") 라우트를 공유할 유인이 제품에 내장돼 있다.
+
+정리하면 이건 "명백한 유출 위험"이 아니라 **미확인 기본값 + 공유 유인**이다. 그 자체로 도입을 막을
+근거는 아니고, 도입 이득이 위 표의 "3번 한 칸"뿐이라 **굳이 이 불확실성을 떠안을 이유가 없다**는 쪽이
+정확한 판단이다. (CLAUDE.md 의 "공개 출력에 실계좌 데이터 금지" 원칙과도 확인 부담이 생긴다.)
+
+### 주간 엔드포인트 카탈로그(`wts_endpoints.py`)에 쓸 만한가?
+
+**아니오.** 이유 셋:
+
+1. **전수성이 반대다.** `wts_endpoints.py` 는 프로덕션 번들 전체를 파싱해 *호출되지 않은* 엔드포인트까지
+   candidate 로 잡는 게 존재 이유다. unbrowse 는 실제 발생 트래픽 기반이라 candidate 발굴을 못 한다.
+2. **CI 제약.** 현 스크립트는 stdlib only + 인증 불필요라 `wts-monitor.yml` 이 무자격증명으로 돈다.
+   unbrowse 를 넣으면 Node 22.5 + 132MB 바이너리 + Chrome + `UNBROWSE_API_KEY` 시크릿 + 크레딧 잔액이
+   주간 워크플로의 의존성이 된다. 크레딧 소진 = 모니터 침묵.
+3. **출력 형태 불일치.** 우리는 `{implemented, excluded, candidate}` 3분류 JSON 카탈로그가 필요한데,
+   unbrowse 는 intent→route 랭킹이 목적이다. 분류는 우리 코드가 여전히 해야 한다.
+
+### 도입 비용 vs 이득
+
+- 비용: Go 단일 바이너리 프로젝트에 Node 22.5 런타임 + npm 글로벌 설치 + 프리빌트 네이티브 바이너리 +
+  외부 계정/API 키/크레딧 + 증권 세션 노출. 이질성 최대치.
+- 이득: 라이브 캡처 1단계에서 "혹시" 첫 로드 POST 바디가 잡힐 가능성. 그마저 업스트림 미해결.
+- ponytail 사다리 1번에서 걸린다: 이 의존성은 존재할 필요가 없다.
+
+### 그래도 가져올 만한 것 (코드 아님, 아이디어)
+
+1. **CDP 로 Chrome 을 직접 띄우고 `Network.enable` 하에 첫 내비게이션** — `capture-workflow.md` "막힌 방법"의
+   미검증 가설과 동일. 필요해지면 `/browse` 밖에서 순수 CDP 로 20줄 스크립트 시도.
+2. `capture-workflow.md` §4 의 TODO("웹 UI 유무 판정을 주간 모니터가 추적")는 unbrowse 와 무관하게
+   그냥 `wts-monitor.yml` 에 라우트 HEAD/리다이렉트 체크를 붙이면 된다.
+
+---
+
+## 확인 못 한 것
+
+- **`--auto-publish` 의 기본값**: `SKILL.md` 에 `unbrowse settings --auto-publish off` 라는 스위치가 있다는 건
+  auto-publish 모드가 존재한다는 뜻인데, 기본이 on 인지 off 인지 레포 문서(`docs/architecture/CLI.md` 포함)에서
+  찾지 못했다. 같은 문서가 "Publishing to the shared graph is not automatic" 이라고도 말하고 있어 서술이 상충한다.
+  **도입을 검토한다면 여기부터 확인해야 한다.**
+- **크레딧 단가 / 무료 한도**: 레포 문서는 "free 또는 metered — 서비스가 정한다" 수준. 가격표는 레포에 없음.
+  (unbrowse.ai 웹사이트는 1차 자료이긴 하나 이번 조사에서 열지 않음.)
+- **외부 쿠키 주입 경로**: `tossctl session.json` 같은 외부 쿠키를 unbrowse 프로필에 주입하는 문서화된 방법을
+  찾지 못함. 번들 내부에 미문서화 플래그가 있을 수는 있음.
+- **실제 동작 검증**: 설치·실행하지 않았다. 위 성능/캡처 서술은 전부 레포 문서·번들 정적 확인·이슈 기반이며,
+  `wts-api.tossinvest.com` 에 대해 실제로 라우트를 잡아내는지는 미검증.
+- **런타임 소스의 실제 동작**: 22MB 번들을 전수 감사하지 않았다. 호스트 문자열·telemetry 스크립트·
+  proxy 문서 수준까지만 확인.
+- **벤치마크 재현**: 3.6×/5.4× 수치는 저자 자체 측정이며 독립 검증 자료를 찾지 않았다.
+- **레포에 없는 CI**: `.github/workflows` 2개 디렉터리만 확인했고 릴리즈 파이프라인 검증은 안 했다.

--- a/docs/reverse-engineering/capture-workflow.md
+++ b/docs/reverse-engineering/capture-workflow.md
@@ -275,14 +275,26 @@ JS 주입(addInitScript)도, fetch 몽키패치도 필요 없다.
 tossctl auth status          # Live Check: valid 여야 함. 아니면 tossctl auth login
 node tools/capture_post_bodies.mjs /account/profit
 node tools/capture_post_bodies.mjs /account/profit --wait 10   # 느린 화면
+node tools/capture_post_bodies.mjs /account/profit --all       # 텔레메트리까지
 ```
 
-출력은 **값이 마스킹된 형태**다 — 구현에 필요한 건 키와 타입이지 실계좌 값이 아니다:
+출력은 **값이 마스킹된 형태**다 — 구현에 필요한 건 키와 타입이지 실계좌 값이 아니다.
+`/account/profit` 실측(2026-07-25), 텔레메트리 제외 14건 중 일부:
 
 ```
-── POST /api/v3/orders/search
-{ "accountNo": "<string>", "page": "<number>", "size": "<number>" }
+── POST /api/v3/profit/readable-tab
+{ "rangeType": "<string>", "startDate": "<string>", "endDate": "<string>" }
+
+── POST /api/v1/profit/wts/daily/market
+{ "currency": "<string>", "startDate": "<string>", "endDate": "<string>",
+  "page": "<number>", "size": "<number>" }
+
+── POST /api/v1/dashboard/intelligences/all  (×2)
+{ "types": ["<string>", "…(1개)"], "variable": { "isBrowserPushEnabled": "<boolean>" } }
 ```
+
+`log/bulk`·`perf-log`·`tuba/*`·`wts-login-device` 는 텔레메트리라 기본 제외된다
+(출력의 절반을 차지한다). 필요하면 `--all`.
 
 원본이 꼭 필요하면 `--raw` 를 쓰되 **그 출력은 커밋·PR·이슈에 남기지 말 것**
 (CLAUDE.md "공개 출력·테스트·문서에 실제 계좌 데이터 금지").

--- a/docs/reverse-engineering/capture-workflow.md
+++ b/docs/reverse-engineering/capture-workflow.md
@@ -225,7 +225,8 @@ profit 계열처럼 POST 이고 파라미터가 필요하면:
    URL에 페이지 쿼리스트링(`?productType=us&profitType=sales`)이 들어 있어 **필드명
    단서**가 된다 (단, 쿼리 파라미터명 ≠ POST 바디 필드명일 수 있음 — 확인 필요).
 3. **빈 바디 `{}` 부터** — overview 류는 빈 바디로 전체를 주는 경우가 많다.
-4. 안 되면 **실제 웹 요청 바디를 봐야 한다** (아래 "막힌 방법" 참고).
+4. 안 되면 **실제 웹 요청 바디를 잡는다** — `node tools/capture_post_bodies.mjs <경로>`.
+   아래 "첫 로드 POST 바디 캡처" 참고. (예전엔 여기가 막혀 있었다.)
 
 ### 4. 웹 UI 유무 판정 = "모바일 전용" 분류의 유일한 기준
 
@@ -254,9 +255,47 @@ domain → client(`getJSON`/`postJSON`, 페이징은 aggregate) → output(테�
   루팅 없이는 APK 재패키징이 유일한데 Play Integrity 로 로그인 거부됨. **불가.**
 - **iOS 앱 캡처**: 인증서 신뢰가 안드로이드보다 쉽고 핀닝도 앱마다 달라 **성공 가능성
   있음** — 필요하면 iOS 기기로 시도.
-- **`/browse` addInitScript 로 SPA 첫 요청 바디 잡기**: `Page.addScriptToEvaluate
-  OnNewDocument` 를 CDP allowlist 에 추가했으나(로컬 빌드), browse 의 goto 가 세션을
-  재생성해 심은 스크립트가 안 따라감 → 이 흐름엔 안 통함. 순수 CDP 세션이면 될 수 있음.
-- **React Query 캐시**: 탭 클릭·pushState 로는 재요청이 안 걸린다(캐시). fresh POST
-  바디를 잡으려면 첫 로드를 가로채야 하는데 위 addInitScript 한계와 맞물림.
+- ~~**`/browse` addInitScript 로 SPA 첫 요청 바디 잡기**~~ / ~~**React Query 캐시**~~
+  → **해결됨 (2026-07-25).** 아래 "첫 로드 POST 바디 캡처" 참고.
 
+  기록용 경위: `Page.addScriptToEvaluateOnNewDocument` 를 CDP allowlist 에 추가했으나
+  (로컬 빌드) browse 의 goto 가 세션을 재생성해 심은 스크립트가 안 따라갔고, React Query
+  캐시 탓에 탭 클릭·pushState 로는 재요청도 안 걸렸다. **두 막힘의 원인은 하나였다 —
+  브라우저를 우리가 소유하지 않았다는 것.** 컨텍스트를 직접 만들면 JS 주입 자체가
+  불필요하고(Network 도메인이 postData 를 그대로 준다), 신선한 프로필이라 캐시도 없다.
+
+
+### 첫 로드 POST 바디 캡처 (`tools/capture_post_bodies.mjs`)
+
+웹 UI 에만 있는 기능의 POST 바디는 라이브 요청을 봐야 안다. 브라우저 컨텍스트를 직접
+소유하고 **내비게이션 전에** `Network.enable` 을 켜면 첫 로드 요청이 통째로 잡힌다.
+JS 주입(addInitScript)도, fetch 몽키패치도 필요 없다.
+
+```bash
+tossctl auth status          # Live Check: valid 여야 함. 아니면 tossctl auth login
+node tools/capture_post_bodies.mjs /account/profit
+node tools/capture_post_bodies.mjs /account/profit --wait 10   # 느린 화면
+```
+
+출력은 **값이 마스킹된 형태**다 — 구현에 필요한 건 키와 타입이지 실계좌 값이 아니다:
+
+```
+── POST /api/v3/orders/search
+{ "accountNo": "<string>", "page": "<number>", "size": "<number>" }
+```
+
+원본이 꼭 필요하면 `--raw` 를 쓰되 **그 출력은 커밋·PR·이슈에 남기지 말 것**
+(CLAUDE.md "공개 출력·테스트·문서에 실제 계좌 데이터 금지").
+
+동작 요약 — 스크립트가 하는 일:
+
+1. Playwright 캐시의 **Chrome for Testing** 을 임시 프로필로 기동
+   (사용자의 실제 Chrome 프로필/기본 브라우저를 건드리지 않는다)
+2. `Network.enable` → `Network.setCookies`(session.json 의 쿠키) → `Page.navigate` 순서
+3. `Network.requestWillBeSent` 에서 non-GET `/api/` 요청의 `postData` 수집
+4. 종료 시 브라우저·임시 프로필 정리
+
+**아무것도 안 잡히면**: 세션 만료(가장 흔함), 해당 라우트에 웹 UI 가 없음(= 모바일 전용),
+또는 화면이 느려서 `--wait` 을 늘려야 하는 경우다.
+
+전제: Node 18+ (내장 `WebSocket` 사용, npm 설치 불필요) 와 Playwright 브라우저 캐시.

--- a/tools/capture_post_bodies.mjs
+++ b/tools/capture_post_bodies.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// SPA 첫 로드의 non-GET 요청 바디를 CDP 로 캡처한다.
+//
+// 왜 이게 필요한가: 웹 UI 에만 있는 기능의 POST 바디는 라이브 요청을 봐야만 알 수 있는데,
+// 탭 클릭·pushState 로는 React Query 캐시 때문에 재요청이 안 걸린다. 첫 로드를 잡아야 한다.
+// 예전에는 addInitScript 로 fetch 를 몽키패치하려 했으나 브라우저를 남이 몰아서 실패했다
+// (docs/reverse-engineering/capture-workflow.md "막힌 방법"). 브라우저 컨텍스트를 직접
+// 소유하면 JS 주입이 아예 필요 없다 — Network 도메인이 postData 를 그대로 준다.
+//
+// 안전:
+//   - 값은 기본적으로 마스킹된다. 구현에 필요한 건 키와 타입이지 실계좌 값이 아니다.
+//     원본이 꼭 필요하면 --raw 를 쓰되 그 출력은 커밋·PR·이슈에 남기지 말 것.
+//   - Playwright 캐시의 "Chrome for Testing" 을 임시 프로필로 띄운다. 사용자의 실제
+//     Chrome 프로필/기본 브라우저를 건드리지 않는다.
+//
+// 사용법:
+//   node tools/capture_post_bodies.mjs <path>            # 예: /account/profit
+//   node tools/capture_post_bodies.mjs <path> --raw      # 값까지 (주의)
+//   node tools/capture_post_bodies.mjs <path> --wait 8   # 대기 초
+//
+// 선행조건: `tossctl auth status` 의 Live Check 가 valid 여야 한다.
+
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync, existsSync, readdirSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join } from "node:path";
+
+const args = process.argv.slice(2);
+const target = args.find((a) => !a.startsWith("--")) ?? "/";
+const raw = args.includes("--raw");
+const waitSec = Number(args[args.indexOf("--wait") + 1]) || 6;
+
+const ORIGIN = "https://www.tossinvest.com";
+const PORT = 9333;
+
+// ── session.json 의 쿠키 → CDP 형식 ──────────────────────────────────────────
+function loadCookies() {
+  const p = join(homedir(), "Library/Application Support/tossctl/session.json");
+  if (!existsSync(p)) throw new Error(`session.json 없음: ${p} — \`tossctl auth login\` 먼저`);
+  const s = JSON.parse(readFileSync(p, "utf8"));
+  const jar = s.cookies ?? {};
+  return Object.entries(jar).map(([name, value]) => ({
+    name,
+    value: String(value),
+    domain: ".tossinvest.com",
+    path: "/",
+    secure: true,
+  }));
+}
+
+// ── Playwright 캐시에서 Chrome for Testing 찾기 ──────────────────────────────
+function findChrome() {
+  const base = join(homedir(), "Library/Caches/ms-playwright");
+  if (!existsSync(base)) throw new Error("ms-playwright 캐시 없음 — Chrome for Testing 을 찾을 수 없다");
+  const dirs = readdirSync(base).filter((d) => d.startsWith("chromium-")).sort().reverse();
+  for (const d of dirs) {
+    const exe = join(base, d, "chrome-mac-arm64",
+      "Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing");
+    if (existsSync(exe)) return exe;
+  }
+  throw new Error("Chrome for Testing 실행파일을 찾지 못했다");
+}
+
+// ── 값 마스킹: 구조는 남기고 내용만 지운다 ───────────────────────────────────
+function redact(v) {
+  if (v === null) return null;
+  if (Array.isArray(v)) return v.length ? [redact(v[0]), `…(${v.length}개)`] : [];
+  if (typeof v === "object") return Object.fromEntries(Object.entries(v).map(([k, x]) => [k, redact(x)]));
+  if (typeof v === "number") return "<number>";
+  if (typeof v === "boolean") return "<boolean>";
+  const s = String(v);
+  return s.length > 12 ? `<string:${s.length}>` : "<string>";
+}
+
+function show(body) {
+  if (!body) return "(바디 없음)";
+  if (raw) return body;
+  try {
+    return JSON.stringify(redact(JSON.parse(body)), null, 2);
+  } catch {
+    return `<non-JSON body: ${body.length} bytes>`;
+  }
+}
+
+// ── CDP ──────────────────────────────────────────────────────────────────────
+const profile = mkdtempSync(join(tmpdir(), "tossctl-capture-"));
+const chrome = spawn(findChrome(), [
+  "--headless=new",
+  `--remote-debugging-port=${PORT}`,
+  `--user-data-dir=${profile}`,
+  "--no-first-run",
+  "--no-default-browser-check",
+  "about:blank",
+], { stdio: "ignore" });
+
+const cleanup = () => {
+  try { chrome.kill(); } catch {}
+  try { rmSync(profile, { recursive: true, force: true }); } catch {}
+};
+process.on("exit", cleanup);
+process.on("SIGINT", () => { cleanup(); process.exit(130); });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function waitForCDP() {
+  for (let i = 0; i < 40; i++) {
+    try { return await (await fetch(`http://127.0.0.1:${PORT}/json/version`)).json(); }
+    catch { await sleep(250); }
+  }
+  throw new Error("CDP 연결 실패");
+}
+
+const ver = await waitForCDP();
+const ws = new WebSocket(ver.webSocketDebuggerUrl);
+let id = 0;
+const pending = new Map();
+const seen = [];
+
+const send = (method, params = {}, sessionId) =>
+  new Promise((resolve) => {
+    const i = ++id;
+    pending.set(i, resolve);
+    ws.send(JSON.stringify({ id: i, method, params, ...(sessionId && { sessionId }) }));
+  });
+
+await new Promise((r) => (ws.onopen = r));
+ws.onmessage = (e) => {
+  const m = JSON.parse(e.data);
+  if (m.id && pending.has(m.id)) { pending.get(m.id)(m.result); pending.delete(m.id); return; }
+  if (m.method === "Network.requestWillBeSent") {
+    const r = m.params.request;
+    if (r.method !== "GET" && r.url.includes("/api/")) {
+      seen.push({ method: r.method, url: r.url, postData: r.postData });
+    }
+  }
+};
+
+const { targetId } = await send("Target.createTarget", { url: "about:blank" });
+const { sessionId } = await send("Target.attachToTarget", { targetId, flatten: true });
+
+await send("Network.enable", {}, sessionId);              // 내비게이션 '전에'
+await send("Network.setCookies", { cookies: loadCookies() }, sessionId);
+await send("Page.enable", {}, sessionId);
+await send("Page.navigate", { url: ORIGIN + target }, sessionId);
+await sleep(waitSec * 1000);
+
+console.log(`\n대상: ${ORIGIN}${target}`);
+console.log(`캡처된 non-GET /api/ 요청: ${seen.length}개` + (raw ? "  [--raw: 값 노출됨]" : "  [값 마스킹됨]"));
+for (const r of seen) {
+  console.log(`\n── ${r.method} ${r.url.replace(/^https?:\/\/[^/]+/, "")}`);
+  console.log(show(r.postData));
+}
+if (!seen.length) {
+  console.log("\n힌트: 세션이 유효한지(`tossctl auth status` → Live Check: valid),");
+  console.log("      해당 라우트에 웹 UI 가 있는지 확인. --wait 로 대기를 늘려볼 것.");
+}
+ws.close();
+process.exit(0);

--- a/tools/capture_post_bodies.mjs
+++ b/tools/capture_post_bodies.mjs
@@ -17,6 +17,7 @@
 //   node tools/capture_post_bodies.mjs <path>            # 예: /account/profit
 //   node tools/capture_post_bodies.mjs <path> --raw      # 값까지 (주의)
 //   node tools/capture_post_bodies.mjs <path> --wait 8   # 대기 초
+//   node tools/capture_post_bodies.mjs <path> --all      # 텔레메트리까지 포함
 //
 // 선행조건: `tossctl auth status` 의 Live Check 가 valid 여야 한다.
 
@@ -29,6 +30,10 @@ const args = process.argv.slice(2);
 const target = args.find((a) => !a.startsWith("--")) ?? "/";
 const raw = args.includes("--raw");
 const waitSec = Number(args[args.indexOf("--wait") + 1]) || 6;
+const keepNoise = args.includes("--all");
+
+// 텔레메트리·로깅 엔드포인트. 기능 발굴에 쓸모없고 출력의 절반을 차지한다.
+const NOISE = /\/(log|perf-log)\/bulk|\/tuba\/|\/wts-login-device/;
 
 const ORIGIN = "https://www.tossinvest.com";
 const PORT = 9333;
@@ -129,9 +134,19 @@ ws.onmessage = (e) => {
   if (m.id && pending.has(m.id)) { pending.get(m.id)(m.result); pending.delete(m.id); return; }
   if (m.method === "Network.requestWillBeSent") {
     const r = m.params.request;
-    if (r.method !== "GET" && r.url.includes("/api/")) {
-      seen.push({ method: r.method, url: r.url, postData: r.postData });
-    }
+    // OPTIONS 는 CORS 프리플라이트라 바디가 없다 — 노이즈.
+    if (r.method === "GET" || r.method === "OPTIONS") return;
+    if (!r.url.includes("/api/")) return;
+    if (!keepNoise && NOISE.test(r.url)) return;   // 텔레메트리 — --all 로 포함
+    // postData 는 바디가 작을 때만 인라인으로 온다. 그 외에는 hasPostData 만 서고
+    // Network.getRequestPostData 로 따로 받아야 한다 (라이브에서 대부분 이쪽).
+    seen.push({
+      method: r.method,
+      url: r.url,
+      postData: r.postData,
+      requestId: m.params.requestId,
+      hasPostData: r.hasPostData,
+    });
   }
 };
 
@@ -144,10 +159,24 @@ await send("Page.enable", {}, sessionId);
 await send("Page.navigate", { url: ORIGIN + target }, sessionId);
 await sleep(waitSec * 1000);
 
+// 인라인으로 안 온 바디를 requestId 로 회수한다.
+for (const r of seen) {
+  if (r.postData || !r.hasPostData) continue;
+  const res = await send("Network.getRequestPostData", { requestId: r.requestId }, sessionId);
+  r.postData = res?.postData;
+}
+
 console.log(`\n대상: ${ORIGIN}${target}`);
 console.log(`캡처된 non-GET /api/ 요청: ${seen.length}개` + (raw ? "  [--raw: 값 노출됨]" : "  [값 마스킹됨]"));
+// 같은 엔드포인트가 여러 번 불리면 한 번만 (로그 수집 등)
+const byKey = new Map();
 for (const r of seen) {
-  console.log(`\n── ${r.method} ${r.url.replace(/^https?:\/\/[^/]+/, "")}`);
+  const k = `${r.method} ${r.url.replace(/^https?:\/\/[^/]+/, "")}`;
+  if (!byKey.has(k)) byKey.set(k, { ...r, count: 1 });
+  else byKey.get(k).count++;
+}
+for (const [k, r] of byKey) {
+  console.log(`\n── ${k}${r.count > 1 ? `  (×${r.count})` : ""}`);
   console.log(show(r.postData));
 }
 if (!seen.length) {


### PR DESCRIPTION
`capture-workflow.md` 에 **"막힌 방법 (다음에 시간 낭비 말 것)"** 으로 적혀 있던 두 항목을 지웠다.

## 원인은 하나였다

- `/browse` 의 goto 가 세션을 재생성해 `addInitScript` 가 안 붙음
- React Query 캐시 때문에 탭 클릭·pushState 로는 재요청이 안 걸림

둘 다 같은 뿌리였다 — **브라우저를 우리가 소유하지 않았다.** 컨텍스트를 직접 만들면:

- JS 주입이 **아예 불필요**하다. 내비게이션 전에 `Network.enable` 을 켜면 CDP 가 `postData` 를 그대로 준다 (fetch 몽키패치 불필요)
- 신선한 프로필이라 **캐시가 존재하지 않는다**

```js
await send('Network.enable', {}, sessionId);              // ← 내비게이션 '전에'
await send('Network.setCookies', { cookies }, sessionId);
await send('Page.navigate', { url }, sessionId);
```

## `tools/capture_post_bodies.mjs`

```bash
tossctl auth status                                  # Live Check: valid 확인
node tools/capture_post_bodies.mjs /account/profit
```

출력 — **값 마스킹이 기본**:

```
── POST /api/v3/orders/search
{ "accountNo": "<string>", "page": "<number>", "size": "<number>" }
```

구현에 필요한 건 키와 타입이지 실계좌 값이 아니다. 원본은 `--raw` 로만 볼 수 있고, 그 출력은 커밋 금지(CLAUDE.md "공개 출력·테스트·문서에 실제 계좌 데이터 금지").

**안전 설계**
- Playwright 캐시의 **Chrome for Testing** 을 임시 프로필로 기동 — 사용자의 실제 Chrome 프로필/기본 브라우저를 건드리지 않는다
- Node 18+ 내장 `WebSocket` 사용 → **npm 설치 불필요**, 새 의존성 없음
- 종료 시 브라우저·임시 프로필 정리

## 검증

로컬 픽스처(첫 로드에 POST 를 쏘는 페이지)를 세워 전 구간 확인:

- 주입한 쿠키가 서버에 도달 (`SERVER-SAW-COOKIE: SESSION=DUMMY-SESSION-VALUE`)
- 첫 로드 POST 바디가 잡히고 마스킹되어 출력

**실계좌 라이브 검증은 미완** — 세션이 만료(`Live Check: invalid`, 401)돼 있어서. `tossctl auth login` 후 확인이 필요하다. 메커니즘 자체는 픽스처로 증명됐다.

## 동봉

`docs/research/2026-07-25-unbrowse.md` — 같은 문제를 푸는 [unbrowse](https://github.com/unbrowse-ai/unbrowse) 를 1차 자료로 조사한 노트. 결론은 **불필요**(132MB 런타임 + 호스티드 크레딧 + 우리가 막힌 바로 그 영역이 저쪽 미해결 epic). 이 PR 의 도구가 그 대안이다.

https://claude.ai/code/session_015CLrLGFKyKziG4mCjaTCmT