### PR TITLE
fix(watchlist): watchlist add 실행 시 지정 그룹에 종목이 추가되지 않던 문제 수정

### DIFF
--- a/docs/reverse-engineering/rpc-catalog.md
+++ b/docs/reverse-engineering/rpc-catalog.md
@@ -96,8 +96,10 @@ This file is the source of truth for endpoint discovery. It should grow before t
 | `auth` | `POST` | `wts-cert-api.tossinvest.com` | `/api/v1/new-watchlists/groups` | 폴더 생성 | `{"name":"..."}` → `.result.{id,name,...}` | `watchlist group create` |
 | `auth` | `PATCH` | `wts-cert-api.tossinvest.com` | `/api/v1/new-watchlists/groups/{id}` | 폴더 리네임 | `{"name":"..."}` | `watchlist group rename` |
 | `auth` | `DELETE` | `wts-cert-api.tossinvest.com` | `/api/v1/new-watchlists/groups/{id}` | 폴더 삭제 | — | `watchlist group delete` |
-| `auth` | `POST` | `wts-cert-api.tossinvest.com` | `/api/v1/new-watchlists/items` | 종목 추가 | `{"watchlistId":id,"items":[{"code":"A005930","itemType":"STOCK"}]}` | `watchlist add` |
-| `auth` | `POST` | `wts-cert-api.tossinvest.com` | `/api/v1/new-watchlists/items/remove` | 종목 제거 | 위와 동일 | `watchlist remove` |
+| `auth` | `POST` | `wts-cert-api.tossinvest.com` | `/api/v1/new-watchlists/items` | 종목 추가 | `{"watchlistIds":[id],"items":[{"code":"...","itemType":"STOCK"}]}` | `watchlist add` |
+| `auth` | `POST` | `wts-cert-api.tossinvest.com` | `/api/v1/new-watchlists/items/remove` | 종목 제거 | `{"watchlistId":id,"items":[{"code":"...","itemType":"STOCK"}]}` | `watchlist remove` |
+
+> **주의**: add 는 `watchlistIds` (복수, `[]int64`), remove 는 `watchlistId` (단수, `int64`). 서버 API 가 비일관적이지만 이것이 실제 스펙이다 (브라우저 DevTools 캡처로 확인).
 
 ## Account, Portfolio, Orders, Watchlist
 

--- a/internal/client/watchlist_manage.go
+++ b/internal/client/watchlist_manage.go
@@ -100,17 +100,23 @@ func (c *Client) DeleteWatchlistGroup(ctx context.Context, groupID int64) error 
 	return c.mutateJSON(ctx, http.MethodDelete, url, nil, nil)
 }
 
+type watchlistItemSpec struct {
+	Code     string `json:"code"`
+	ItemType string `json:"itemType"`
+}
+
+type addWatchlistItemsRequest struct {
+	WatchlistIDs []int64             `json:"watchlistIds"`
+	Items        []watchlistItemSpec `json:"items"`
+}
+
+type removeWatchlistItemsRequest struct {
+	WatchlistID int64               `json:"watchlistId"`
+	Items       []watchlistItemSpec `json:"items"`
+}
+
 // AddWatchlistItem adds a stock to a folder (symbol or product code).
 func (c *Client) AddWatchlistItem(ctx context.Context, groupID int64, symbol string) error {
-	return c.watchlistItemOp(ctx, "/items", groupID, symbol)
-}
-
-// RemoveWatchlistItem removes a stock from a folder.
-func (c *Client) RemoveWatchlistItem(ctx context.Context, groupID int64, symbol string) error {
-	return c.watchlistItemOp(ctx, "/items/remove", groupID, symbol)
-}
-
-func (c *Client) watchlistItemOp(ctx context.Context, path string, groupID int64, symbol string) error {
 	if err := c.requireSession(); err != nil {
 		return err
 	}
@@ -118,11 +124,27 @@ func (c *Client) watchlistItemOp(ctx context.Context, path string, groupID int64
 	if err != nil {
 		return err
 	}
-	body, _ := json.Marshal(map[string]any{
-		"watchlistId": groupID,
-		"items":       []map[string]string{{"code": code, "itemType": "STOCK"}},
+	body, _ := json.Marshal(addWatchlistItemsRequest{
+		WatchlistIDs: []int64{groupID},
+		Items:        []watchlistItemSpec{{Code: code, ItemType: "STOCK"}},
 	})
-	return c.mutateJSON(ctx, http.MethodPost, c.certBaseURL+watchlistBase+path, body, nil)
+	return c.mutateJSON(ctx, http.MethodPost, c.certBaseURL+watchlistBase+"/items", body, nil)
+}
+
+// RemoveWatchlistItem removes a stock from a folder.
+func (c *Client) RemoveWatchlistItem(ctx context.Context, groupID int64, symbol string) error {
+	if err := c.requireSession(); err != nil {
+		return err
+	}
+	code, err := c.resolveProductCode(ctx, symbol)
+	if err != nil {
+		return err
+	}
+	body, _ := json.Marshal(removeWatchlistItemsRequest{
+		WatchlistID: groupID,
+		Items:       []watchlistItemSpec{{Code: code, ItemType: "STOCK"}},
+	})
+	return c.mutateJSON(ctx, http.MethodPost, c.certBaseURL+watchlistBase+"/items/remove", body, nil)
 }
 
 // mutateJSON issues a non-GET request with session auth (X-XSRF-TOKEN included

--- a/internal/client/watchlist_manage_test.go
+++ b/internal/client/watchlist_manage_test.go
@@ -16,6 +16,16 @@ import (
 func TestWatchlistMutationContract(t *testing.T) {
 	var gotMethod, gotPath, gotBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Respond to resolveProductCode lookup (POST /api/v2/search/stocks).
+		if r.Method == "POST" && r.URL.Path == "/api/v2/search/stocks" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"result": map[string]any{
+					"stocks": []map[string]string{{"stockCode": "US.AAPL", "stockName": "Apple Inc", "matchType": "SYMBOL"}},
+				},
+			})
+			return
+		}
 		gotMethod, gotPath = r.Method, r.URL.Path
 		b, _ := io.ReadAll(r.Body)
 		gotBody = string(b)
@@ -57,6 +67,45 @@ func TestWatchlistMutationContract(t *testing.T) {
 	}
 	if gotMethod != "DELETE" || gotPath != "/api/v1/new-watchlists/groups/123" {
 		t.Errorf("delete routing: %s %s", gotMethod, gotPath)
+	}
+
+	// add item → POST /items with watchlistIds (plural, array)
+	if err := c.AddWatchlistItem(context.Background(), 456, "AAPL"); err != nil {
+		t.Fatalf("add item: %v", err)
+	}
+	if gotMethod != "POST" || gotPath != "/api/v1/new-watchlists/items" {
+		t.Errorf("add routing: %s %s", gotMethod, gotPath)
+	}
+	var addBody map[string]any
+	_ = json.Unmarshal([]byte(gotBody), &addBody)
+	// watchlistIds must be present as an array (not watchlistId singular).
+	ids, ok := addBody["watchlistIds"].([]any)
+	if !ok || len(ids) != 1 {
+		t.Fatalf("add body: expected watchlistIds array with 1 element, got: %s", gotBody)
+	}
+	if int64(ids[0].(float64)) != 456 {
+		t.Errorf("add body: expected watchlistIds=[456], got: %s", gotBody)
+	}
+	if _, hasSingular := addBody["watchlistId"]; hasSingular {
+		t.Errorf("add body: must NOT contain singular watchlistId field, got: %s", gotBody)
+	}
+
+	// remove item → POST /items/remove with watchlistId (singular, number)
+	if err := c.RemoveWatchlistItem(context.Background(), 456, "AAPL"); err != nil {
+		t.Fatalf("remove item: %v", err)
+	}
+	if gotMethod != "POST" || gotPath != "/api/v1/new-watchlists/items/remove" {
+		t.Errorf("remove routing: %s %s", gotMethod, gotPath)
+	}
+	var rmBody map[string]any
+	_ = json.Unmarshal([]byte(gotBody), &rmBody)
+	// watchlistId must be present as a number (not watchlistIds plural).
+	wid, ok := rmBody["watchlistId"].(float64)
+	if !ok || int64(wid) != 456 {
+		t.Fatalf("remove body: expected watchlistId=456, got: %s", gotBody)
+	}
+	if _, hasPlural := rmBody["watchlistIds"]; hasPlural {
+		t.Errorf("remove body: must NOT contain plural watchlistIds field, got: %s", gotBody)
 	}
 }
 


### PR DESCRIPTION
Closes #176 

## 변경 사항

`watchlist add --group <id>` 실행 시 지정한 그룹에 종목이 추가되지 않고 매번 새 "기본" 그룹이 생성되던 버그를 수정합니다.

### 근본 원인

기존 코드가 add/remove 엔드포인트에 동일한 request body 필드명(`watchlistId`, 단수)을 사용했지만, 서버 API 스펙은 두 엔드포인트에서 서로 다른 필드명과 타입을 요구합니다:

| 엔드포인트 | 올바른 필드명 | 타입 | 기존 코드 |
|---|---|---|---|
| `POST /items` (종목 추가) | `watchlistIds` (복수) | `[]int64` | ❌ `watchlistId` (단수, `int64`) |
| `POST /items/remove` (종목 제거) | `watchlistId` (단수) | `int64` | ✅ `watchlistId` (단수, `int64`) |

서버가 add 엔드포인트에서 `watchlistId`(단수)를 인식하지 못해 기본 그룹을 자동 생성하는 폴백 동작을 수행했습니다. 에러 없이 200으로 응답했기 때문에 CLI 사용자는 정상 동작으로 인식했고, 반복 사용 시 그룹 최대 개수 초과로 `watchlist.too-many-lists` 400 에러가 발생하여 모든 watchlist 작업이 차단되었습니다.

### 핵심 수정 (`internal/client/watchlist_manage.go`)

- **엔드포인트별 전용 Request DTO 정의**:
  ```go
  type watchlistItemSpec struct {
      Code     string `json:"code"`
      ItemType string `json:"itemType"`
  }

  type addWatchlistItemsRequest struct {
      WatchlistIDs []int64             `json:"watchlistIds"`
      Items        []watchlistItemSpec `json:"items"`
  }

  type removeWatchlistItemsRequest struct {
      WatchlistID int64               `json:"watchlistId"`
      Items       []watchlistItemSpec `json:"items"`
  }
  ```
- **Add / Remove 전용 메서드로 분리**:
  - `AddWatchlistItem`: `addWatchlistItemsRequest`(`watchlistIds: []int64`)를 사용하여 `POST /items` 호출
  - `RemoveWatchlistItem`: `removeWatchlistItemsRequest`(`watchlistId: int64`)를 사용하여 `POST /items/remove` 호출
  - 불필요한 공통 헬퍼의 런타임 path 문자열 분기(`if path == "/items"`) 및 `map[string]any` 마샬링 제거

### 테스트 추가 (`internal/client/watchlist_manage_test.go`)

`TestWatchlistMutationContract`에 add/remove body contract 상호 배타적 검증 추가:
- add body에 `watchlistIds`(배열)가 존재하고 `watchlistId`(단수)가 **없는지** 검증
- remove body에 `watchlistId`(숫자)가 존재하고 `watchlistIds`(복수)가 **없는지** 검증
- `resolveProductCode`에 필요한 `POST /api/v2/search/stocks` mock 응답 추가

### 문서 교정 (`docs/reverse-engineering/rpc-catalog.md`)

- add 엔드포인트 Body 컬럼: `watchlistId` → `watchlistIds:[id]`
- remove 엔드포인트 Body 컬럼: 명시적 분리 (기존 "위와 동일" 제거)
- add/remove 필드명 비대칭에 대한 주의 주석 추가

### 영향 없는 영역

- `AddWatchlistItem` / `RemoveWatchlistItem` 함수 시그니처 (변경 없음)
- CLI 커맨드 핸들러 (`cmd/tossctl/watchlist.go`)
- MCP tools, monitor probes
- JSON / CSV 출력 분기
- 거래(mutating) 로직

## 영향 범위

- [x] 조회 / 관심종목 mutation (비금융, 되돌림 가능)
- [ ] 거래 (mutation)
- [ ] 설치 / CI
- [x] 문서 (`rpc-catalog.md` 엔드포인트 스펙 교정)

## 테스트

- [x] `go test ./...` 전체 통과
- [x] 수동 확인 완료

### 자동 테스트

```bash
go test -v ./internal/client -run TestWatchlist
go test ./...
```

### 수동 검증

- `tossctl watchlist add AAPL --group <id>` → 지정 그룹에 정상 추가, 새 "기본" 그룹 미생성 확인
- `tossctl watchlist remove AAPL --group <id>` → 지정 그룹에서 정상 제거 확인
- 브라우저 DevTools 캡처로 실제 웹 프론트엔드 스펙과 일치 확인

## 체크리스트

- [x] 기존 동작을 깨뜨리지 않음
- [x] 거래 관련 변경인 경우 안전장치(config gate, confirm token 등) 유지 확인
