### PR TITLE
docs(readme): 신규 6개 기능 en 표·양쪽 커맨드 레퍼런스 동기화

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -8,7 +8,7 @@
   <h1>tossinvest-cli</h1>
   <p><strong>The most flexible way to connect Toss Securities. Via CLI, via MCP server, from any AI agent — 100% of the official API, plus the features only the web app had.</strong></p>
   <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot — any AI agent drives Toss Securities accounts, quotes, and trades through one <code>tossctl</code>. <strong>Attach it as an MCP server (<code>tossctl mcp</code>) or run it by hand</strong>, <strong>with no key at all — or auto-routed through the official path when you connect one.</strong></p>
-  <p><sub>Investor flows · market indices · AI signals · screener · watchlist management · transaction ledger · real-time push · fractional orders · dry-run preview — 24 WTS-only features, and <strong>100% of the official Open API's coverage, included too.</strong> <a href="#support-scope">Full comparison ↓</a></sub></p>
+  <p><sub>Investor flows · market indices · AI signals · screener · watchlist management · transaction ledger · real-time push · fractional orders · dry-run preview — 39 WTS-only features, and <strong>100% of the official Open API's coverage, included too.</strong> <a href="#support-scope">Full comparison ↓</a></sub></p>
   <p><sub><em>An unofficial Toss Securities CLI for AI agents. Auto-routes through the official OAuth path when you connect an official key.</em></sub></p>
 </div>
 
@@ -142,7 +142,7 @@ Waiting for approval in the Toss app on your phone...
 ## Support Scope
 
 > **tossctl covers 100% of the official Toss Open API's read & trade coverage — and goes beyond.**
-> It maps to every endpoint in the official [Open API docs](https://developers.tossinvest.com/docs) (accounts, holdings, quotes, orderbook, ticks, candles, price limits, sellable quantity, commissions, orders, …), and adds investor flows, market indices, AI signals, screener, watchlist management, transaction ledger, real-time push, fractional orders, dry-run preview, and more — **24 features that aren't in the official API are tossctl-only.**
+> It maps to every endpoint in the official [Open API docs](https://developers.tossinvest.com/docs) (accounts, holdings, quotes, orderbook, ticks, candles, price limits, sellable quantity, commissions, orders, …), and adds investor flows, market indices, AI signals, screener, watchlist management, transaction ledger, real-time push, fractional orders, dry-run preview, and more — **39 features that aren't in the official API are tossctl-only.**
 
 <p align="center">
   <img src="docs/assets/api-comparison.en.svg" alt="tossctl vs official Open API (upcoming) coverage — tossctl is a superset" width="900" />
@@ -194,6 +194,12 @@ The Toss Securities official Open API is currently **rolling out in stages to pr
 | **🆕 Realized profit by period** | `profit summary --type sales\|dividend\|lending\|account-interest [--from --to]` (one category's earned amount, return rate, purchase basis in KRW/USD) | ❌ | ✅ |
 | **🆕 Per-stock daily realized profit** | `profit daily [--from --to] [--currency KRW\|USD]` (symbol · quantity · P/L · rate · sell/buy amounts, every page merged — CSV for tax prep) | ❌ | ✅ |
 | **🆕 Overseas transfer income (tax)** | `tax overseas --year YYYY` (capital-gains filing: rate · deduction · per-stock P/L) | ❌ | ✅ |
+| **Toss Prime status & benefits** | `account prime` (fee/interest across three tiers: standard, Prime, your rate) | ❌ | ✅ |
+| **🆕 Deposit interest (예탁금 이용료)** | `account interest --year YYYY` (per payment: pre-tax · tax · net · accrual period · estimated flag) | ❌ | ✅ |
+| **🆕 Commission schedule** | `account commission` (KR/US equity rates, US options per-contract fee, reduced-rate status) | ❌ | ✅ |
+| **🆕 Order funding gap** | `order funding` (whether buying is possible now · deposit needed · exchange needed) | ❌ | ✅ |
+| **🆕 US options trading hours** | `market option-hours` (previous · today · next business-day sessions) | ❌ | ✅ |
+| **🆕 Popular community lounges** | `community boards` (lounges by follower count · comment counts · joined) | ❌ | ✅ |
 | **Expected lending income** | `lending expected` (projected share-lending income: monthly/yearly USD + per-stock) | ❌ | ✅ |
 | **Community rankings** | `community rankings --type influencer\|profit\|followers` | ❌ | ✅ |
 | **Sector movements** | `market sectors [id]` (industry tree, 1d·1m·1y returns) | ❌ | ✅ |
@@ -215,6 +221,7 @@ tossctl opens even these up, via backend APIs callable with a web session.
 
 | Feature | Command | Mobile app | Web (WTS) | tossctl |
 |---------|---------|:--:|:--:|:--:|
+| **🆕 RIA tax-saving report** | `tax ria` (overseas capital-gains saving account: tax before/after deduction · saving · weighted quarterly P/L · sell limit) | ✅ | ❌ (no UI) | ✅ (read) |
 | **🆕 Stock accumulation plans** | `accumulate list`, `accumulate status <symbol>` (recurring auto-buy: Active/Paused · amount/frequency · rounds) | ✅ (settings UI) | ❌ (no UI) | ✅ (read) |
 | **🆕 US dividend payout mode** | the «미국 배당» block in `account detail` (`CASH` paid out / `STOCK` reinvested + last change date) | ✅ (settings UI) | ❌ (no UI) | ✅ (read) |
 
@@ -580,6 +587,12 @@ tossctl portfolio allocation
 tossctl portfolio dividends [--year YYYY] [--by-payment-date]
 tossctl profit                                   # cumulative realized profit (by category)
 tossctl tax overseas [--year YYYY]               # overseas transfer income (tax)
+tossctl tax ria                                  # RIA tax-saving report (mobile-app-only)
+tossctl account interest [--year YYYY]           # deposit interest, per payment
+tossctl account commission                       # commission schedule per market
+tossctl order funding                            # buyable? deposit/exchange still needed
+tossctl market option-hours                      # US options business days
+tossctl community boards                         # popular lounges by followers
 tossctl accumulate list|status <symbol>          # stock accumulation (mobile-app-only)
 tossctl market investors|earnings|briefing|sectors|themes|index|ranking|signals
 tossctl community rankings --type influencer|profit|followers

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <h1>tossinvest-cli</h1>
   <p><strong>토스증권에 연결하는 가장 유연한 방법. CLI 로, MCP 서버로, 어떤 AI 에이전트로든 — 공식 API는 물론 웹앱에만 있던 기능까지 하나로.</strong></p>
   <p>Claude Code · Codex · Gemini · Cursor · GitHub Copilot — 어떤 AI 에이전트로든 <code>tossctl</code> 하나로 토스증권 계좌·시세·거래를 다룹니다. <strong>MCP 서버(<code>tossctl mcp</code>)로 붙이거나 터미널에서 직접</strong>, <strong>공식 키 없이 바로 또는 연결 시 자동 라우팅.</strong></p>
-  <p><sub>수급 · 시장지수 · AI 시그널 · 조건검색 · 관심종목 관리 · 거래내역 ledger · 실시간 푸시 · 원화 소수점 주문 · dry-run preview 등 WTS 전용 기능 24가지 — <strong>공식 Open API 지원 범위도 물론 100% 포함합니다.</strong> <a href="#지원-범위">전체 비교표 ↓</a></sub></p>
+  <p><sub>수급 · 시장지수 · AI 시그널 · 조건검색 · 관심종목 관리 · 거래내역 ledger · 실시간 푸시 · 원화 소수점 주문 · dry-run preview 등 WTS 전용 기능 39가지 — <strong>공식 Open API 지원 범위도 물론 100% 포함합니다.</strong> <a href="#지원-범위">전체 비교표 ↓</a></sub></p>
   <p><sub><em>The most flexible way to connect Toss Securities — via CLI, via MCP, from any AI agent. 100% of the official Open API, plus 24 features only the web app had.</em></sub></p>
 </div>
 
@@ -186,7 +186,7 @@ Waiting for approval in the Toss app on your phone...
 ## 지원 범위
 
 > **tossctl 은 토스 공식 Open API 의 조회·거래 범위를 100% 커버하고, 그 너머까지 다룹니다.**
-> 공식 [Open API 문서](https://developers.tossinvest.com/docs)의 모든 엔드포인트(계좌·잔고·시세·호가·체결·캔들·상하한가·매도가능수량·수수료·주문 등)에 대응하며, 추가로 수급·시장지수·AI 시그널·조건검색·관심종목 관리·거래내역 ledger·실시간 푸시·원화 소수점 주문·dry-run preview 등 **24개가 공식 Open API에 없는 tossctl 고유 범위**입니다.
+> 공식 [Open API 문서](https://developers.tossinvest.com/docs)의 모든 엔드포인트(계좌·잔고·시세·호가·체결·캔들·상하한가·매도가능수량·수수료·주문 등)에 대응하며, 추가로 수급·시장지수·AI 시그널·조건검색·관심종목 관리·거래내역 ledger·실시간 푸시·원화 소수점 주문·dry-run preview 등 **39개가 공식 Open API에 없는 tossctl 고유 범위**입니다.
 
 <p align="center">
   <img src="docs/assets/api-comparison.svg" alt="tossctl vs 공식 Open API(예정) 커버리지 비교 — tossctl 이 상위집합" width="840" />
@@ -709,6 +709,12 @@ tossctl profit                                   # 누적 실현손익 (카테�
 tossctl profit summary --type sales --from 2026-01-01 --to 2026-07-25   # 기간별
 tossctl profit daily --from 2026-01-01 --to 2026-07-25 --output csv      # 종목별 (세금용)
 tossctl tax overseas [--year YYYY]               # 해외주식 양도소득 (세금)
+tossctl tax ria                                  # RIA 절세 리포트 (모바일 앱 전용)
+tossctl account interest [--year YYYY]           # 예탁금 이용료 (지급 건별)
+tossctl account commission                       # 계좌 수수료 체계
+tossctl order funding                            # 매수 가능 여부·필요 입금/환전액
+tossctl market option-hours                      # 미국 옵션 영업일·거래시간
+tossctl community boards                         # 인기 라운지 (팔로워 순)
 tossctl accumulate list|status <symbol>          # 주식모으기 (모바일 앱 전용)
 tossctl market investors|earnings|briefing|sectors|themes|index|ranking|signals
 tossctl community rankings --type influencer|profit|followers


### PR DESCRIPTION
릴리즈 전 문서 점검에서 누락 4종을 찾아 채웠다.

| 누락 | 내용 |
|---|---|
| en 비교표 | 신규 5개(`account interest`·`account commission`·`order funding`·`market option-hours`·`community boards`) 전부 빠져 있었다 |
| en 모바일 전용 표 | `tax ria` 누락 |
| ko/en 커맨드 레퍼런스 | 신규 6개 전부 누락 |
| en 비교표 (기존) | `account prime` 이 원래부터 빠져 있었다 — 이번 작업과 무관한 누락 |

이제 ko/en 모두 **비교표 36행 + 모바일 전용 3행 = 39행**으로 일치한다.

## 카운트 정정

헤더와 지원범위 문단의 "**24**가지 WTS 전용 기능" 은 오래전부터 실제 행 수와 어긋나 있었다(이번 6개를 빼도 33행). 실제 값 **39** 로 맞췄다.

## 검증

- 신규 6개 × (ko표·en표·ko레퍼런스·en레퍼런스) 4곳 모두 존재 확인
- `update_new_markers.py --check` 통과 (ko/en 각 17행 🆕)
- `make lint` · `go test ./...` 통과