### PR TITLE
docs(analysis): WTS 카탈로그 변경 분석 (2026-08-03)

### DIFF
--- a/docs/reverse-engineering/change-analysis/2026-08-03.md
+++ b/docs/reverse-engineering/change-analysis/2026-08-03.md
@@ -81,3 +81,38 @@ deletions).
 4. 삭제된 3개 경로(`dashboard/intelligences/all` v1, `stock-prices/after`,
    `user-permissions/grant/guidelines`)는 미구현이었으므로 조치 불필요. 다음
    `wts-monitor` 갱신에서 재등장하지 않는지만 관찰한다.
+
+---
+
+## 5. 실행 결과 (같은 날 처리 완료)
+
+권장 1번대로 플레이북을 돌렸다. 결과와 **분석이 빗나간 지점**을 남긴다.
+
+| 경로 | 라이브 결과 | 처리 |
+|---|---|---|
+| `rights/us/dividend-option/account-give-type` | GET 200 — `{giveType: CASH\|STOCK, updateDate}` | **구현** (v0.32.0, #133) |
+| `rights/us/categories/{ALL\|DIVIDEND_OPTION}` | GET 200 이지만 `body` 가 늘 빈 배열 | candidate 유지 (#134) |
+| `rights/us/categories/dividend-option/detail` | 400, 파라미터명 11개 시도 미인식 | candidate 유지 (#134) |
+| `rights/us/exercises/*` (2개) | **POST 403 — 쓰기 동작** | **excluded** |
+
+### 3절의 "전부 조회성(GET으로 추정)" 은 틀렸다
+
+`exercises/*` 두 개는 조회가 아니라 **배당 수령 방식을 바꾸는 쓰기**다. 웹 세션으로
+POST 하면 403 이 떨어진다. 이름 패턴(`account-give-type`)이 조회처럼 보이는 게 함정
+이었고, `exercises`(권리 **행사**)라는 상위 세그먼트가 진짜 단서였다. `account detail`
+이 계좌 변경 동작을 노출하지 않는 기준에 따라 `EXCLUDED` 로 내렸다.
+
+### 2절의 "`accountKey` 헤더 필요 여부" — 불필요했다
+
+`getJSONWithAccountKey` 가 아니라 일반 `getJSON` 으로 200 이 온다. 계좌 스코프는
+세션 쿠키만으로 해결된다. 그래서 `internal/client/rights.go` 신설(권장 2번) 대신
+`account_detail.go` 의 다섯 번째 병렬 조회로 붙였다 — 새 파일도 새 커맨드도 없다.
+
+### 웹 UI 판정: 모바일 앱 전용
+
+`/account`, `/account/dividends`, `/account/rights` 가 API 를 각각 54~59개 호출하는
+동안 `rights/us` 호출 **0건**. 번들(26청크·3.0MB)에 페이지 라우트 0개, `수령`/`현금`/
+`재투자` 라벨 0개. 라우트 매니페스트에 경로가 있는 건 자동 생성된 API 클라이언트일
+뿐 화면이 아니다. README 의 «📱 모바일 앱 전용» 표에 한·영 모두 등재했다.
+
+카탈로그: implemented 81 → 82, excluded 507 → 509.

--- a/docs/reverse-engineering/change-analysis/2026-08-03.md
+++ b/docs/reverse-engineering/change-analysis/2026-08-03.md
@@ -1,0 +1,83 @@
+# API 변경 분석 — 2026-08-03
+
+## 0. 스코프
+
+이번 주기에는 공식 Open API spec (`docs/migration/openapi.latest.json`,
+`docs/migration/.openapi-snapshot.json`) 변경이 없다 (마지막 갱신은 `5607f4f`,
+2026-07-27, 26시간 관측 윈도우 밖). 아래는 `wts-monitor` 봇의 주간 WTS 카탈로그
+갱신(`8037a62`, `docs/reverse-engineering/wts-endpoints.json`)만 다룬다.
+
+## 1. 변경 요약
+
+`build_id` `xkQNNf2H_FwrnlhjqBSW_` → `1fBomD3D0Cbl8kcbaAnYo`, `total` 935 → 949
+(chunk 25→26). `candidate` 358→361, `excluded` 496→507, `meaningful` 439→442.
+해시/날짜 갱신만이 아니라 실제 경로 추가·삭제가 있는 diff (86 insertions, 19
+deletions).
+
+### 삭제된 경로 (3개, 전부 `candidate`, 미구현)
+
+| 경로 | 비고 |
+|---|---|
+| `/api/v1/dashboard/intelligences/all` | 같은 커밋에서 `/api/v2/dashboard/intelligences/all` 이 신규 `candidate` 로 추가됨 — **버전 범프**로 보인다 (경로만 v1→v2, 기능 이동으로 추정) |
+| `/api/v1/stock-prices/after` | 대체 경로 없음 |
+| `/api/v1/user-permissions/grant/guidelines` | 대체 경로 없음 |
+
+### 신규 경로 (다수, 대부분 `excluded` 마케팅/온보딩성)
+
+`excluded` 신규: `product-eligibility/*/deposit` (2), `feed/recommend/boards`,
+`promotion/bingsu-run/*` (2), `promotion/terms/user/events/participating` (2),
+`settings/privacy/info`, `user-profiles/relation/alimy/shareholding/badge`,
+`lending/stock-balance`, `terms/toss/third-party` — 전부 `note` 상 온보딩/마케팅/약관
+류라 tossctl 스코프 밖.
+
+`candidate` 신규 (관심 대상):
+
+| 경로 | 비고 |
+|---|---|
+| `/api/v2/dashboard/intelligences/all` | 위 v1 삭제분의 이동 |
+| `/api/v1/rights/us/categories` | 미국주식 권리(rights) 카테고리 조회 |
+| `/api/v1/rights/us/categories/dividend-option/detail` | 배당 재투자 옵션 상세 |
+| `/api/v1/rights/us/dividend-option/account-give-type` | 계좌별 배당 옵션 지급 유형 |
+| `/api/v1/rights/us/exercises/categories/dividend-option/account-default-give-type` | 계좌 기본 지급 유형 |
+| `/api/v1/rights/us/exercises/categories/dividend-option/account-give-type` | 계좌 지급 유형 (exercises 하위) |
+
+## 2. tossctl 커버리지 대조
+
+- 삭제된 3개 경로(`dashboard/intelligences/all` v1, `stock-prices/after`,
+  `user-permissions/grant/guidelines`) 는 `internal/`, `cmd/` 어디에도 참조가 없다
+  (grep 결과 0건) — **미구현 상태였으므로 삭제로 인한 실제 영향 없음**.
+  주의: WTS 카탈로그의 "삭제"는 JS 번들에서 해당 경로 참조가 사라졌다는 뜻일 뿐,
+  백엔드 엔드포인트 자체가 폐지됐다는 보장은 아니다 (프론트가 다른 화면/버전으로
+  이동했을 수 있음).
+- 신규 `rights/us/*/dividend-option` 클러스터는 `internal/`, `cmd/` 어디에도
+  없음 (미구현). 다만 같은 성격의 계좌 스코프 조회 패턴이 이미
+  `internal/client/dividends.go` (`/api/v1/dividends/accounts` 등, `accountKey`
+  헤더로 계좌 스코프하는 `getJSONWithAccountKey` 헬퍼)에 구현돼 있어, 신규
+  기능을 얹을 때 재사용 가능한 뼈대가 이미 있다.
+- 공식 spec 커버리지(`internal/official/`, `internal/mcp/operations.go`)는 이번
+  분석 대상이 아님 (spec 변경 없음).
+
+## 3. 분류
+
+**(b) 신규 기능 후보.** Breaking 위험 없음 — 삭제된 3개 경로는 모두 미구현
+상태였고, 카탈로그 삭제가 곧 백엔드 폐지를 의미하지도 않는다. 신규
+`rights/us/*/dividend-option` 5개 경로는 "미국주식 배당 재투자 옵션 조회/설정"
+기능으로 보이며, 전부 조회성(GET으로 추정, `categories`/`detail`/`account-give-type`
+이름 패턴) 이라 tossctl 의 "조회 전용 CLI/MCP" 성격에 맞는 개발 후보다.
+
+## 4. 권장 후속 조치
+
+1. `capture-workflow.md` 플레이북대로 `rights/us/categories`,
+   `rights/us/categories/dividend-option/detail`,
+   `rights/us/dividend-option/account-give-type` 3개를 실계좌로 라이브 프로브해
+   실제 메서드(GET 추정)/응답 스키마/계좌 스코프 필요 여부(`accountKey` 헤더)를
+   확인한다. 값은 화면에서만 확인하고 raw 캡처는 커밋하지 않는다.
+2. 응답 스키마가 확인되면 `internal/client/dividends.go` 패턴을 따라
+   `internal/client/rights.go` (가칭) 신설을 검토 — 미국주식 배당 옵션 조회를
+   `tossctl` 서브커맨드/MCP 오퍼레이션으로 노출할지는 실사용 시나리오(해당 옵션을
+   보유한 계좌가 있는지) 확인 후 사람이 결정한다.
+3. `/api/v2/dashboard/intelligences/all` 은 기존 v1 `candidate` 가 미구현 상태로
+   이동한 것뿐이라 우선순위 낮음 — 별도 조치 불필요.
+4. 삭제된 3개 경로(`dashboard/intelligences/all` v1, `stock-prices/after`,
+   `user-permissions/grant/guidelines`)는 미구현이었으므로 조치 불필요. 다음
+   `wts-monitor` 갱신에서 재등장하지 않는지만 관찰한다.


### PR DESCRIPTION
## 변경 사항

`wts-monitor` 봇의 주간 카탈로그 갱신(`8037a62`)에서 관측된 경로 추가/삭제를 분석하고 `docs/reverse-engineering/change-analysis/2026-08-03.md` 를 새로 작성했다. 공식 Open API spec(`docs/migration/openapi.latest.json`)은 이번 26시간 관측 윈도우 내 변경이 없어 분석 대상에서 제외했다.

요약:
- 삭제된 3개 `candidate` 경로(`dashboard/intelligences/all` v1, `stock-prices/after`, `user-permissions/grant/guidelines`)는 `internal/`, `cmd/` 어디에도 미구현 상태였음을 grep 으로 확인 — breaking 위험 없음.
- 신규 `candidate` 경로 중 `rights/us/*/dividend-option` 클러스터(5개, 미국주식 배당 재투자 옵션 조회)를 개발 후보로 분류. 기존 `internal/client/dividends.go` 의 계좌 스코프 조회 패턴을 재사용할 수 있는 뼈대가 이미 있음.
- 분류: **(b) 신규 기능 후보** (breaking 위험 없음).

기존 코드는 수정하지 않았다 — 분석 문서 신규 작성뿐이며, 구현 여부는 사람이 판단한다.

## 영향 범위

- [x] 문서

## 테스트

- [ ] `make test` 통과 (문서 전용 변경이라 해당 없음)
- [x] 수동 확인 완료 (grep 기반 커버리지 대조, 라이브 API 호출 없음)

## 체크리스트

- [x] 기존 동작을 깨뜨리지 않음
- [ ] 거래 관련 변경인 경우 안전장치(config gate, confirm token 등) 유지 확인 (해당 없음)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SqYRCshURwsPxMXPJWdaez)_