### PR TITLE
fix(watchlist): honor group id when adding items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ tossctl 사용자 관점의 변경 이력입니다. 각 버전에서 "무엇을 
 
 ### 기여자용
 - WTS endpoint 인벤토리가 Go AST 의 문자열 상수·`fmt.Sprintf` 조립 경로와 런타임 monitor probe 를 함께 읽고 host·method·소유권 불일치를 테스트에서 fail-closed로 감지합니다.
+- `@anthonyminyungi` 님이 관심종목 add 요청의 실제 `watchlistIds` 계약을 제보하고 수정안을 제공했습니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
 
 ## [0.46.0] - 2026-08-29
 

--- a/docs/reverse-engineering/rpc-catalog.md
+++ b/docs/reverse-engineering/rpc-catalog.md
@@ -96,8 +96,10 @@ This file is the source of truth for endpoint discovery. It should grow before t
 | `auth` | `POST` | `wts-cert-api.tossinvest.com` | `/api/v1/new-watchlists/groups` | 폴더 생성 | `{"name":"..."}` → `.result.{id,name,...}` | `watchlist group create` |
 | `auth` | `PATCH` | `wts-cert-api.tossinvest.com` | `/api/v1/new-watchlists/groups/{id}` | 폴더 리네임 | `{"name":"..."}` | `watchlist group rename` |
 | `auth` | `DELETE` | `wts-cert-api.tossinvest.com` | `/api/v1/new-watchlists/groups/{id}` | 폴더 삭제 | — | `watchlist group delete` |
-| `auth` | `POST` | `wts-cert-api.tossinvest.com` | `/api/v1/new-watchlists/items` | 종목 추가 | `{"watchlistId":id,"items":[{"code":"A005930","itemType":"STOCK"}]}` | `watchlist add` |
-| `auth` | `POST` | `wts-cert-api.tossinvest.com` | `/api/v1/new-watchlists/items/remove` | 종목 제거 | 위와 동일 | `watchlist remove` |
+| `auth` | `POST` | `wts-cert-api.tossinvest.com` | `/api/v1/new-watchlists/items` | 종목 추가 | `{"watchlistIds":[id],"items":[{"code":"...","itemType":"STOCK"}]}` | `watchlist add` |
+| `auth` | `POST` | `wts-cert-api.tossinvest.com` | `/api/v1/new-watchlists/items/remove` | 종목 제거 | `{"watchlistId":id,"items":[{"code":"...","itemType":"STOCK"}]}` | `watchlist remove` |
+
+> **주의**: add 는 `watchlistIds` (복수, `[]int64`), remove 는 `watchlistId` (단수, `int64`). 서버 API 가 비일관적이지만 이것이 실제 스펙이다 (브라우저 DevTools 캡처로 확인).
 
 ## Account, Portfolio, Orders, Watchlist
 

--- a/internal/client/watchlist_manage.go
+++ b/internal/client/watchlist_manage.go
@@ -176,17 +176,23 @@ func (c *Client) DeleteWatchlistGroup(ctx context.Context, groupID int64) error 
 	return c.mutateJSON(ctx, http.MethodDelete, url, nil, nil)
 }
 
+type watchlistItemSpec struct {
+	Code     string `json:"code"`
+	ItemType string `json:"itemType"`
+}
+
+type addWatchlistItemsRequest struct {
+	WatchlistIDs []int64             `json:"watchlistIds"`
+	Items        []watchlistItemSpec `json:"items"`
+}
+
+type removeWatchlistItemsRequest struct {
+	WatchlistID int64               `json:"watchlistId"`
+	Items       []watchlistItemSpec `json:"items"`
+}
+
 // AddWatchlistItem adds a stock to a folder (symbol or product code).
 func (c *Client) AddWatchlistItem(ctx context.Context, groupID int64, symbol string) error {
-	return c.watchlistItemOp(ctx, c.certBaseURL+watchlistItemsPath, groupID, symbol)
-}
-
-// RemoveWatchlistItem removes a stock from a folder.
-func (c *Client) RemoveWatchlistItem(ctx context.Context, groupID int64, symbol string) error {
-	return c.watchlistItemOp(ctx, c.certBaseURL+watchlistItemsRemovePath, groupID, symbol)
-}
-
-func (c *Client) watchlistItemOp(ctx context.Context, endpoint string, groupID int64, symbol string) error {
 	if err := c.requireSession(); err != nil {
 		return err
 	}
@@ -194,11 +200,27 @@ func (c *Client) watchlistItemOp(ctx context.Context, endpoint string, groupID i
 	if err != nil {
 		return err
 	}
-	body, _ := json.Marshal(map[string]any{
-		"watchlistId": groupID,
-		"items":       []map[string]string{{"code": code, "itemType": "STOCK"}},
+	body, _ := json.Marshal(addWatchlistItemsRequest{
+		WatchlistIDs: []int64{groupID},
+		Items:        []watchlistItemSpec{{Code: code, ItemType: "STOCK"}},
 	})
-	return c.mutateJSON(ctx, http.MethodPost, endpoint, body, nil)
+	return c.mutateJSON(ctx, http.MethodPost, c.certBaseURL+watchlistItemsPath, body, nil)
+}
+
+// RemoveWatchlistItem removes a stock from a folder.
+func (c *Client) RemoveWatchlistItem(ctx context.Context, groupID int64, symbol string) error {
+	if err := c.requireSession(); err != nil {
+		return err
+	}
+	code, err := c.resolveProductCode(ctx, symbol)
+	if err != nil {
+		return err
+	}
+	body, _ := json.Marshal(removeWatchlistItemsRequest{
+		WatchlistID: groupID,
+		Items:       []watchlistItemSpec{{Code: code, ItemType: "STOCK"}},
+	})
+	return c.mutateJSON(ctx, http.MethodPost, c.certBaseURL+watchlistItemsRemovePath, body, nil)
 }
 
 // mutateJSON issues a non-GET request with session auth (X-XSRF-TOKEN included

--- a/internal/client/watchlist_manage.go
+++ b/internal/client/watchlist_manage.go
@@ -100,17 +100,23 @@ func (c *Client) DeleteWatchlistGroup(ctx context.Context, groupID int64) error 
 	return c.mutateJSON(ctx, http.MethodDelete, url, nil, nil)
 }
 
+type watchlistItemSpec struct {
+	Code     string `json:"code"`
+	ItemType string `json:"itemType"`
+}
+
+type addWatchlistItemsRequest struct {
+	WatchlistIDs []int64             `json:"watchlistIds"`
+	Items        []watchlistItemSpec `json:"items"`
+}
+
+type removeWatchlistItemsRequest struct {
+	WatchlistID int64               `json:"watchlistId"`
+	Items       []watchlistItemSpec `json:"items"`
+}
+
 // AddWatchlistItem adds a stock to a folder (symbol or product code).
 func (c *Client) AddWatchlistItem(ctx context.Context, groupID int64, symbol string) error {
-	return c.watchlistItemOp(ctx, "/items", groupID, symbol)
-}
-
-// RemoveWatchlistItem removes a stock from a folder.
-func (c *Client) RemoveWatchlistItem(ctx context.Context, groupID int64, symbol string) error {
-	return c.watchlistItemOp(ctx, "/items/remove", groupID, symbol)
-}
-
-func (c *Client) watchlistItemOp(ctx context.Context, path string, groupID int64, symbol string) error {
 	if err := c.requireSession(); err != nil {
 		return err
 	}
@@ -118,11 +124,27 @@ func (c *Client) watchlistItemOp(ctx context.Context, path string, groupID int64
 	if err != nil {
 		return err
 	}
-	body, _ := json.Marshal(map[string]any{
-		"watchlistId": groupID,
-		"items":       []map[string]string{{"code": code, "itemType": "STOCK"}},
+	body, _ := json.Marshal(addWatchlistItemsRequest{
+		WatchlistIDs: []int64{groupID},
+		Items:        []watchlistItemSpec{{Code: code, ItemType: "STOCK"}},
 	})
-	return c.mutateJSON(ctx, http.MethodPost, c.certBaseURL+watchlistBase+path, body, nil)
+	return c.mutateJSON(ctx, http.MethodPost, c.certBaseURL+watchlistBase+"/items", body, nil)
+}
+
+// RemoveWatchlistItem removes a stock from a folder.
+func (c *Client) RemoveWatchlistItem(ctx context.Context, groupID int64, symbol string) error {
+	if err := c.requireSession(); err != nil {
+		return err
+	}
+	code, err := c.resolveProductCode(ctx, symbol)
+	if err != nil {
+		return err
+	}
+	body, _ := json.Marshal(removeWatchlistItemsRequest{
+		WatchlistID: groupID,
+		Items:       []watchlistItemSpec{{Code: code, ItemType: "STOCK"}},
+	})
+	return c.mutateJSON(ctx, http.MethodPost, c.certBaseURL+watchlistBase+"/items/remove", body, nil)
 }
 
 // mutateJSON issues a non-GET request with session auth (X-XSRF-TOKEN included

--- a/internal/client/watchlist_manage_test.go
+++ b/internal/client/watchlist_manage_test.go
@@ -16,6 +16,16 @@ import (
 func TestWatchlistMutationContract(t *testing.T) {
 	var gotMethod, gotPath, gotBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Respond to resolveProductCode lookup (POST /api/v2/search/stocks).
+		if r.Method == "POST" && r.URL.Path == "/api/v2/search/stocks" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"result": map[string]any{
+					"stocks": []map[string]string{{"stockCode": "US.AAPL", "stockName": "Apple Inc", "matchType": "SYMBOL"}},
+				},
+			})
+			return
+		}
 		gotMethod, gotPath = r.Method, r.URL.Path
 		b, _ := io.ReadAll(r.Body)
 		gotBody = string(b)
@@ -57,6 +67,45 @@ func TestWatchlistMutationContract(t *testing.T) {
 	}
 	if gotMethod != "DELETE" || gotPath != "/api/v1/new-watchlists/groups/123" {
 		t.Errorf("delete routing: %s %s", gotMethod, gotPath)
+	}
+
+	// add item → POST /items with watchlistIds (plural, array)
+	if err := c.AddWatchlistItem(context.Background(), 456, "AAPL"); err != nil {
+		t.Fatalf("add item: %v", err)
+	}
+	if gotMethod != "POST" || gotPath != "/api/v1/new-watchlists/items" {
+		t.Errorf("add routing: %s %s", gotMethod, gotPath)
+	}
+	var addBody map[string]any
+	_ = json.Unmarshal([]byte(gotBody), &addBody)
+	// watchlistIds must be present as an array (not watchlistId singular).
+	ids, ok := addBody["watchlistIds"].([]any)
+	if !ok || len(ids) != 1 {
+		t.Fatalf("add body: expected watchlistIds array with 1 element, got: %s", gotBody)
+	}
+	if int64(ids[0].(float64)) != 456 {
+		t.Errorf("add body: expected watchlistIds=[456], got: %s", gotBody)
+	}
+	if _, hasSingular := addBody["watchlistId"]; hasSingular {
+		t.Errorf("add body: must NOT contain singular watchlistId field, got: %s", gotBody)
+	}
+
+	// remove item → POST /items/remove with watchlistId (singular, number)
+	if err := c.RemoveWatchlistItem(context.Background(), 456, "AAPL"); err != nil {
+		t.Fatalf("remove item: %v", err)
+	}
+	if gotMethod != "POST" || gotPath != "/api/v1/new-watchlists/items/remove" {
+		t.Errorf("remove routing: %s %s", gotMethod, gotPath)
+	}
+	var rmBody map[string]any
+	_ = json.Unmarshal([]byte(gotBody), &rmBody)
+	// watchlistId must be present as a number (not watchlistIds plural).
+	wid, ok := rmBody["watchlistId"].(float64)
+	if !ok || int64(wid) != 456 {
+		t.Fatalf("remove body: expected watchlistId=456, got: %s", gotBody)
+	}
+	if _, hasPlural := rmBody["watchlistIds"]; hasPlural {
+		t.Errorf("remove body: must NOT contain plural watchlistIds field, got: %s", gotBody)
 	}
 }
 

--- a/website-fumadocs/content/docs/changelog.en.mdx
+++ b/website-fumadocs/content/docs/changelog.en.mdx
@@ -25,6 +25,7 @@ Version history below (source: the Korean-language [CHANGELOG.md](https://github
 
 ### 기여자용
 - WTS endpoint 인벤토리가 Go AST 의 문자열 상수·`fmt.Sprintf` 조립 경로와 런타임 monitor probe 를 함께 읽고 host·method·소유권 불일치를 테스트에서 fail-closed로 감지합니다.
+- `@anthonyminyungi` 님이 관심종목 add 요청의 실제 `watchlistIds` 계약을 제보하고 수정안을 제공했습니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
 
 ## [0.46.0] - 2026-08-29
 

--- a/website-fumadocs/content/docs/changelog.mdx
+++ b/website-fumadocs/content/docs/changelog.mdx
@@ -25,6 +25,7 @@ description: tossctl 버전별 변경 사항 (사용자 관점)
 
 ### 기여자용
 - WTS endpoint 인벤토리가 Go AST 의 문자열 상수·`fmt.Sprintf` 조립 경로와 런타임 monitor probe 를 함께 읽고 host·method·소유권 불일치를 테스트에서 fail-closed로 감지합니다.
+- `@anthonyminyungi` 님이 관심종목 add 요청의 실제 `watchlistIds` 계약을 제보하고 수정안을 제공했습니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
 
 ## [0.46.0] - 2026-08-29
 


### PR DESCRIPTION
## Summary

Fixes #176. The add and remove watchlist endpoints use different request contracts. Add now sends watchlistIds as an integer array, while remove keeps the singular watchlistId field.

This is the same underlying fix proposed in #177, reapplied on top of v0.47.0 after the contributor PR became conflicting. Endpoint-specific DTOs and regression tests prevent the contracts from drifting again.

## Verification

- go test ./internal/client ./cmd/tossctl -count=1
- git diff --check origin/main...HEAD

No live trading command was executed.