### PR TITLE
fix(tools): 캡처 도구 결함 3건 — 호스트 은닉·오해되는 라벨·자격증명 노출

### DIFF
--- a/docs/reverse-engineering/capture-workflow.md
+++ b/docs/reverse-engineering/capture-workflow.md
@@ -282,16 +282,20 @@ node tools/capture_post_bodies.mjs /account/profit --all       # 텔레메트리
 `/account/profit` 실측(2026-07-25), 텔레메트리 제외 14건 중 일부:
 
 ```
-── POST /api/v3/profit/readable-tab
+── POST https://wts-cert-api.tossinvest.com/api/v3/profit/readable-tab
 { "rangeType": "<string>", "startDate": "<string>", "endDate": "<string>" }
 
-── POST /api/v1/profit/wts/daily/market
+── POST https://wts-cert-api.tossinvest.com/api/v1/profit/wts/daily/market
 { "currency": "<string>", "startDate": "<string>", "endDate": "<string>",
   "page": "<number>", "size": "<number>" }
 
-── POST /api/v1/dashboard/intelligences/all  (×2)
-{ "types": ["<string>", "…(1개)"], "variable": { "isBrowserPushEnabled": "<boolean>" } }
+── POST https://wts-info-api.tossinvest.com/api/v1/dashboard/intelligences/all  (×2)
+{ "types": ["<string>"], "variable": { "isBrowserPushEnabled": "<boolean>" } }
 ```
+
+**호스트를 그대로 보여준다.** 토스는 `wts-api` / `wts-info-api` / `wts-cert-api` 를
+섞어 쓰고 `client.Config` 도 셋을 따로 받으므로, 경로만 보면 어느 BaseURL 에 붙일지
+알 수 없다. 위 예시에서도 profit 은 cert, intelligences 는 info 다.
 
 `log/bulk`·`perf-log`·`tuba/*`·`wts-login-device` 는 텔레메트리라 기본 제외된다
 (출력의 절반을 차지한다). 필요하면 `--all`.

--- a/tools/capture_post_bodies.mjs
+++ b/tools/capture_post_bodies.mjs
@@ -10,6 +10,7 @@
 // 안전:
 //   - 값은 기본적으로 마스킹된다. 구현에 필요한 건 키와 타입이지 실계좌 값이 아니다.
 //     원본이 꼭 필요하면 --raw 를 쓰되 그 출력은 커밋·PR·이슈에 남기지 말 것.
+//     --raw 에서도 token/secret/csrf 류 키는 계속 가려진다(재사용 가능한 자격증명).
 //   - Playwright 캐시의 "Chrome for Testing" 을 임시 프로필로 띄운다. 사용자의 실제
 //     Chrome 프로필/기본 브라우저를 건드리지 않는다.
 //
@@ -69,7 +70,13 @@ function findChrome() {
 // ── 값 마스킹: 구조는 남기고 내용만 지운다 ───────────────────────────────────
 function redact(v) {
   if (v === null) return null;
-  if (Array.isArray(v)) return v.length ? [redact(v[0]), `…(${v.length}개)`] : [];
+  // 라벨은 "총 N개" 로 쓴다. 예전엔 "…(N개)" 였는데 앞에 표본이 하나 찍히니
+  // "N개 더" 로 읽혀 실제로 개수를 잘못 세는 일이 있었다.
+  if (Array.isArray(v)) {
+    if (v.length === 0) return [];
+    if (v.length === 1) return [redact(v[0])];
+    return [redact(v[0]), `…총 ${v.length}개`];
+  }
   if (typeof v === "object") return Object.fromEntries(Object.entries(v).map(([k, x]) => [k, redact(x)]));
   if (typeof v === "number") return "<number>";
   if (typeof v === "boolean") return "<boolean>";
@@ -77,9 +84,29 @@ function redact(v) {
   return s.length > 12 ? `<string:${s.length}>` : "<string>";
 }
 
+// SECRET_KEY 는 --raw 에서도 절대 원본을 내보내지 않는 필드다. 마스킹이 값을
+// 지우는 건 계좌 데이터를 가리기 위함이고, 이쪽은 재사용 가능한 자격증명이라
+// 성격이 다르다 — 조사 중 XSRF 토큰을 콘솔에 흘린 적이 있어 방어를 넣는다.
+const SECRET_KEY = /token|secret|password|passwd|authorization|cookie|csrf|xsrf/i;
+
+function stripSecrets(v) {
+  if (v === null || typeof v !== "object") return v;
+  if (Array.isArray(v)) return v.map(stripSecrets);
+  return Object.fromEntries(
+    Object.entries(v).map(([k, x]) => [k, SECRET_KEY.test(k) ? "<secret 제거됨>" : stripSecrets(x)]),
+  );
+}
+
 function show(body) {
   if (!body) return "(바디 없음)";
-  if (raw) return body;
+  if (raw) {
+    // --raw 여도 자격증명은 거른다.
+    try {
+      return JSON.stringify(stripSecrets(JSON.parse(body)), null, 2);
+    } catch {
+      return body;
+    }
+  }
   try {
     return JSON.stringify(redact(JSON.parse(body)), null, 2);
   } catch {
@@ -171,7 +198,9 @@ console.log(`캡처된 non-GET /api/ 요청: ${seen.length}개` + (raw ? "  [--r
 // 같은 엔드포인트가 여러 번 불리면 한 번만 (로그 수집 등)
 const byKey = new Map();
 for (const r of seen) {
-  const k = `${r.method} ${r.url.replace(/^https?:\/\/[^/]+/, "")}`;
+  // 호스트를 남긴다. 토스는 wts-api / wts-info-api / wts-cert-api 를 섞어 쓰고
+  // client 도 셋을 따로 설정하므로, 경로만 보면 어느 BaseURL 에 붙일지 알 수 없다.
+  const k = `${r.method} ${r.url.replace(/\?.*$/, "")}`;
   if (!byKey.has(k)) byKey.set(k, { ...r, count: 1 });
   else byKey.get(k).count++;
 }


### PR DESCRIPTION
`profit` 기능(#114)을 캐면서 **셋 다 실제로 걸렸다.** 전부 도구가 조사를 방해한 사례다.

## 1. 호스트를 잘라내 어느 백엔드인지 숨겼다

origin 을 지우고 경로만 찍었는데, 토스는 `wts-api` / `wts-info-api` / `wts-cert-api` 를 섞어 쓰고 `client.Config` 도 셋을 따로 받는다. profit 이 cert 에 있다는 걸 모른 채 `wts-api` 로 찔러 **403·404 를 한참 헤맸다.**

```diff
-── POST /api/v3/profit/readable-tab
+── POST https://wts-cert-api.tossinvest.com/api/v3/profit/readable-tab
+── POST https://wts-info-api.tossinvest.com/api/v1/dashboard/intelligences/all
```

같은 화면에서도 호스트가 갈린다(profit=cert, intelligences=info).

## 2. 배열 라벨 `…(N개)` 가 "N개 더" 로 읽혔다

앞에 표본이 하나 찍히니 `1+N` 으로 오독해 **`profitType` 을 5종으로 잘못 셌다**(실제 4종). `…총 N개` 로 바꾸고, 원소가 하나면 라벨을 아예 붙이지 않는다.

## 3. `--raw` 가 자격증명을 그대로 흘렸다

마스킹은 계좌 값을 가리는 용도라 `token`/`secret`/`csrf` 류는 대상이 아니었고, **조사 중 XSRF 토큰이 콘솔에 찍혔다.** 재사용 가능한 자격증명은 성격이 다르므로 `--raw` 에서도 항상 가린다.

```
{"xsrfToken":"<secret 제거됨>","nested":{"apiSecret":"<secret 제거됨>","amount":1000},"ok":"보존"}
```

## 검증

라이브로 셋 다 확인. `capture-workflow.md` 의 예시 출력도 새 형식으로 갱신하고 호스트가 섞인다는 사실을 명시했다.

https://claude.ai/code/session_015CLrLGFKyKziG4mCjaTCmT