### PR TITLE
docs(re): 스크리너 필터 어휘 번들 스크랩 실패 기록

### DIFF
--- a/docs/reverse-engineering/capture-workflow.md
+++ b/docs/reverse-engineering/capture-workflow.md
@@ -329,6 +329,45 @@ jq -r '.endpoints["/api/v3/stock-prices"].observed' docs/reverse-engineering/wts
 부르는 것과 전용 페이지가 부르는 것은 다르다. 번들에서 `href:"/..."` 로 링크된 화면을 찾아
 그쪽 네트워크를 본다.
 
+### 스크리너 필터 어휘 — 번들 스크랩은 실패했다 (2026-08-04)
+
+README 는 필터 어휘(`배당_수익률` 같은 한글 id)가 "토스 번들에만 있어 공개돼 있지
+않다" 고 적어뒀다. 번들에서 뽑아 카탈로그로 내보내려 했고 **실패했다. 재시도하지 말 것.**
+
+필터는 번들에 `new C({id:VAR, nation:[...], name, description, conditionMap})` 로
+선언돼 있고 한글 id 는 변수에 담겨 있다. 변수를 해석해 뽑아봤다:
+
+| 시도 | 프리셋 실제 id 와 일치 |
+|---|---|
+| 한글 문자열 변수만 매핑 | 14/17 (82%) — 미해결 변수 6개 |
+| ASCII 식별자까지 매핑 확대 | **10/17 (58%)** — 변수는 풀렸는데 **틀린 문자열**에 붙음 |
+
+넓힐수록 나빠진 이유는 이 문서가 위에서 이미 경고한 것이다 — **minified 변수명은
+청크마다 재사용된다.** 같은 `ea` 가 다른 청크에서 다른 문자열이라, 정적 해석은
+구조적으로 신뢰할 수 없다.
+
+**신뢰할 수 있는 출처는 프리셋이다.** `market screener --output json` 이 각 프리셋의
+`filters` 배열을 그대로 내보낸다(v0.29.0). 거기 든 id 는 서버가 준 것이라 확실하다.
+
+#### 대신 확실히 알아낸 호출 시그니처
+
+번들의 **호출부**(변수가 아니라 리터럴 경로)는 신뢰할 수 있다. 호스트는 전부 CERT:
+
+```
+POST /api/v1/screener/filters/base   {filterId, nation}   → basedAt
+POST /api/v1/screener/filters/range  {filterId, nation}   (400 — 바디 미확정)
+POST /api/v1/screener/screen/count   []                   (400 — 바디 미확정)
+GET  /api/v1/screener/presets/user?useCustom=true         → 사용자 저장 프리셋
+GET  /api/v2/screener/presets/common?useCustom=true       (구현됨)
+POST /api/v2/screener/screen                              (구현됨)
+```
+
+`filters/base` 는 `{filterId:"배당_수익률", nation:"kr"}` 로 보내면 파싱을 통과해
+도메인 에러(`screener.bad-request.based-at`)가 난다 — **바디 형식은 맞다.**
+
+`presets/user` 는 이 계정에서 빈 배열이라 항목 구조를 못 봤다. 저장된 프리셋이 생기면
+그때 구현할 것.
+
 ### 막힌 방법 (다음에 시간 낭비 말 것)
 
 - **안드로이드 앱 트래픽 캡처**: 갤럭시(루팅X)에 mitmproxy 인증서까지 설치 성공해도,


### PR DESCRIPTION
README 가 *"필터 어휘(`배당_수익률` 같은 한글 id)는 토스 번들에만 있어 공개돼 있지 않다"* 고 적어둔 문제를 풀려다 **실패했다.** 다음 세션이 같은 벽을 다시 치지 않도록 근거를 남긴다.

## 측정

필터는 번들에 `new C({id:VAR, nation, name, description})` 로 선언되고 한글 id 는 변수에 담긴다. 변수를 해석해 뽑아본 결과, **프리셋의 실제 필터 id 를 정답으로 삼아** 채점했다:

| 시도 | 일치 |
|---|---|
| 한글 문자열 변수만 매핑 | 14/17 (82%) — 미해결 변수 6개 |
| ASCII 식별자까지 확대 | **10/17 (58%)** |

**넓힐수록 나빠졌다.** 변수는 풀렸는데 틀린 문자열에 붙었기 때문이다. 원인은 `capture-workflow.md` 가 이미 경고한 것 — **minified 변수명은 청크마다 재사용된다.**

틀린 필터 id 를 내보내면 사용자가 조립한 `--filter` 가 실패한다. 이번 세션에서 `rights/us` 목록·`lending/revenue` 를 "빈 배열이라 모델링 불가" 로 보류한 것과 같은 기준으로 **출시하지 않는다.**

**신뢰할 수 있는 출처는 프리셋이다.** `market screener --output json` 이 서버가 준 `filters` 배열을 그대로 낸다(v0.29.0). 11/11 정상 동작을 확인했다 — 회귀 없음.

## 확실히 얻은 것

번들의 **호출부**(변수가 아니라 리터럴 경로)는 신뢰할 수 있다. 호스트는 전부 **CERT**:

```
POST /api/v1/screener/filters/base   {filterId, nation}   → basedAt
POST /api/v1/screener/filters/range  {filterId, nation}   (400 — 바디 미확정)
POST /api/v1/screener/screen/count   []                   (400 — 바디 미확정)
GET  /api/v1/screener/presets/user?useCustom=true
```

`filters/base` 에 `{filterId:"배당_수익률", nation:"kr"}` 를 보내면 파싱을 통과해 도메인 에러(`screener.bad-request.based-at`)가 난다 — **바디 형식이 맞다는 증거**다.

## 트리거

이슈 #141 에 체크박스로 기록. `presets/user` 는 이 계정에서 빈 배열이라 항목 구조를 못 봤다.

문서만 추가한다. 코드 변경 없음.