### PR TITLE
docs(re): 리버스 엔지니어링 README 를 현실에 맞게 다시 씀

### DIFF
--- a/docs/reverse-engineering/README.md
+++ b/docs/reverse-engineering/README.md
@@ -1,18 +1,46 @@
 # Reverse Engineering Notes
 
-This directory will hold the Toss Securities web protocol research artifacts used to implement the read-only client.
+토스증권 웹(WTS)의 비공개 API 를 조사한 결과물이다. 공식 Open API 로는 닿지
+않는 조회를 `tossctl` 이 제공할 수 있는 근거가 여기에 있다.
 
-Planned contents:
+## 어디부터 읽나
 
-- RPC catalog
-- auth notes
-- breakage log
-- fixture sanitization rules
-- public fixture refresh workflow
+| 파일 | 내용 |
+|---|---|
+| **[capture-workflow.md](capture-workflow.md)** | **신규 기능 발굴 실전 플레이북** — 세션 주입 → 번들에서 경로 추출 → 라이브 프로브 → POST 바디 캡처 → 웹UI 유무 판정 → 구현. 새 기능을 붙인다면 여기서 시작한다. "막힌 방법" 절도 함께 읽을 것 |
+| [wts-endpoints.json](wts-endpoints.json) | WTS API 전체 카탈로그(구현/후보/의도적 제외). `tools/wts_endpoints.py` 로 갱신, 주간 `wts-monitor.yml` 이 변화를 추적 |
+| [rpc-catalog.md](rpc-catalog.md) | 엔드포인트별 요청/응답 형태 메모 |
+| [auth-notes.md](auth-notes.md) | 세션·쿠키·인증 헤더 |
+| [push-events.md](push-events.md) | 실시간 push 이벤트 |
+| [change-analysis/](change-analysis/) | 서버 변경이 관측된 날의 분석 기록 |
 
-Do not commit raw captures with sensitive cookies, tokens, account numbers, or personal data.
+## 도구
 
-Useful scripts:
+```bash
+# 첫 로드 POST 바디 캡처 (값 마스킹이 기본, 조회 발굴엔 --get)
+node tools/capture_post_bodies.mjs /account/profit
+node tools/capture_post_bodies.mjs /feed/news --get
 
-- `python3 tools/sanitize_har.py <input.har> <output.har>`
-- `python3 tools/fetch_public_fixtures.py fixtures/responses/public`
+# 엔드포인트 카탈로그 갱신 (JS 번들 전수 파싱, stdlib only)
+python3 tools/wts_endpoints.py
+
+# HAR 새니타이즈 · 공개 픽스처 갱신
+python3 tools/sanitize_har.py <input.har> <output.har>
+python3 tools/fetch_public_fixtures.py fixtures/responses/public
+```
+
+**번들 파싱과 라이브 캡처는 상호보완이다.** `wts_endpoints.py` 는 번들에서 경로를
+전수로 뽑지만 호출 형태(바디)는 모르고, 번들에 안 실린 엔드포인트는 못 본다 —
+실제로 `profit/readable-tab`, `dashboard/wts/news`, `stock-infos/{code}/red-flags`
+가 카탈로그에 없는 채 라이브 캡처로만 발견됐다. 반대로 캡처는 그 화면에서 실제로
+발생한 요청만 보여준다. 둘 다 쓴다.
+
+## 데이터 취급
+
+**실제 계좌 데이터는 커밋하지 않는다** — 쿠키·토큰·계좌번호·개인정보가 든 raw
+캡처는 어떤 형태로도 남기지 않는다. 테스트 픽스처는 합성 더미로 만들고, 라이브로
+검증하되 그 값은 화면에서만 본다. 캡처 도구가 값을 기본 마스킹하는 이유도 같다
+(`--raw` 출력은 이슈·PR 에 붙여넣지 말 것).
+
+용어는 루트 [`CONTEXT.md`](../../CONTEXT.md), 되돌리기 어려운 결정은
+[`docs/adr/`](../adr/).


### PR DESCRIPTION
`docs/reverse-engineering/README.md` 가 **프로젝트 초기 스텁 그대로**였다:

> This directory **will** hold the Toss Securities web protocol research artifacts...
>
> **Planned** contents: RPC catalog, auth notes, breakage log...

그 사이 실제 산출물이 쌓였는데 진입점이 아무것도 가리키지 않았다. 특히 **실전 플레이북인 `capture-workflow.md` 와 캡처 도구가 빠져 있어서**, 디렉터리를 처음 여는 사람이 가장 필요한 문서로 가지 못했다.

## 변경

- **어디부터 읽는지 표로** — `capture-workflow.md` 를 맨 위에
- 도구 네 개를 실제 사용 예와 함께 — `capture_post_bodies.mjs` 가 목록에 없었다
- **번들 파싱과 라이브 캡처가 상호보완**임을 명시. 이번 세션에 `profit/readable-tab` · `dashboard/wts/news` · `stock-infos/{code}/red-flags` 가 **카탈로그에 없는 채 라이브 캡처로만** 발견됐다. 둘 중 하나만 쓰면 놓친다는 걸 기록해 둔다
- 데이터 취급 규칙을 캡처 도구의 마스킹 동작과 연결 (`--raw` 출력은 이슈·PR 에 붙여넣지 말 것)
- `CONTEXT.md` / `docs/adr/` 로 연결

링크 대상과 언급한 도구가 전부 실재하는지 확인했다. 문서만 변경.

> 참고: `CLAUDE.md` 는 `.gitignore` 대상이라 레포에 없다(`.gitignore:28`). 추적되는 쪽의 진입점은 이 README 다.

https://claude.ai/code/session_015CLrLGFKyKziG4mCjaTCmT