### PR TITLE
docs: preserve contributor mention notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ tossctl 사용자 관점의 변경 이력입니다. 각 버전에서 "무엇을 
 - `watchlist add --group <id>`가 지정한 폴더를 무시하고 기본 폴더를 만들던 문제를 수정했습니다. add 요청은 `watchlistIds` 배열을, remove 요청은 `watchlistId` 단일 값을 사용하도록 엔드포인트별 계약을 분리했습니다.
 
 ### 기여자
-- 실제 API 계약을 제보하고 수정안을 제공해 주신 `@anthonyminyungi` 님께 감사드립니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
+- 실제 API 계약을 제보하고 수정안을 제공해 주신 @anthonyminyungi 님께 감사드립니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
 
 ## [0.47.0] - 2026-09-01
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,13 @@ python3 -m pip install -e .
 2. PR 템플릿의 체크리스트를 채워주세요.
 3. 거래(mutation) 관련 변경은 안전장치(config gate, confirm token 등)가 유지되는지 반드시 확인합니다.
 
+### 기여자 크레딧과 멘션
+
+- 릴리즈에 반영된 제보·패치는 `CHANGELOG.md`의 `### 기여자` 아래에 기록합니다.
+- GitHub 알림이 가도록 사용자명은 반드시 일반 텍스트 `@handle`로 쓰고, 백틱이나 링크 안에 넣지 않습니다.
+- 같은 문장을 GitHub Release 본문에도 복사하고, 관련 PR 링크를 함께 남깁니다.
+- `python3 -m unittest discover -s tools/tests -p 'test_*.py'`가 코드 스팬 안의 멘션을 자동으로 잡습니다.
+
 ## 프로젝트 구조
 
 ```

--- a/tools/tests/test_changelog.py
+++ b/tools/tests/test_changelog.py
@@ -1,0 +1,49 @@
+"""Release-credit formatting guards.
+
+GitHub only turns a username into a notification mention when the @handle is
+plain Markdown text. Keeping it inside a code span makes it look right while
+silently failing to notify the contributor.
+"""
+
+import pathlib
+import re
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CHANGELOG = ROOT / "CHANGELOG.md"
+CREDIT_HEADING = re.compile(r"^### (?:기여자|Contributors?)\s*$")
+HANDLE = re.compile(r"@([A-Za-z0-9][A-Za-z0-9-]*)")
+CODE_SPAN = re.compile(r"`[^`\n]*`")
+
+
+class TestChangelogCredits(unittest.TestCase):
+    def test_credit_handles_are_real_github_mentions(self):
+        lines = CHANGELOG.read_text(encoding="utf-8").splitlines()
+        in_credit_section = False
+        sections = 0
+        for line in lines:
+            if CREDIT_HEADING.match(line):
+                in_credit_section = True
+                sections += 1
+                continue
+            if line.startswith("### "):
+                in_credit_section = False
+            if not in_credit_section:
+                continue
+
+            handles = HANDLE.findall(line)
+            if not handles:
+                continue
+            outside_code = CODE_SPAN.sub("", line)
+            for handle in handles:
+                self.assertIn(
+                    f"@{handle}",
+                    outside_code,
+                    f"@{handle} in a contributor credit must be plain text: {line}",
+                )
+        self.assertGreater(sections, 0, "CHANGELOG must contain a contributor section")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/website-fumadocs/content/docs/changelog.en.mdx
+++ b/website-fumadocs/content/docs/changelog.en.mdx
@@ -15,7 +15,7 @@ Version history below (source: the Korean-language [CHANGELOG.md](https://github
 - `watchlist add --group <id>`가 지정한 폴더를 무시하고 기본 폴더를 만들던 문제를 수정했습니다. add 요청은 `watchlistIds` 배열을, remove 요청은 `watchlistId` 단일 값을 사용하도록 엔드포인트별 계약을 분리했습니다.
 
 ### 기여자
-- 실제 API 계약을 제보하고 수정안을 제공해 주신 `@anthonyminyungi` 님께 감사드립니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
+- 실제 API 계약을 제보하고 수정안을 제공해 주신 @anthonyminyungi 님께 감사드립니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
 
 ## [0.47.0] - 2026-09-01
 

--- a/website-fumadocs/content/docs/changelog.mdx
+++ b/website-fumadocs/content/docs/changelog.mdx
@@ -15,7 +15,7 @@ description: tossctl 버전별 변경 사항 (사용자 관점)
 - `watchlist add --group <id>`가 지정한 폴더를 무시하고 기본 폴더를 만들던 문제를 수정했습니다. add 요청은 `watchlistIds` 배열을, remove 요청은 `watchlistId` 단일 값을 사용하도록 엔드포인트별 계약을 분리했습니다.
 
 ### 기여자
-- 실제 API 계약을 제보하고 수정안을 제공해 주신 `@anthonyminyungi` 님께 감사드립니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
+- 실제 API 계약을 제보하고 수정안을 제공해 주신 @anthonyminyungi 님께 감사드립니다([#177](https://github.com/JungHoonGhae/tossinvest-cli/pull/177)).
 
 ## [0.47.0] - 2026-09-01
 


### PR DESCRIPTION
## Summary

Fix contributor-credit mentions that were wrapped in code spans and therefore did not notify the contributor. The v0.47.1 changelog now uses a plain @anthonyminyungi mention, generated changelog mirrors stay synchronized, and CONTRIBUTING documents the credit/release checklist.

Added a regression test that rejects code-span handles in contributor sections.

## Verification

- PYTHONHASHSEED=1 python3 -m unittest discover -s tools/tests -p test_*.py (35 passed)
- python3 tools/sync_changelog.py
- git diff --check