### PR TITLE
feat(tools): 캡처에 --get 추가 — GET 으로만 오는 조회 표면 발굴

### DIFF
--- a/docs/reverse-engineering/capture-workflow.md
+++ b/docs/reverse-engineering/capture-workflow.md
@@ -276,7 +276,12 @@ tossctl auth status          # Live Check: valid 여야 함. 아니면 tossctl a
 node tools/capture_post_bodies.mjs /account/profit
 node tools/capture_post_bodies.mjs /account/profit --wait 10   # 느린 화면
 node tools/capture_post_bodies.mjs /account/profit --all       # 텔레메트리까지
+node tools/capture_post_bodies.mjs /feed/news --get            # GET 도 (조회 발굴)
 ```
+
+기본은 non-GET 만 잡는다(POST 바디가 원래 목적). **조회 기능을 발굴할 땐 `--get`** 을
+써야 한다 — 뉴스·랭킹처럼 GET 으로만 오는 표면이 많고, 그런 건 기본 출력에 안 나온다.
+실제로 `/feed/news` 의 `dashboard/wts/news` 는 `--get` 을 붙이기 전까지 보이지 않았다.
 
 출력은 **값이 마스킹된 형태**다 — 구현에 필요한 건 키와 타입이지 실계좌 값이 아니다.
 `/account/profit` 실측(2026-07-25), 텔레메트리 제외 14건 중 일부:

--- a/tools/capture_post_bodies.mjs
+++ b/tools/capture_post_bodies.mjs
@@ -19,6 +19,7 @@
 //   node tools/capture_post_bodies.mjs <path> --raw      # 값까지 (주의)
 //   node tools/capture_post_bodies.mjs <path> --wait 8   # 대기 초
 //   node tools/capture_post_bodies.mjs <path> --all      # 텔레메트리까지 포함
+//   node tools/capture_post_bodies.mjs <path> --get      # GET 도 (조회 기능 발굴용)
 //
 // 선행조건: `tossctl auth status` 의 Live Check 가 valid 여야 한다.
 
@@ -32,6 +33,8 @@ const target = args.find((a) => !a.startsWith("--")) ?? "/";
 const raw = args.includes("--raw");
 const waitSec = Number(args[args.indexOf("--wait") + 1]) || 6;
 const keepNoise = args.includes("--all");
+// 기본은 non-GET(바디가 있는 것)만. 조회 기능을 발굴할 땐 GET 도 봐야 한다.
+const withGet = args.includes("--get");
 
 // 텔레메트리·로깅 엔드포인트. 기능 발굴에 쓸모없고 출력의 절반을 차지한다.
 const NOISE = /\/(log|perf-log)\/bulk|\/tuba\/|\/wts-login-device/;
@@ -162,7 +165,8 @@ ws.onmessage = (e) => {
   if (m.method === "Network.requestWillBeSent") {
     const r = m.params.request;
     // OPTIONS 는 CORS 프리플라이트라 바디가 없다 — 노이즈.
-    if (r.method === "GET" || r.method === "OPTIONS") return;
+    if (r.method === "OPTIONS") return;              // CORS 프리플라이트
+    if (r.method === "GET" && !withGet) return;
     if (!r.url.includes("/api/")) return;
     if (!keepNoise && NOISE.test(r.url)) return;   // 텔레메트리 — --all 로 포함
     // postData 는 바디가 작을 때만 인라인으로 온다. 그 외에는 hasPostData 만 서고
@@ -194,7 +198,7 @@ for (const r of seen) {
 }
 
 console.log(`\n대상: ${ORIGIN}${target}`);
-console.log(`캡처된 non-GET /api/ 요청: ${seen.length}개` + (raw ? "  [--raw: 값 노출됨]" : "  [값 마스킹됨]"));
+console.log(`캡처된 ${withGet ? "" : "non-GET "}/api/ 요청: ${seen.length}개` + (raw ? "  [--raw: 값 노출됨]" : "  [값 마스킹됨]"));
 // 같은 엔드포인트가 여러 번 불리면 한 번만 (로그 수집 등)
 const byKey = new Map();
 for (const r of seen) {


### PR DESCRIPTION
도구가 non-GET 만 잡고 있었다. POST 바디를 알아내는 게 원래 목적이었으니 기본값으로는 맞지만, **조회 기능은 GET 인 경우가 많아 발굴에는 눈이 가려져 있었다.**

## 실제로 막혔던 사례

피드 뉴스 탭의 엔드포인트를 찾으려고 `/feed` 를 캡처했는데 **아무 뉴스 관련 요청도 안 나왔다**. 뉴스 목록이 GET 으로 오고, 그 GET 을 봐야 `/feed/news` 라우트로 좁힐 수 있었기 때문이다.

```bash
$ node tools/capture_post_bodies.mjs /feed --wait 10
# → dashboard/asset/sections 류만. 뉴스 흔적 없음

$ node tools/capture_post_bodies.mjs /feed --get --wait 10
── GET https://wts-cert-api.tossinvest.com/api/v4/feed/recommend/ranking-posts   # ← 실마리
```

그 뒤 `/feed/news` 로 좁혀 **`POST /api/v1/dashboard/wts/news`** 를 찾았다. 이 엔드포인트는 **카탈로그에 아예 없다** — 번들 스캐너가 놓친 것으로, `profit/readable-tab` 에 이어 두 번째 사례다.

## 변경

`--get` 플래그. 기본 동작은 그대로(non-GET 만) — 출력이 GET 으로 뒤덮이면 POST 바디를 찾기 어려워진다.

`capture-workflow.md` 에 "조회 발굴엔 `--get`" 을 명시.

https://claude.ai/code/session_015CLrLGFKyKziG4mCjaTCmT