### PR TITLE
fix(monitor): breaking-risk 제목 오탐 — 마커를 줄 전체로 앵커링

### DIFF
--- a/.github/workflows/daily-monitor.yml
+++ b/.github/workflows/daily-monitor.yml
@@ -281,7 +281,11 @@ jobs:
             echo "이미 오늘자 PR 존재 — 생략"; exit 0
           fi
           TITLE_PREFIX=""
-          grep -qi "breaking-risk" "$FILE" && TITLE_PREFIX="[breaking-risk] "
+          # 마커는 위 프롬프트가 지정한 `> breaking-risk` **한 줄** 이다. 파일 전체를
+          # substring 으로 훑으면 "breaking-risk 로 표시하지는 않되" 같은 부정문에도
+          # 걸려 제목이 거짓 경보가 된다 (2026-07-27 분석에서 실제로 발생). 줄 전체를
+          # 앵커링해 산문 언급과 마커를 구분한다.
+          grep -qiE '^> *breaking-risk *$' "$FILE" && TITLE_PREFIX="[breaking-risk] "
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git checkout -b "$BR"


### PR DESCRIPTION
## 문제

`daily-monitor.yml:284` 가 분석 문서를 **파일 전체 substring** 으로 훑는다.

```bash
grep -qi "breaking-risk" "$FILE" && TITLE_PREFIX="[breaking-risk] "
```

그래서 breaking risk 를 **부정하는** 문장에도 걸린다.

**#126 이 실제 사례다.** 본문에 이렇게 적혀 있는데:

> …크래시는 아니지만 데이터 완결성 관점에서 사용자를 오도할 수 있는 잠재적 결함이므로 **breaking-risk 로 표시하지는 않되**, 후속 조치가 필요하다고 판단한다.

제목은 `[breaking-risk] docs(analysis): API 변경 분석 2026-07-27` 로 나갔다.

## 왜 고치는가

경보가 거짓말하면 매일 오는 크론을 사람이 안 읽게 된다. **진짜 breaking 변경이 왔을 때 놓치는 게 실제 비용이다.** 분석 문서는 성격상 "이건 breaking 인가?" 를 논하므로, 이 오탐은 계속 재발한다.

## 변경

마커는 같은 워크플로의 프롬프트(`:262`)가 지정한 **`> breaking-risk` 한 줄**이다. 줄 전체를 앵커링해 산문 언급과 마커를 구분한다.

```bash
grep -qiE '^> *breaking-risk *$' "$FILE" && TITLE_PREFIX="[breaking-risk] "
```

## 검증

세 문서로 확인했다.

| 입력 | 기존 | 수정 후 |
|---|---|---|
| 실제 2026-07-27 분석 (부정문 포함) | `[breaking-risk]` ← 오탐 | 안 붙음 |
| `> breaking-risk` 마커 있는 문서 | `[breaking-risk]` | `[breaking-risk]` |
| no-op 분석 문서 | 안 붙음 | 안 붙음 |

YAML 파싱도 확인했다. 워크플로 한 줄 변경이라 코드 테스트는 없다.