### PR TITLE
캡처 도구 --click 지원, 문서 정정

### DIFF
--- a/docs/reverse-engineering/capture-workflow.md
+++ b/docs/reverse-engineering/capture-workflow.md
@@ -268,6 +268,24 @@ node tools/capture_post_bodies.mjs --sweep --get        # 파라미터·호스�
 (`probe`·`observed` 는 추출기가 다시 만들 수 없는 관측값이다 — 보존을 빼먹으면 주간
 모니터가 매주 월요일 지운다).
 
+#### 로드만으로 안 나는 요청은 `--click` (2026-08-04)
+
+스윕은 **페이지 로드 시점 요청만** 잡는다. 탭·모달·필터 편집 UI 는 눌러야 요청이 난다.
+
+```bash
+node tools/capture_post_bodies.mjs /screener --get --click "직접 만들기,필터추가" --click-wait 6
+```
+
+- 셀렉터가 아니라 **보이는 텍스트**로 찾는다. 토스 번들은 클래스명이 minified 라 셀렉터를
+  알아낼 방법이 없고, 텍스트는 화면에서 그대로 읽힌다.
+- 라벨을 모르면 아무 문자열이나 넘겨라 — 못 찾으면 **화면의 클릭 가능한 텍스트 후보를
+  출력**한다. 거기서 골라 다시 돌리면 된다.
+- 한계: 클릭으로 닿지 않는 조작(슬라이더 드래그 등)은 여전히 안 된다. 그 경우
+  `Input.dispatchMouseEvent` 로 내려가야 한다.
+
+**스윕은 대기가 짧아 무거운 화면을 놓친다.** 옵션 체인이 그랬다 — 스윕에선 안 잡히고
+단건 `--wait 14` 로만 잡혔다. 특정 화면을 노릴 땐 단건 모드에 대기를 넉넉히 준다.
+
 #### `observed` 가 호스트 문제를 없앤다
 
 토스는 `wts-api`/`wts-info-api`/`wts-cert-api` 를 섞어 쓰고 경로만 보고는 알 수 없다.
@@ -369,6 +387,22 @@ README 는 필터 어휘(`배당_수익률` 같은 한글 id)가 "토스 번들�
 #### 대신 확실히 알아낸 호출 시그니처
 
 번들의 **호출부**(변수가 아니라 리터럴 경로)는 신뢰할 수 있다. 호스트는 전부 CERT:
+
+**2026-08-04 진전** — `--click` 으로 필터 편집 UI 를 열어 `screen/count` 바디를 잡았다:
+
+```bash
+node tools/capture_post_bodies.mjs /screener --get --click "직접 만들기,필터추가,시가총액"
+```
+
+```
+POST /api/v1/screener/screen/count
+{"filters":[{"id":"<string>","conditions":[{"id":"<string>","type":"<string>","value":"<string>"}]}]}
+```
+
+`filters/base` 와 `filters/range` 는 **여전히 안 잡힌다.** 필터를 추가하고 다시 눌러도
+요청이 나지 않는다 — 값 범위 슬라이더를 실제로 조작해야 하는 것으로 보이고, 텍스트
+클릭으로는 닿지 않는다. 다음 시도는 CDP `Input.dispatchMouseEvent` 로 드래그를 흉내내는
+쪽이다.
 
 ```
 POST /api/v1/screener/filters/base   {filterId, nation}   → basedAt

--- a/docs/reverse-engineering/wts-endpoints.json
+++ b/docs/reverse-engineering/wts-endpoints.json
@@ -13,11 +13,11 @@
   "overrides": {
     "/api/v1/bond-infos": {
       "status": "candidate",
-      "note": "채권: 호출법은 확정됐으나 guid 출처가 보유 포지션뿐이라 응답 미관측. 트리거 = 계좌에 채권 보유 발생"
+      "note": "채권: 파라미터 확정 — GET ?guid= (INFO). guid 출처가 보유 포지션뿐이라 응답 미관측. 이슈 #143, 트리거 = 계좌에 채권 보유 발생"
     },
     "/api/v1/bond-infos/simple": {
       "status": "candidate",
-      "note": "채권: 호출법은 확정됐으나 guid 출처가 보유 포지션뿐이라 응답 미관측. 트리거 = 계좌에 채권 보유 발생"
+      "note": "채권 목록: GET ?guids= (복수, INFO). 이슈 #143 과 같은 트리거"
     },
     "/api/v1/usa-bond/receipt/tax/zero-coupon-discount": {
       "status": "candidate",
@@ -146,6 +146,18 @@
     "/api/v1/usa-market/get-option-biz-day-by-overtime": {
       "status": "candidate",
       "note": "옵션 영업일 (INFO, GET ?overtimeFlag=). market option-hours 와 중복"
+    },
+    "/api/v1/dashboard/common/stocks/mini-chart": {
+      "status": "candidate",
+      "note": "다종목 미니차트 (CERT, POST {codes:[]}, 1일 10분봉). 200 확인 2026-08-04. quote batch --chart 가 종목마다 GetChart 를 N번 부르는 걸 1요청으로 줄일 수 있으나, 측정된 성능 문제가 없어 보류 — v3/stock-prices 와 같은 판단"
+    },
+    "/api/v1/dashboard/asset/sections/all": {
+      "status": "candidate",
+      "note": "thin: sections 빈 배열 (CERT, POST {types}). 200 이지만 내용 없음 (2026-08-04)"
+    },
+    "/api/v2/dashboard/intelligences/all": {
+      "status": "candidate",
+      "note": "POST {types, variable}. types 어휘 미상으로 400 (2026-08-04)"
     }
   },
   "endpoints": {
@@ -1660,7 +1672,7 @@
         "host": "wts-info-api",
         "query": [],
         "body": [],
-        "at": "2026-08-03"
+        "at": "2026-08-04"
       }
     },
     "/api/v1/dashboard/wts/overview/ai-signal-home/latest": {

--- a/tools/capture_post_bodies.mjs
+++ b/tools/capture_post_bodies.mjs
@@ -20,6 +20,12 @@
 //   node tools/capture_post_bodies.mjs <path> --wait 8   # 대기 초
 //   node tools/capture_post_bodies.mjs <path> --all      # 텔레메트리까지 포함
 //   node tools/capture_post_bodies.mjs <path> --get      # GET 도 (조회 기능 발굴용)
+//   node tools/capture_post_bodies.mjs <path> --click "필터,적용"   # 로드 뒤 눌러본다
+//   node tools/capture_post_bodies.mjs <path> --click "필터" --click-wait 6
+//
+//   --click 은 **보이는 텍스트**로 요소를 찾는다(셀렉터 아님). 토스 번들은 클래스명이
+//   minified 라 셀렉터를 알 방법이 없고, 텍스트는 화면에서 그대로 읽힌다. 탭·모달·필터
+//   편집 UI 처럼 눌러야 요청이 나는 화면이 이걸로 열린다.
 //
 //   # 스윕: 여러 라우트를 돌며 엔드포인트별 **파라미터 키**를 카탈로그에 기록한다.
 //   # `probe_candidates.py` 가 needs-params 로 분류한 것들의 파라미터 이름을 알아내는 용도.
@@ -45,6 +51,10 @@ const flagValue = (name) => {
   return i >= 0 ? args[i + 1] : undefined;
 };
 const waitSec = Number(flagValue("--wait")) || 6;
+// 로드 뒤 눌러볼 요소들의 **보이는 텍스트**(콤마 구분). 페이지 로드로는 안 나는
+// 요청(탭·모달·필터 편집 UI)을 잡을 때 쓴다.
+const clickLabels = (flagValue("--click") || "").split(",").map((s) => s.trim()).filter(Boolean);
+const clickWaitSec = Number(flagValue("--click-wait")) || 4;
 const keepNoise = args.includes("--all");
 // 기본은 non-GET(바디가 있는 것)만. 조회 기능을 발굴할 땐 GET 도 봐야 한다.
 const withGet = args.includes("--get");
@@ -215,11 +225,46 @@ const { sessionId } = await send("Target.attachToTarget", { targetId, flatten: t
 await send("Network.enable", {}, sessionId);              // 내비게이션 '전에'
 await send("Network.setCookies", { cookies: loadCookies() }, sessionId);
 await send("Page.enable", {}, sessionId);
+await send("Runtime.enable", {}, sessionId);   // --click 의 Runtime.evaluate 용
+// 페이지 로드만으로는 안 나는 요청이 있다 — 탭·모달·필터 편집 UI 는 눌러야 뜬다.
+// 셀렉터가 아니라 **보이는 텍스트**로 찾는다: 토스 번들은 클래스명이 minified 라
+// 셀렉터를 알아낼 방법이 없고, 텍스트는 화면에서 그대로 읽힌다.
+const clickAfterLoad = async () => {
+  for (const label of clickLabels) {
+    const expr = `(() => {
+      const wanted = ${JSON.stringify(label)};
+      const el = [...document.querySelectorAll('button,a,[role="button"],[role="tab"],li,span,div')]
+        .filter((e) => e.offsetParent !== null)
+        .find((e) => e.textContent.trim() === wanted);
+      if (!el) {
+        // 못 찾았으면 후보를 돌려준다. 라벨을 모르는 채로 재시도를 반복하는 게
+        // 이 도구를 쓸 때 가장 많이 낭비되는 시간이다.
+        const cands = [...document.querySelectorAll('button,[role="button"],[role="tab"],a')]
+          .filter((e) => e.offsetParent !== null)
+          .map((e) => e.textContent.trim())
+          .filter((t) => t && t.length <= 20);
+        return "miss:" + [...new Set(cands)].slice(0, 30).join(" | ");
+      }
+      el.click();
+      return "hit";
+    })()`;
+    const res = await send("Runtime.evaluate", { expression: expr, returnByValue: true }, sessionId);
+    const outcome = String(res?.result?.value ?? "");
+    if (outcome === "hit") {
+      process.stderr.write(`  · 클릭 "${label}": 성공\n`);
+    } else {
+      process.stderr.write(`  · 클릭 "${label}": 요소 없음\n    후보: ${outcome.slice(5)}\n`);
+    }
+    await sleep(clickWaitSec * 1000);
+  }
+};
+
 const routes = sweep ? sweepRoutes : [target];
 for (const route of routes) {
   if (sweep) process.stderr.write(`  → ${route}\n`);
   await send("Page.navigate", { url: ORIGIN + route }, sessionId);
   await sleep(waitSec * 1000);
+  if (clickLabels.length) await clickAfterLoad();
 }
 
 // 인라인으로 안 온 바디를 requestId 로 회수한다.


### PR DESCRIPTION
릴리즈용 기능이 아니라 발굴 도구·문서 개선입니다. `CHANGELOG` 항목 없음.

## `--click` — 로드만으로 안 나는 요청 잡기

스윕은 **페이지 로드 시점 요청만** 잡습니다. 탭·모달·필터 편집 UI는 눌러야 요청이 나는데 그걸 열 방법이 없었습니다.

```bash
node tools/capture_post_bodies.mjs /screener --get --click "직접 만들기,필터추가" --click-wait 6
```

- **셀렉터가 아니라 보이는 텍스트**로 찾습니다. 토스 번들은 클래스명이 minified라 셀렉터를 알아낼 방법이 없고, 텍스트는 화면에서 그대로 읽힙니다.
- 못 찾으면 **화면의 클릭 가능한 텍스트 후보를 출력**합니다. 라벨을 모르는 채 재시도를 반복하는 게 이 도구를 쓸 때 가장 많이 낭비되는 시간이었습니다.

### 이걸로 얻은 것 (이슈 #141)

`screener/screen/count`의 바디 구조를 잡았습니다:

```
{"filters":[{"id":"...","conditions":[{"id":"...","type":"...","value":"..."}]}]}
```

`filters/base`·`filters/range`는 **여전히 안 납니다.** 필터를 추가하고 다시 눌러도 요청이 나지 않아, 값 범위 슬라이더를 실제로 조작해야 하는 것으로 보입니다. 텍스트 클릭으로는 닿지 않고 다음은 `Input.dispatchMouseEvent`입니다.

## 부수 발견

**스윕은 대기가 짧아 무거운 화면을 놓칩니다.** 옵션 체인이 그랬습니다 — 스윕에선 안 잡히고 단건 `--wait 14`로만 잡혔습니다. 문서에 적었습니다.

## CLAUDE.md 정정

🆕 마커 설명이 **틀려 있었습니다.** "README 각 행에 `<!--since:...-->`"라고 적혀 있는데 실제 단일 진실 소스는 `update_new_markers.py`의 `FEATURE_DATES` 딕셔너리입니다. 주석을 손으로 넣었다가 스크립트가 지우는 걸 겪었습니다.

릴리즈 절도 실제로 필요한 순서로 갱신했습니다 — 웹사이트 changelog 동기화가 별도 단계라는 점, 라이브 확인 4곳, 그리고 **빈도는 하루 1회까지**(기능을 모아서 크게 냄).

## 카탈로그

라이브로 확인한 판정 5건을 `overrides`에 추가했습니다.

- `mini-chart` — 200이지만 `quote batch --chart` 최적화용일 뿐이고 측정된 성능 문제가 없어 보류 (`v3/stock-prices`와 같은 판단)
- `dashboard/asset/sections/all` — 200이지만 `sections` 빈 배열
- `bond-infos` — 파라미터 확정(`?guid=`, 복수는 `?guids=`). 이슈 #143의 트리거는 그대로 "계좌에 채권 보유 발생"