### PR TITLE
v0.47.1 release: ship watchlist group fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ tossctl 사용자 관점의 변경 이력입니다. 각 버전에서 "무엇을 
 
 ## [Unreleased]
 
+## [0.47.1] - 2026-09-01
+
+### 버그 수정
+- `watchlist add --group <id>`가 지정한 폴더를 무시하고 기본 폴더를 만들던 문제를 수정했습니다. add 요청은 `watchlistIds` 배열을, remove 요청은 `watchlistId` 단일 값을 사용하도록 엔드포인트별 계약을 분리했습니다.
+
+### 기여자
+- 실제 API 계약을 제보하고 수정안을 제공해 주신 `@anthonyminyungi` 님께 감사드립니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
+
 ## [0.47.0] - 2026-09-01
 
 ### 변경
@@ -20,7 +28,6 @@ tossctl 사용자 관점의 변경 이력입니다. 각 버전에서 "무엇을 
 
 ### 기여자용
 - WTS endpoint 인벤토리가 Go AST 의 문자열 상수·`fmt.Sprintf` 조립 경로와 런타임 monitor probe 를 함께 읽고 host·method·소유권 불일치를 테스트에서 fail-closed로 감지합니다.
-- `@anthonyminyungi` 님이 관심종목 add 요청의 실제 `watchlistIds` 계약을 제보하고 수정안을 제공했습니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
 
 ## [0.46.0] - 2026-08-29
 

--- a/website-fumadocs/content/docs/changelog.en.mdx
+++ b/website-fumadocs/content/docs/changelog.en.mdx
@@ -9,6 +9,14 @@ Version history below (source: the Korean-language [CHANGELOG.md](https://github
 
 ## [Unreleased]
 
+## [0.47.1] - 2026-09-01
+
+### 버그 수정
+- `watchlist add --group <id>`가 지정한 폴더를 무시하고 기본 폴더를 만들던 문제를 수정했습니다. add 요청은 `watchlistIds` 배열을, remove 요청은 `watchlistId` 단일 값을 사용하도록 엔드포인트별 계약을 분리했습니다.
+
+### 기여자
+- 실제 API 계약을 제보하고 수정안을 제공해 주신 `@anthonyminyungi` 님께 감사드립니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
+
 ## [0.47.0] - 2026-09-01
 
 ### 변경
@@ -25,7 +33,6 @@ Version history below (source: the Korean-language [CHANGELOG.md](https://github
 
 ### 기여자용
 - WTS endpoint 인벤토리가 Go AST 의 문자열 상수·`fmt.Sprintf` 조립 경로와 런타임 monitor probe 를 함께 읽고 host·method·소유권 불일치를 테스트에서 fail-closed로 감지합니다.
-- `@anthonyminyungi` 님이 관심종목 add 요청의 실제 `watchlistIds` 계약을 제보하고 수정안을 제공했습니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
 
 ## [0.46.0] - 2026-08-29
 

--- a/website-fumadocs/content/docs/changelog.mdx
+++ b/website-fumadocs/content/docs/changelog.mdx
@@ -9,6 +9,14 @@ description: tossctl 버전별 변경 사항 (사용자 관점)
 
 ## [Unreleased]
 
+## [0.47.1] - 2026-09-01
+
+### 버그 수정
+- `watchlist add --group <id>`가 지정한 폴더를 무시하고 기본 폴더를 만들던 문제를 수정했습니다. add 요청은 `watchlistIds` 배열을, remove 요청은 `watchlistId` 단일 값을 사용하도록 엔드포인트별 계약을 분리했습니다.
+
+### 기여자
+- 실제 API 계약을 제보하고 수정안을 제공해 주신 `@anthonyminyungi` 님께 감사드립니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
+
 ## [0.47.0] - 2026-09-01
 
 ### 변경
@@ -25,7 +33,6 @@ description: tossctl 버전별 변경 사항 (사용자 관점)
 
 ### 기여자용
 - WTS endpoint 인벤토리가 Go AST 의 문자열 상수·`fmt.Sprintf` 조립 경로와 런타임 monitor probe 를 함께 읽고 host·method·소유권 불일치를 테스트에서 fail-closed로 감지합니다.
-- `@anthonyminyungi` 님이 관심종목 add 요청의 실제 `watchlistIds` 계약을 제보하고 수정안을 제공했습니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
 
 ## [0.46.0] - 2026-08-29
 


### PR DESCRIPTION
## Summary

Prepare v0.47.1 with the watchlist add contract fix from #179. The changelog now records the patch separately from v0.47.0 and credits @anthonyminyungi for the original API contract report and patch.

## Verification

- Generated changelog mirrors synchronized
- git diff --check passed
- The code fix was validated in PR #179 and is already present on main

No live trading command was executed.