### PR TITLE
docs(analysis): WTS 카탈로그 변경 분석 (2026-08-10)

### DIFF
--- a/docs/reverse-engineering/change-analysis/2026-08-10.md
+++ b/docs/reverse-engineering/change-analysis/2026-08-10.md
@@ -43,15 +43,20 @@ WTS 카탈로그(`wts-endpoints.json`) 주간 갱신(`8e9a351`, `wts-monitor` �
 (오늘 main 에 코드 커밋 없음), 대상 엔드포인트가 실제로 사라지거나 동작이 바뀐 정황도
 없다 — 즉 tossctl 사용자에게 영향은 없다.
 
-원인은 카탈로그 생성 로직 쪽으로 보인다. `tics/rankings` 와
-`usa-market/get-option-biz-day-by-overtime` 두 건은 `overrides` 에도
-`status: candidate` 로 박혀 있는데(각각 "중복: market themes 로 이미 구현됨",
-"market option-hours 와 중복" 이라는 노트와 함께), 그 노트 자체가 구현되어 있다는
-사실을 전제로 쓰여 있어 `status` 값과 노트 내용이 모순된다. 나머지 9건은 `overrides`
-에도 없으므로 이번 빌드(build_id 변경, chunk_count 81→80)에서 스캐너가 특정 JS 청크를
-못 찾자 "implemented" 판정 근거를 잃고 기본값(candidate)으로 되돌아간 것으로 보인다 —
-즉 **번들 스캔 기반 자동 판정의 false negative**이며, 우리 쪽 구현 상태를 반영하지
-않는다.
+### 원인 (#160 에서 확정)
+
+처음에는 번들 스캔의 false negative 로 봤으나, **스캐너는 정상 동작이었다.** 원인은
+구현 사실을 *보존되지 않는 자리*에 쓴 것이다.
+
+`classify()` 는 `overrides` → `IMPLEMENTED` 패턴 → 자동 분류 순으로 본다. 2026-08-04~07
+에 신규 구현을 반영하면서 카탈로그의 `endpoints[].status` 를 직접 고쳤는데, 그 자리는
+재생성 때 자동 분류 결과로 덮인다. 보존하려면 `tools/wts_endpoints.py` 의 `IMPLEMENTED`
+패턴에 넣어야 한다. build_id 가 바뀐 건 재생성을 촉발한 계기일 뿐이다.
+
+두 건은 원인이 하나 더 있었다. `tics/rankings` 와
+`usa-market/get-option-biz-day-by-overtime` 은 `overrides` 가 `status: candidate` 로
+고정하는데 노트는 "이미 구현됨" 이라 **서로 모순**이었다. override 는 패턴보다 우선하므로
+패턴을 추가해도 먹지 않는다.
 
 ## 3. 분류
 
@@ -62,9 +67,11 @@ WTS 카탈로그(`wts-endpoints.json`) 주간 갱신(`8e9a351`, `wts-monitor` �
 
 ## 4. 권장 후속 조치
 
-1. `wts-monitor` 의 `implemented` 판정 로직을 점검 — 번들 청크 존재 여부만으로
-   판정한다면, 이미 우리 코드에 구현이 확인된 엔드포인트는 `internal/client/` grep
-   결과와 대조해 override 로 고정하는 편이 안전하다(번들이 바뀔 때마다 흔들리지 않도록).
-2. `overrides` 의 `tics/rankings`, `usa-market/get-option-biz-day-by-overtime` 두 건은
-   노트와 상태값이 모순되므로 `status: implemented` 로 정정을 검토.
-3. 위 11건에 대해 코드 변경은 불필요 — 이번 PR 은 이 문서 하나만 추가한다.
+**#160 에서 전부 처리됐다.**
+
+1. 11건을 `IMPLEMENTED` 패턴에 등록 — 재생성 두 번 돌려 `implemented` 112 유지 확인.
+2. 모순된 override 2건을 `status: implemented` 로 정정.
+3. `CLAUDE.md` 에 "구현 반영은 `IMPLEMENTED` 패턴, `endpoints[].status` 직접 수정 금지"
+   를 명시 — 이 사고의 재발 경로를 막는다.
+
+엔드포인트 동작 자체는 변한 게 없으므로 tossctl 코드 변경은 없었다.

--- a/docs/reverse-engineering/change-analysis/2026-08-10.md
+++ b/docs/reverse-engineering/change-analysis/2026-08-10.md
@@ -1,0 +1,70 @@
+# API 변경 분석 — 2026-08-10
+
+## 0. 스코프
+
+WTS 카탈로그(`wts-endpoints.json`) 주간 갱신(`8e9a351`, `wts-monitor` 봇)만 다룬다.
+공식 Open API spec 은 이번 26시간 내 갱신 없음(마지막 갱신은 2026-08-07, 1.2.13).
+
+## 1. 변경 요약
+
+`build_id` `-owfs18fvEJHIHRdmooMq` → `_9vWo9cLoNnz5P1aQeayp`, `chunk_count` 81 → 80.
+
+경로 집합 자체는 **불변**이다 — 추가(➕) 0건, 삭제(➖) 0건. `total` 도 988로 그대로.
+
+대신 두 종류의 실질 변경이 있다:
+
+1. **연구 노트 추가** — 이전 세션들의 라이브 캡처·프로브 결과가 각 항목에 `note` 로
+   정리됨(중복 발견, thin 응답, 파라미터 미상 등). 순수 문서화, 조치 불필요.
+2. **`status: implemented → candidate` 플립 11건** — `counts.implemented` 112 → 101,
+   `counts.candidate` 366 → 377 로 정확히 대응.
+
+2번이 이번 분석의 핵심이다.
+
+## 2. `implemented → candidate` 플립 11건 대조
+
+전부 `internal/client/`(및 대다수는 `internal/ops/wts_operations.go`)에 실제로
+구현되어 있는지 grep 으로 확인했다.
+
+| 경로 | tossctl 구현 위치 | 실제 구현 여부 |
+|---|---|---|
+| `/api/v1/crypto-prices` | `internal/client/crypto.go` | ✅ 구현됨 |
+| `/api/v1/dashboard/wts/overview/signals` | `internal/client/insights.go` | ✅ 구현됨 |
+| `/api/v1/margin/cert/notice/receivable` | `internal/client/insights.go` | ✅ 구현됨 |
+| `/api/v1/option-both-chain/get-all` | `internal/client/options.go` | ✅ 구현됨 |
+| `/api/v1/option-maturity-date/get-all` | `internal/client/options.go` | ✅ 구현됨 |
+| `/api/v1/screener/filters/base` | `internal/client/screener_filters.go` | ✅ 구현됨 |
+| `/api/v1/screener/filters/range` | `internal/client/screener_filters.go` | ✅ 구현됨 |
+| `/api/v1/search-all/wts-auto-complete` | `internal/client/insights.go` | ✅ 구현됨 |
+| `/api/v1/tics/rankings` | `internal/client/marketdata.go` (`GetThemeRankings`) | ✅ 구현됨 — URL 리터럴 정확히 일치 |
+| `/api/v1/usa-market/get-option-biz-day-by-overtime` | `internal/client/option_hours.go` | ✅ 구현됨 — URL 리터럴 정확히 일치 |
+| `/api/v2/reasoning/stocks` | `internal/client/insights.go` | ✅ 구현됨 |
+
+**11건 전부 코드상 구현이 그대로 살아있다.** Go 소스는 이번 주기에 전혀 손대지 않았고
+(오늘 main 에 코드 커밋 없음), 대상 엔드포인트가 실제로 사라지거나 동작이 바뀐 정황도
+없다 — 즉 tossctl 사용자에게 영향은 없다.
+
+원인은 카탈로그 생성 로직 쪽으로 보인다. `tics/rankings` 와
+`usa-market/get-option-biz-day-by-overtime` 두 건은 `overrides` 에도
+`status: candidate` 로 박혀 있는데(각각 "중복: market themes 로 이미 구현됨",
+"market option-hours 와 중복" 이라는 노트와 함께), 그 노트 자체가 구현되어 있다는
+사실을 전제로 쓰여 있어 `status` 값과 노트 내용이 모순된다. 나머지 9건은 `overrides`
+에도 없으므로 이번 빌드(build_id 변경, chunk_count 81→80)에서 스캐너가 특정 JS 청크를
+못 찾자 "implemented" 판정 근거를 잃고 기본값(candidate)으로 되돌아간 것으로 보인다 —
+즉 **번들 스캔 기반 자동 판정의 false negative**이며, 우리 쪽 구현 상태를 반영하지
+않는다.
+
+## 3. 분류
+
+**(a) no-op** — tossctl 코드·사용자 영향 없음. 신규 개발 후보(b)도, breaking(c)도 아니다.
+
+다만 카탈로그가 지금 부정확한 상태로 남아 있으면, 다음 분석 세션이 "미구현"으로 오인해
+중복 작업을 검토할 위험이 있어 후속 조치를 권고한다.
+
+## 4. 권장 후속 조치
+
+1. `wts-monitor` 의 `implemented` 판정 로직을 점검 — 번들 청크 존재 여부만으로
+   판정한다면, 이미 우리 코드에 구현이 확인된 엔드포인트는 `internal/client/` grep
+   결과와 대조해 override 로 고정하는 편이 안전하다(번들이 바뀔 때마다 흔들리지 않도록).
+2. `overrides` 의 `tics/rankings`, `usa-market/get-option-biz-day-by-overtime` 두 건은
+   노트와 상태값이 모순되므로 `status: implemented` 로 정정을 검토.
+3. 위 11건에 대해 코드 변경은 불필요 — 이번 PR 은 이 문서 하나만 추가한다.


### PR DESCRIPTION
## 변경 사항

`wts-monitor` 봇의 주간 카탈로그 갱신(`8e9a351`)을 분석했다. 공식 Open API spec 은 이번 주기에 변경 없음(마지막 갱신 2026-08-07, 1.2.13).

경로 추가/삭제는 0건이지만 `status: implemented → candidate` 플립이 11건 있어, 각각을 `internal/client/` grep 으로 대조했다. **11건 전부 실제로는 구현되어 있음** — Go 소스는 이번 주기에 변경되지 않았고, tossctl 사용자 영향은 없다. 원인은 카탈로그 생성기의 번들 스캔 기반 `implemented` 판정이 이번 빌드(build_id 변경)에서 근거를 잃은 false negative 로 보인다.

분류: **(a) no-op** — 코드 변경 불필요. 다만 카탈로그 정확도 이슈이므로 후속 조치(스캐너 판정 로직 점검, overrides 2건 모순 정정)를 문서에 권고 사항으로 남겼다.

기존 코드는 건드리지 않았고 새 분석 문서 1개만 추가한다: `docs/reverse-engineering/change-analysis/2026-08-10.md`

## 영향 범위

- [ ] 조회 (읽기 전용)
- [ ] 거래 (mutation)
- [ ] 설치 / CI
- [x] 문서

## 테스트

- [ ] `make test` 통과
- [x] 수동 확인 완료 (문서 전용 변경, grep 대조로 구현 여부 확인)

## 체크리스트

- [x] 기존 동작을 깨뜨리지 않음
- [ ] 거래 관련 변경인 경우 안전장치(config gate, confirm token 등) 유지 확인