### PR TITLE
docs(agents): 트리아지 라벨 매핑 추가

### DIFF
--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,37 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker (GitHub Issues — see `issue-tracker.md`).
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.
+
+## 이 레포의 현재 상태
+
+**`wontfix` 만 GitHub 에 실제로 존재한다.** 나머지 네 개는 아직 만들지 않았다 — 일부러다.
+쓸지 모르는 라벨을 미리 만들면 라벨 목록만 늘고 아무 이슈도 달리지 않는다.
+
+`/triage` 를 처음 돌릴 때 그 자리에서 만들면 된다:
+
+```bash
+gh label create needs-triage    --description "Maintainer needs to evaluate this issue"
+gh label create needs-info      --description "Waiting on reporter for more information"
+gh label create ready-for-agent --description "Fully specified, ready for an AFK agent"
+gh label create ready-for-human --description "Requires human implementation"
+```
+
+## 트리아지 대상이 아닌 라벨
+
+- **`trigger-waiting`** — 조건이 충족될 때까지 **의도적으로** 보류된 이슈. 방치가 아니고,
+  정보가 부족한 것도 아니다. 판단은 이미 끝났고 실행 시점만 남았다.
+  `needs-triage`(평가 필요)나 `needs-info`(정보 부족)와 헷갈리면 안 된다 —
+  **`trigger-waiting` 이 붙은 이슈는 트리아지 큐에 넣지 않는다.**
+  트리거 조건은 각 이슈 본문에 체크박스로 적혀 있다.


### PR DESCRIPTION
`/setup-matt-pocock-skills` 가 남겨둔 마지막 조각. 이슈 트래커(`issue-tracker.md`)와 도메인 문서(`domain.md`)는 이미 있었고 라벨 매핑만 없었다.

## 결정

**기본 5개 역할명을 그대로 쓴다** — `needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`.

**GitHub 라벨은 아직 만들지 않는다.** `wontfix` 만 실제로 존재하고, 나머지 넷은 `/triage` 를 처음 돌릴 때 그 자리에서 만든다 (명령어를 문서에 적어뒀다). 열린 이슈가 2개인데 둘 다 `trigger-waiting` 이라 지금 트리아지할 대상 자체가 없다. 쓸지 모르는 라벨을 미리 만들면 목록만 늘고 아무 이슈도 안 달린다.

## `trigger-waiting` 을 트리아지 대상에서 뺀 이유

문서에 명시했다. `trigger-waiting` 은 **판단이 끝나고 실행 시점만 남은** 상태다:

- `needs-triage` = 아직 평가 안 함
- `needs-info` = 정보가 부족함
- `trigger-waiting` = 다 알고 있고, "지금은 아니다" 가 결론

#111·#125 가 여기 해당한다. 트리거 조건이 각 이슈 본문에 체크박스로 적혀 있다. 트리아지 큐에 다시 넣으면 이미 내린 결론을 매번 재검토하게 된다.

## `CLAUDE.md`

`### Triage labels` 항목을 `## Agent skills` 블록에 추가했다. 다만 `CLAUDE.md` 는 `.gitignore:28` 대상이라 이 PR 에는 안 들어간다 (로컬 전용). 추적되는 건 `docs/agents/` 쪽이다.

`AGENTS.md` 는 건드리지 않았다 — 그건 tossctl 을 자동화하려는 **외부 에이전트용 recipe** 지 기여자 규약 파일이 아니라서, 내부 이슈 분류를 넣을 자리가 아니다.