### PR TITLE
v0.48.0 release: conditional ops and metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ tossctl 사용자 관점의 변경 이력입니다. 각 버전에서 "무엇을 
 
 ## [Unreleased]
 
+## [0.48.0] - 2026-09-02
+
 ### 새 기능
 - **조건주문을 ops/MCP에서도 조회·실행할 수 있습니다.** `conditional_orders`·`conditional_order`로 목록·상세를 조회하고, `place_conditional_order`·`cancel_conditional_order`·`modify_conditional_order`로 preview 후 실행합니다. 쓰기는 공식 Open API 전용이며 기본 호출은 dry-run입니다([#111](https://github.com/JungHoonGhae/tossinvest-cli/issues/111)).
 - **`quote metadata <symbol>[,symbol,...] [...]`** — 공식 Open API에서 최대 200개 종목의 이름·영문명·ISIN·시장·증권 유형·상장 상태·통화·상장주식수·상장/상장폐지일과 국내 KRX/NXT 거래 상태를 한 번에 조회합니다. `market stocks`가 시장 전체의 종목 유니버스를 찾는 명령이라면, 이 명령은 이미 아는 심볼의 정확한 참조 데이터를 채우는 용도입니다. JSON·CSV는 공식 응답의 전체 메타데이터를 보존합니다.

--- a/tools/update_new_markers.py
+++ b/tools/update_new_markers.py
@@ -25,6 +25,7 @@ FILES = ["README.md", "README.en.md"]
 # Longest keys are matched first so e.g. "market ranking" never matches a
 # "community rankings" row. Date = CHANGELOG version date of first appearance.
 FEATURE_DATES = {
+    "quote metadata": "2026-09-02",
     "market halt": "2026-08-24",
     "market anomalies": "2026-08-24",
     "quote reasons": "2026-08-24",

--- a/website-fumadocs/content/docs/changelog.en.mdx
+++ b/website-fumadocs/content/docs/changelog.en.mdx
@@ -9,6 +9,8 @@ Version history below (source: the Korean-language [CHANGELOG.md](https://github
 
 ## [Unreleased]
 
+## [0.48.0] - 2026-09-02
+
 ### 새 기능
 - **조건주문을 ops/MCP에서도 조회·실행할 수 있습니다.** `conditional_orders`·`conditional_order`로 목록·상세를 조회하고, `place_conditional_order`·`cancel_conditional_order`·`modify_conditional_order`로 preview 후 실행합니다. 쓰기는 공식 Open API 전용이며 기본 호출은 dry-run입니다([#111](https://github.com/JungHoonGhae/tossinvest-cli/issues/111)).
 - **`quote metadata <symbol>[,symbol,...] [...]`** — 공식 Open API에서 최대 200개 종목의 이름·영문명·ISIN·시장·증권 유형·상장 상태·통화·상장주식수·상장/상장폐지일과 국내 KRX/NXT 거래 상태를 한 번에 조회합니다. `market stocks`가 시장 전체의 종목 유니버스를 찾는 명령이라면, 이 명령은 이미 아는 심볼의 정확한 참조 데이터를 채우는 용도입니다. JSON·CSV는 공식 응답의 전체 메타데이터를 보존합니다.

--- a/website-fumadocs/content/docs/changelog.mdx
+++ b/website-fumadocs/content/docs/changelog.mdx
@@ -9,6 +9,8 @@ description: tossctl 버전별 변경 사항 (사용자 관점)
 
 ## [Unreleased]
 
+## [0.48.0] - 2026-09-02
+
 ### 새 기능
 - **조건주문을 ops/MCP에서도 조회·실행할 수 있습니다.** `conditional_orders`·`conditional_order`로 목록·상세를 조회하고, `place_conditional_order`·`cancel_conditional_order`·`modify_conditional_order`로 preview 후 실행합니다. 쓰기는 공식 Open API 전용이며 기본 호출은 dry-run입니다([#111](https://github.com/JungHoonGhae/tossinvest-cli/issues/111)).
 - **`quote metadata <symbol>[,symbol,...] [...]`** — 공식 Open API에서 최대 200개 종목의 이름·영문명·ISIN·시장·증권 유형·상장 상태·통화·상장주식수·상장/상장폐지일과 국내 KRX/NXT 거래 상태를 한 번에 조회합니다. `market stocks`가 시장 전체의 종목 유니버스를 찾는 명령이라면, 이 명령은 이미 아는 심볼의 정확한 참조 데이터를 채우는 용도입니다. JSON·CSV는 공식 응답의 전체 메타데이터를 보존합니다.


### PR DESCRIPTION
## 요약

- v0.47.1 이후 변경사항을 v0.48.0으로 확정
- 조건주문 ops/MCP와 종목 메타데이터 일괄 조회 포함
- WTS 고정 정책 및 백엔드 타입 안전성 개선 포함
- changelog 웹 사본 동기화 및 quote metadata의 README 신규 기능 날짜 등록

## 기여자 크레딧

- 이번 릴리즈 범위 PR 작성자는 모두 저장소 소유자입니다.
- 기존 외부 기여자 @anthonyminyungi의 크레딧은 v0.47.1 섹션에 실제 mention으로 유지됩니다.

## 검증

- go test ./... -count=1
- make lint
- Python 도구 테스트 36개, PYTHONHASHSEED 2종
- README 신규 마커 check
- website-fumadocs npm run build