### PR TITLE
docs(analysis): status=CLOSED 페이징 라이브 확인 결과 추가

### DIFF
--- a/docs/reverse-engineering/change-analysis/2026-07-27.md
+++ b/docs/reverse-engineering/change-analysis/2026-07-27.md
@@ -32,3 +32,25 @@
 3. 필요 시 `tossctl order` 계열에 공식 API 기반의 `CLOSED` 주문 목록 조회 서브커맨드(조건주문의 `order conditional list --status CLOSED --cursor ...` 와 동일한 UX)를 추가하는 것을 검토한다.
 4. `internal/official/orders_reads_test.go` 에 `status=CLOSED` + `hasNext=true` 응답을 모킹한 회귀 테스트를 추가해 페이지네이션 필드 누락을 방지한다.
 5. 위 항목들은 기존 동작을 깨지 않는 순수 확장이므로 다음 정기 개발 사이클에 반영해도 무방하다. 실계좌 데이터/라이브 API 호출 없이 목(mock) 기반 테스트로 검증할 것.
+
+---
+
+## 5. 라이브 확인 (2026-07-28, v0.31.0 이후 추가)
+
+작성 시점에는 spec 의 **description 텍스트**만 바뀐 상태여서 서버가 실제로 그렇게
+동작하는지는 미확인이었다. 실계좌 조회로 확정했다 (조회 전용, 값은 남기지 않는다).
+
+| | `status=CLOSED` | `status=OPEN` (대조군) |
+|---|---|---|
+| 응답 | 200 — `400 closed-not-supported` 아님 | 200 |
+| `has_next` | `true` | `false` |
+| `next_cursor` | 내려옴 | 없음 (`omitempty`) |
+| 커서 되먹임 | **다른 주문이 나옴** — 페이지가 실제로 넘어간다 | — |
+| `limit` | 존중됨 | — |
+
+즉 3절의 판단이 맞았다. `status=CLOSED` 는 실제로 페이징하며, 수정 전 구현이었다면
+**첫 페이지만 조용히 반환되고 나머지는 사라졌을 것이다** (`has_next=true` 인데 그
+사실이 호출자에게 전달되지 않으므로).
+
+수정은 #128 에서 반영됐고 v0.31.0 으로 배포됐다. 4절 권장 1·2·4번 완료, 3번(공식 API
+기반 CLOSED 조회 CLI 서브커맨드)은 제품 결정이라 보류.


### PR DESCRIPTION
#126 의 분석은 spec 의 **description 텍스트**만 보고 쓴 것이라, 서버가 실제로 그렇게 동작하는지는 미확인 상태였다. v0.31.0 배포 후 실계좌 조회로 확정했다.

| | `status=CLOSED` | `status=OPEN` (대조군) |
|---|---|---|
| 응답 | 200 — `400 closed-not-supported` 아님 | 200 |
| `has_next` | `true` | `false` |
| `next_cursor` | 내려옴 | 없음 (`omitempty`) |
| 커서 되먹임 | **다른 주문이 나옴** | — |
| `limit` | 존중됨 | — |

즉 #128 이 고친 상황이 실재한다. 수정 전 구현이었다면 `has_next=true` 인데 그 사실이 호출자에게 전달되지 않아 **첫 페이지만 조용히 반환**됐을 것이다.

조회 전용 호출이고, **실계좌 값은 문서에 남기지 않았다** — 구조(키 존재 여부, boolean, id 동일성 비교)만 기록. 주문번호·종목·금액 없음.

#126 권장 1·2·4번 완료(#128), 3번은 제품 결정이라 보류라는 것도 함께 적었다.