### PR TITLE
docs(analysis): API 변경 분석 2026-08-12 (조건주문 발동 세션 설명 보강)

### DIFF
--- a/docs/reverse-engineering/change-analysis/2026-08-12.md
+++ b/docs/reverse-engineering/change-analysis/2026-08-12.md
@@ -1,0 +1,64 @@
+# API 변경 분석 — 2026-08-12
+
+## 0. 스코프
+
+이번 관측 윈도우(최근 26시간)에는 `wts-monitor` 봇의 WTS 카탈로그
+(`docs/reverse-engineering/wts-endpoints.json`) 갱신이 없다.
+
+공식 Open API spec 관련 커밋은 2건이다.
+
+- `6386f11` (2026-08-12 11:00 UTC) — spec `1.2.13` → `1.2.14`,
+  `commissionRate` 표현 방식 변경.
+- `7628bd2` (2026-08-12 22:41 UTC) — 버전 범프 없음, `createConditionalOrder`
+  설명 텍스트만 갱신.
+
+**`6386f11`은 이미 분석·조치 완료된 상태다.** 같은 날 #163
+(`[breaking-risk] docs(analysis): API 변경 분석 2026-08-12`, 브랜치
+`analysis/api-change-20260812`)이 이 변경을 (c) breaking 위험으로
+분류해 분석 문서를 남겼고, 곧이어 #164
+(`수수료율 스케일 회귀 방어 (spec 1.2.14 breaking-risk)`, 브랜치
+`fix/commission-rate-scale`)가 회귀 테스트 추가와 주석/CSV 헤더 정정을
+포함한 대응을 제출했다. 두 PR 모두 현재 open 상태(머지 대기)다. 이 문서는
+같은 내용을 중복 분석하지 않고, **`6386f11` 이후에 발생해 아직 다루어지지
+않은 `7628bd2`만** 신규로 다룬다.
+
+## 1. 변경 요약 (`7628bd2`)
+
+`POST` 조건주문 생성 엔드포인트(`createConditionalOrder`)의
+`description`에 "발동 세션" 문단이 추가됐다.
+
+- 국내 주식 조건주문: KRX **정규장에서만** 발동.
+- 해외 주식 조건주문: 장 구분과 무관하게 **거래 가능한 모든 시간대**에 발동.
+
+`operationId`, 파라미터, 요청/응답 스키마 변경은 없다 — 순수 설명 텍스트
+보강.
+
+## 2. tossctl 커버리지 대조
+
+조건주문은 이미 구현돼 있다: `internal/official/conditional_writes.go`
+(생성), `internal/official/conditional_reads.go`(조회),
+`cmd/tossctl/order.go`(CLI 진입점), `internal/output/conditional.go`(출력).
+이번 변경은 스키마·파라미터가 아니라 설명 텍스트뿐이라 구현에 영향 없음.
+
+다만 "국내는 정규장 한정 발동 / 해외는 24시간 발동 가능"이라는 동작은
+현재 `cmd/tossctl/order.go`의 조건주문 관련 도움말이나 README 어디에도
+명시돼 있지 않다 — 사용자가 국내 종목에 정규장 밖에서 조건주문을 걸어놓고
+왜 발동 안 하는지 헷갈릴 수 있는 지점이라, 문서화하면 유용하다.
+
+## 3. 분류
+
+**(a) no-op.** 스키마/파라미터/`operationId` 변경 없음, 코드 조치 불필요.
+breaking 위험 없음.
+
+(`6386f11`의 breaking-risk 분류·조치는 #163/#164에서 이미 진행 중이므로
+이 문서의 분류 대상이 아니다.)
+
+## 4. 권장 후속 조치
+
+1. (우선순위 낮음) "국내 조건주문은 KRX 정규장에서만 발동, 해외는 24시간
+   발동 가능"이라는 내용을 `cmd/tossctl/order.go`의 조건주문 도움말 또는
+   README/문서에 반영할지는 사람이 판단한다 — 기능 변경이 아니므로 급하지
+   않음.
+2. `6386f11`(`commissionRate` 스케일 변경) 관련 후속 조치는 #163, #164를
+   참고 — 이 문서에서 별도로 제안하지 않는다.
+3. WTS 카탈로그는 이번 주기에 갱신이 없었으므로 별도 조치 없음.


### PR DESCRIPTION
## 요약

최근 26시간 공식 Open API spec 갱신 커밋 2건 중, `6386f11`(commissionRate 표현 방식 변경)은 이미 #163(분석)·#164(대응)에서 다루고 있어 중복 분석하지 않았다. 이 PR은 그 이후 커밋인 `7628bd2`(`createConditionalOrder` 설명에 "발동 세션" 문단 추가 — 국내 KRX 정규장 한정 발동 / 해외 24시간 발동)만 신규로 분석한다.

- `operationId`/파라미터/스키마 변경 없음 — 순수 설명 텍스트 보강.
- 조건주문은 `internal/official/conditional_writes.go`, `internal/official/conditional_reads.go`, `cmd/tossctl/order.go`, `internal/output/conditional.go`에 이미 구현돼 있고, 이번 변경은 구현에 영향 없음.
- 분류: **(a) no-op** — breaking 위험 없음, 코드 조치 불필요.
- WTS 카탈로그는 이번 주기에 갱신 없음.

## 변경 파일

`docs/reverse-engineering/change-analysis/2026-08-12.md` 신규 작성. 기존 코드 수정 없음.

## 후속 조치 (참고용, 급하지 않음)

"국내 조건주문은 정규장 한정 발동 / 해외는 24시간 발동"을 `order` 커맨드 도움말이나 README에 반영할지는 사람이 판단.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ng2MVTFRJg2pN9bcaQYAbb)_