### PR TITLE
test: 이번 세션에 넓힌 표면을 잠근다 — 마스킹 계약·모니터 헬퍼·인자 강제변환

### DIFF
--- a/internal/ops/helpers_test.go
+++ b/internal/ops/helpers_test.go
@@ -1,0 +1,142 @@
+package ops
+
+import (
+	"strings"
+	"testing"
+)
+
+// probe check 헬퍼는 주간 모니터가 API 계약 변화를 잡는 근거다. 여기가 틀리면
+// 모니터링이 조용히 눈을 감는다 — 통과해야 할 때 실패하는 것보다 나쁘다.
+
+func TestExpectStatus(t *testing.T) {
+	if err := ExpectStatus(200, 200); err != nil {
+		t.Errorf("일치하는데 오류: %v", err)
+	}
+	err := ExpectStatus(503, 200)
+	if err == nil {
+		t.Fatal("불일치를 통과시켰다 — 모니터가 장애를 놓친다")
+	}
+	if !strings.Contains(err.Error(), "503") || !strings.Contains(err.Error(), "200") {
+		t.Errorf("오류에 실제/기대 상태가 둘 다 있어야 한다: %v", err)
+	}
+}
+
+func TestExpectPath(t *testing.T) {
+	body := []byte(`{"result":{"totalAssetAmount":{"krw":1},"name":"x","items":[1],"flag":true,"nil":null}}`)
+	ok := []struct{ path, typ string }{
+		{"result", "object"},
+		{"result.totalAssetAmount", "object"},
+		{"result.totalAssetAmount.krw", "number"},
+		{"result.name", "string"},
+		{"result.items", "array"},
+		{"result.flag", "bool"},
+		{"result.nil", "null"},
+	}
+	for _, c := range ok {
+		if err := ExpectPath(body, c.path, c.typ); err != nil {
+			t.Errorf("ExpectPath(%q,%q) 실패: %v", c.path, c.typ, err)
+		}
+	}
+
+	// 계약이 깨진 상황들 — 전부 잡아야 한다
+	bad := []struct {
+		name, path, typ string
+		body            []byte
+		wantIn          string
+	}{
+		{"키 사라짐", "result.gone", "number", body, "missing"},
+		{"타입 바뀜", "result.name", "number", body, "expected number"},
+		{"중간이 객체가 아님", "result.name.deeper", "string", body, "expected object"},
+		{"JSON 아님", "result", "object", []byte("<html>503</html>"), "decode body"},
+	}
+	for _, c := range bad {
+		err := ExpectPath(c.body, c.path, c.typ)
+		if err == nil {
+			t.Errorf("%s: 통과시켰다 — 모니터가 계약 변화를 놓친다", c.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), c.wantIn) {
+			t.Errorf("%s: 오류에 %q 가 없다: %v", c.name, c.wantIn, err)
+		}
+	}
+}
+
+// 인자 강제변환은 48개 핸들러가 공유한다. 에이전트가 잘못된 타입을 보냈을 때
+// 조용히 0/false 로 흘러가지 않고 분명한 오류가 나와야 한다.
+func TestArgCoercion(t *testing.T) {
+	args := map[string]any{
+		"num": float64(5), "intish": 7,
+		"flag": true, "text": "hi",
+		"list": []any{"a", "b"},
+	}
+
+	t.Run("정상 변환", func(t *testing.T) {
+		if v, err := argInt(args, "num"); err != nil || v != 5 {
+			t.Errorf("argInt(num) = %v, %v", v, err)
+		}
+		if v, err := argInt(args, "intish"); err != nil || v != 7 {
+			t.Errorf("argInt(intish) = %v, %v", v, err)
+		}
+		if v, err := argBool(args, "flag"); err != nil || !v {
+			t.Errorf("argBool = %v, %v", v, err)
+		}
+		if v, err := argStringSlice(args, "list"); err != nil || len(v) != 2 || v[0] != "a" {
+			t.Errorf("argStringSlice = %v, %v", v, err)
+		}
+	})
+
+	t.Run("없는 키는 제로값 + 오류 없음", func(t *testing.T) {
+		for _, f := range []func() error{
+			func() error { _, e := argInt(args, "nope"); return e },
+			func() error { _, e := argBool(args, "nope"); return e },
+			func() error { _, e := argStringSlice(args, "nope"); return e },
+			func() error { _, e := argString(args, "nope"); return e },
+		} {
+			if err := f(); err != nil {
+				t.Errorf("선택 인자 부재는 오류가 아니어야 한다: %v", err)
+			}
+		}
+	})
+
+	t.Run("타입 불일치는 분명한 오류", func(t *testing.T) {
+		cases := []struct {
+			name string
+			fn   func() error
+		}{
+			{"int 자리에 문자열", func() error { _, e := argInt(args, "text"); return e }},
+			{"bool 자리에 문자열", func() error { _, e := argBool(args, "text"); return e }},
+			{"배열 자리에 문자열", func() error { _, e := argStringSlice(args, "text"); return e }},
+			{"문자열 자리에 bool", func() error { _, e := argString(args, "flag"); return e }},
+		}
+		for _, c := range cases {
+			err := c.fn()
+			if err == nil {
+				t.Errorf("%s: 조용히 제로값으로 흘렀다", c.name)
+				continue
+			}
+			if !strings.Contains(err.Error(), "must be") {
+				t.Errorf("%s: 오류 문구가 불친절하다: %v", c.name, err)
+			}
+		}
+		// 배열 안의 원소 타입도 검사해야 한다
+		bad := map[string]any{"list": []any{"ok", 3}}
+		if _, err := argStringSlice(bad, "list"); err == nil {
+			t.Error("배열 원소 타입 불일치를 통과시켰다")
+		}
+	})
+}
+
+// Get 은 MCP describe_operation 의 근거다.
+func TestCatalogGet(t *testing.T) {
+	c := NewCatalog()
+	op, ok := c.Get("accounts")
+	if !ok {
+		t.Fatal("알려진 오퍼레이션을 못 찾는다")
+	}
+	if op.ID != "accounts" {
+		t.Errorf("ID = %q", op.ID)
+	}
+	if _, ok := c.Get("존재하지_않음"); ok {
+		t.Error("없는 오퍼레이션을 찾았다고 한다")
+	}
+}

--- a/internal/output/account_detail_test.go
+++ b/internal/output/account_detail_test.go
@@ -1,0 +1,117 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/domain"
+)
+
+// 합성 더미. 실제 계좌 데이터는 쓰지 않는다.
+func sampleDetail() domain.AccountDetail {
+	restricted := false
+	diff := true
+	return domain.AccountDetail{
+		Number:       "137-01-000930",
+		Name:         "홍길동",
+		Status:       "00",
+		OpenedAt:     "2021-03-05",
+		LastTradedAt: "2026-07-24",
+		Withdrawable: &domain.WithdrawableByDay{Day0: 1000, Day1: 2000, Day2: 3000},
+		WithdrawalLimits: &domain.WithdrawalLimits{
+			PerTransaction: 10000000, PerDay: 100000000, UsedToday: 0,
+		},
+		FullWithdrawalOn:   "2026-07-28",
+		TransferRestricted: &restricted,
+		MarginKR:           &domain.MarginStatus{Receivable: false},
+		MarginUS:           &domain.MarginStatus{Receivable: false},
+		DifferentialMargin: &diff,
+		FetchedAt:          time.Now(),
+	}
+}
+
+// 이 출력은 이슈·채팅에 붙여넣어진다. 마스킹이 기본이라는 계약을 잠근다 —
+// 리팩터가 이걸 떨어뜨리면 실명과 계좌번호가 그대로 샌다.
+func TestAccountDetailMasksByDefault(t *testing.T) {
+	d := sampleDetail()
+	for _, format := range []Format{FormatTable, FormatJSON} {
+		var buf bytes.Buffer
+		if err := WriteAccountDetail(&buf, format, d, false); err != nil {
+			t.Fatal(err)
+		}
+		out := buf.String()
+		if strings.Contains(out, d.Number) {
+			t.Errorf("[%s] 계좌번호 전체가 노출됐다", format)
+		}
+		if strings.Contains(out, d.Name) {
+			t.Errorf("[%s] 예금주 실명이 노출됐다 — accountName 은 실명이다", format)
+		}
+		if !strings.Contains(out, "*") {
+			t.Errorf("[%s] 마스킹 흔적이 없다: %s", format, out)
+		}
+	}
+}
+
+// --full 은 명시적 해제여야 한다 (그리고 그때만).
+func TestAccountDetailFullRevealsBoth(t *testing.T) {
+	d := sampleDetail()
+	var buf bytes.Buffer
+	if err := WriteAccountDetail(&buf, FormatTable, d, true); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, d.Number) || !strings.Contains(out, d.Name) {
+		t.Errorf("--full 인데 전체가 안 나온다: %s", out)
+	}
+}
+
+// 포맷을 바꾸는 것이 마스킹 우회로가 되면 안 된다.
+func TestAccountDetailJSONHonoursMasking(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteAccountDetail(&buf, FormatJSON, sampleDetail(), false); err != nil {
+		t.Fatal(err)
+	}
+	var got domain.AccountDetail
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got.Number, "*") || !strings.Contains(got.Name, "*") {
+		t.Errorf("JSON 이 마스킹을 우회했다: number=%q name=%q", got.Number, got.Name)
+	}
+}
+
+// 의미를 모르는 상태 코드는 사람이 읽는 출력에 넣지 않는다(JSON 에는 남긴다).
+func TestAccountDetailHidesOpaqueStatusFromTable(t *testing.T) {
+	d := sampleDetail() // Status: "00"
+	var buf bytes.Buffer
+	if err := WriteAccountDetail(&buf, FormatTable, d, false); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "00)") {
+		t.Error("의미 모르는 status 코드를 사람 읽는 출력에 넣었다")
+	}
+	var j bytes.Buffer
+	if err := WriteAccountDetail(&j, FormatJSON, d, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(j.String(), `"status"`) {
+		t.Error("JSON 에는 status 가 남아야 한다")
+	}
+}
+
+// 못 불러온 항목은 조용히 사라지지 않고 경고로 보여야 한다.
+func TestAccountDetailShowsWarnings(t *testing.T) {
+	d := sampleDetail()
+	d.MarginKR, d.MarginUS, d.DifferentialMargin = nil, nil, nil
+	d.Warnings = []string{"미수거래 상태: 서버 오류"}
+	var buf bytes.Buffer
+	if err := WriteAccountDetail(&buf, FormatTable, d, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "미수거래 상태") {
+		t.Errorf("경고가 출력되지 않았다: %s", buf.String())
+	}
+}

--- a/internal/output/news_test.go
+++ b/internal/output/news_test.go
@@ -1,0 +1,110 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/domain"
+)
+
+func sampleNews() domain.MarketNews {
+	return domain.MarketNews{
+		Type:  "PERSONALIZE_WATCH",
+		Title: "관심 뉴스",
+		Items: []domain.NewsItem{{
+			ID: "n1", Title: "더미 헤드라인", Summary: "더미 요약문",
+			Source: "더미통신", CreatedAt: "2026-07-25T09:00:00",
+			Stocks: []domain.NewsRelatedStock{
+				{Code: "A000000", Name: "더미종목", Fluctuation: 2.15},
+				{Code: "A111111", Name: "더미종목2", Fluctuation: -0.4},
+			},
+		}},
+		FetchedAt: time.Now(),
+	}
+}
+
+// 관련 종목 등락률은 이 피드가 헤드라인 목록보다 나은 유일한 지점이다 — 항상 나와야 한다.
+func TestMarketNewsAlwaysShowsRelatedStockMoves(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteMarketNews(&buf, FormatTable, sampleNews(), false); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{"더미종목 +2.15%", "더미종목2 -0.40%"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("관련 종목 등락률 %q 가 없다:\n%s", want, out)
+		}
+	}
+}
+
+// 요약은 기본 생략(50건이면 벽), --full 로만.
+func TestMarketNewsSummaryIsOptIn(t *testing.T) {
+	n := sampleNews()
+	var plain, full bytes.Buffer
+	if err := WriteMarketNews(&plain, FormatTable, n, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteMarketNews(&full, FormatTable, n, true); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(plain.String(), "더미 요약문") {
+		t.Error("기본 출력에 요약이 들어갔다")
+	}
+	if !strings.Contains(plain.String(), "--full") {
+		t.Error("요약이 있는데 --full 안내가 없다")
+	}
+	if !strings.Contains(full.String(), "더미 요약문") {
+		t.Error("--full 인데 요약이 없다")
+	}
+}
+
+// 범위 라벨은 서버가 준 title 을 쓴다 — 한글 라벨을 코드에 박지 않기 위함.
+func TestMarketNewsUsesServerTitle(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteMarketNews(&buf, FormatTable, sampleNews(), false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "관심 뉴스") {
+		t.Error("서버가 준 title 이 헤더에 없다")
+	}
+
+	// title 이 없으면 enum 으로 폴백
+	n := sampleNews()
+	n.Title = ""
+	var buf2 bytes.Buffer
+	if err := WriteMarketNews(&buf2, FormatTable, n, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf2.String(), "PERSONALIZE_WATCH") {
+		t.Error("title 이 없을 때 enum 폴백이 없다")
+	}
+}
+
+func TestMarketNewsCSVIsFlat(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteMarketNews(&buf, FormatCSV, sampleNews(), false); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("헤더 + 1행이어야 한다: %v", lines)
+	}
+	// 관련 종목은 한 셀에 기계가 나눌 수 있는 형태로
+	if !strings.Contains(lines[1], "더미종목:A000000:2.15|") {
+		t.Errorf("CSV 의 stocks 셀 형식이 다르다: %s", lines[1])
+	}
+}
+
+func TestMarketNewsEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	n := sampleNews()
+	n.Items = nil
+	if err := WriteMarketNews(&buf, FormatTable, n, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "없습니다") {
+		t.Errorf("빈 결과 안내가 없다: %s", buf.String())
+	}
+}

--- a/internal/output/profit_period_test.go
+++ b/internal/output/profit_period_test.go
@@ -1,0 +1,94 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/JungHoonGhae/tossinvest-cli/internal/domain"
+)
+
+func usdPtr(v float64) *float64 { return &v }
+
+// 날짜는 API 의 YYYYMMDD 로 들어오고 사람에게는 YYYY-MM-DD 로 보여야 한다.
+func TestPeriodLabelFormatsDates(t *testing.T) {
+	cases := map[[2]string]string{
+		{"", ""}:                 "전체 기간",
+		{"20260101", "20260725"}: "2026-01-01 ~ 2026-07-25",
+	}
+	for in, want := range cases {
+		if got := periodLabel(in[0], in[1]); got != want {
+			t.Errorf("periodLabel(%q,%q) = %q, want %q", in[0], in[1], got, want)
+		}
+	}
+}
+
+func TestWritePeriodProfit(t *testing.T) {
+	p := domain.PeriodProfit{
+		Type: "sales", From: "20260101", To: "20260725",
+		EarningAmount:  domain.DualCurrency{KRW: -1421, USD: usdPtr(-1.02)},
+		EarningRate:    domain.DualCurrency{KRW: -66.9},
+		PurchaseAmount: domain.DualCurrency{KRW: 2124},
+		FetchedAt:      time.Now(),
+	}
+	var buf bytes.Buffer
+	if err := WritePeriodProfit(&buf, FormatTable, p); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{"sales", "2026-01-01 ~ 2026-07-25", "수익률", "-66.90"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("%q 가 없다:\n%s", want, out)
+		}
+	}
+	// USD 가 없으면 대시로
+	p.EarningAmount.USD = nil
+	var buf2 bytes.Buffer
+	if err := WritePeriodProfit(&buf2, FormatTable, p); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf2.String(), "-") {
+		t.Error("USD 부재 표시가 없다")
+	}
+}
+
+// 통화는 행마다가 아니라 헤더에 한 번 — 조회 전체의 기준이기 때문.
+func TestWriteDailyProfitShowsBasisInHeader(t *testing.T) {
+	d := domain.DailyProfit{
+		From: "20260101", To: "20260725", Currency: "KRW",
+		Stocks: []domain.DailyProfitStock{
+			{Date: "2026-07-15", Symbol: "A000000", Name: "더미종목", Quantity: 10,
+				ProfitLoss: domain.DualCurrency{KRW: -1000}, ProfitRate: -12.13},
+			{Date: "2026-06-11", Symbol: "DUMMY", Name: "더미2", Quantity: 46,
+				ProfitLoss: domain.DualCurrency{KRW: 500}, ProfitRate: 3.2},
+		},
+		FetchedAt: time.Now(),
+	}
+	var buf bytes.Buffer
+	if err := WriteDailyProfit(&buf, FormatTable, d); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "수익률 기준 KRW") {
+		t.Errorf("기준 통화가 헤더에 없다:\n%s", out)
+	}
+	if strings.Count(out, "KRW") > 3 {
+		t.Error("기준 통화가 행마다 반복되는 것 같다 — 헤더에 한 번이면 된다")
+	}
+	// 합계가 맞아야 한다
+	if !strings.Contains(out, "합계") || !strings.Contains(out, "-500") {
+		t.Errorf("합계(-1000+500=-500)가 틀렸다:\n%s", out)
+	}
+}
+
+func TestWriteDailyProfitEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteDailyProfit(&buf, FormatTable,
+		domain.DailyProfit{From: "20260101", To: "20260131", Currency: "KRW"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "없습니다") {
+		t.Errorf("빈 결과 안내가 없다: %s", buf.String())
+	}
+}


### PR DESCRIPTION
기능을 여섯 개 넣는 동안 커버리지가 **50.4% → 49.6%** 로 떨어졌다. 표면을 더 넓히기 전에 잠근다. **퍼센트가 아니라 "깨지면 뭐가 새는가" 순서로** 골랐다.

## 1. account detail 마스킹 계약 — 가장 큰 구멍, 내가 이번에 만든 것

`WriteAccountDetail` 과 `maskName` 이 **0%** 였다. 마스킹은 CLI 로 수동 확인만 했고, 리팩터가 그걸 떨어뜨리면 **예금주 실명과 계좌번호가 터미널로 새는데 아무도 못 잡는** 상태였다.

고정한 것: table·JSON 양쪽 기본 마스킹 · `--full` 이 유일한 해제 · **JSON 이 우회로가 아님** · 불투명 `status` 는 사람 출력에서 제외 · 못 불러온 항목은 경고로 표시.

실효성 확인 — 마스킹을 무력화하면 네 건이 실패한다:

```
--- FAIL: TestAccountDetailMasksByDefault
    [table] 계좌번호 전체가 노출됐다
    [table] 예금주 실명이 노출됐다 — accountName 은 실명이다
    [json]  계좌번호 전체가 노출됐다
    [json]  예금주 실명이 노출됐다
```

## 2. probe check 헬퍼 — 모니터링이 눈감는 걸 막는다

`ExpectStatus` · `ExpectPath` · `jsonTypeOf` 전부 0% 였다. 이건 **주간 모니터가 API 계약 변화를 잡는 근거**다. 여기가 틀리면 통과해야 할 때 실패하는 것보다 나쁜 일 — 조용히 눈을 감는다 — 이 일어난다.

키 소실 · 타입 변경 · 중간 노드가 객체가 아님 · 비 JSON 응답(`<html>503</html>`)을 전부 잡아내는지 고정.

## 3. 인자 강제변환 — 48개 핸들러가 공유하는 에이전트 대면 경로

`argInt` · `argBool` · `argStringSlice` 전부 0%. 에이전트가 잘못된 타입을 보냈을 때 **조용히 0/false 로 흐르지 않고** 분명한 오류가 나오는지, 선택 인자 부재는 오류가 아닌지, **배열 원소 타입까지** 검사하는지 고정.

## 4. 신규 포매터

`market news` — 관련 종목 등락률이 **항상** 나오는지(이 피드의 존재 이유), 요약은 `--full` 옵트인인지, 서버 `title` 을 쓰고 없으면 enum 폴백인지, CSV 셀 형식.
`profit period` — 기준 통화가 헤더에 한 번만(행마다 반복 아님), 합계 정확성, 날짜 `YYYYMMDD → YYYY-MM-DD`.

## 결과

전부 **합성 더미** 데이터.

| | 전 | 후 |
|---|---|---|
| 총계 | 49.6% | **51.8%** |
| `internal/output` | 40.2% | **47.3%** |
| `internal/ops` | 9.4% | **20.5%** |

`make test`(21 패키지) · `make lint` 통과.

https://claude.ai/code/session_015CLrLGFKyKziG4mCjaTCmT