### PR TITLE
v0.50.1 docs: finalize release architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,8 @@ application core + 로컬 상태 파일`로 나뉩니다. 일반 Toss Banking/My
   - 링크 로그인 지원 — `auth login --link` (휴대폰에서 탭), `--headless [--qr-output <path>]` (SSH/CI 호환)
   - `auth extend` — 토스 서버 측 ~7일 활성 timer를 폰 푸시 승인 한 번으로 연장 (1년 SESSION 쿠키와 별개의 만료 시계). 24h 미만 남았을 때 모든 명령에서 stderr 한 줄 경고
 - 계좌, 포트폴리오, 미체결 주문, 관심종목, 시세 조회
+- 관심종목 폴더, 목표가 알림, 숨긴 보유종목의 preview/confirm 기반 설정 변경
+- opt-in 미국 옵션 모의투자: 격리 원장 조회·주문과 실주문 preview 전환
 - `orders completed`, `order show <id>` 기반 주문 상태 조회
 - 거래내역 ledger: `transactions list/overview` — 매매/입출금/배당/주식입출고 + 현금 overview (KR/US, table/JSON/CSV, 200일 캡)
 - 실시간 푸시: `push listen` — 토스 SSE 채널(`sse-message.tossinvest.com`) 구독으로 주문/가격/보유종목 변경 알림을 JSONL 스트림으로 출력 (이벤트 분류는 [`docs/reverse-engineering/push-events.md`](reverse-engineering/push-events.md))
@@ -82,7 +84,7 @@ Person(agent, "Agent / Automation", "Claude, Codex, shell script, OpenClaw 같�
 System(cli, "tossinvest-cli", "공식 Open API와 증권 WTS를 CLI·MCP로 노출")
 
 System_Ext(tossWeb, "Toss Securities Web", "WTS 브라우저 로그인과 웹 UI")
-System_Ext(wtsApi, "Toss Securities WTS APIs", "비공식 조회·검증된 설정 변경·CLI 일반주문")
+System_Ext(wtsApi, "Toss Securities WTS APIs", "비공식 조회·설정·CLI 일반주문·격리 모의투자")
 System_Ext(officialApi, "Toss Securities Open API", "공식 조회·ops/MCP 주문·조건주문")
 System_Ext(mobileApi, "Toss Main-app Mobile APIs", "Banking/MyData 포함; 미연결 정적 분석 대상")
 System_Ext(playwright, "Playwright Chromium", "실제 브라우저 로그인 세션 확보")
@@ -91,7 +93,7 @@ Rel(user, cli, "실행", "CLI")
 Rel(agent, cli, "호출", "CLI / JSON")
 Rel(cli, playwright, "로그인 시 실행", "Python helper")
 Rel(playwright, tossWeb, "브라우저 로그인", "HTTPS")
-Rel(cli, wtsApi, "조회 / 설정 / 선택된 CLI 일반주문", "HTTPS + WTS session")
+Rel(cli, wtsApi, "조회 / 설정 / 선택된 CLI 일반주문 / 모의투자", "HTTPS + WTS session")
 Rel(cli, officialApi, "조회 / official 주문", "HTTPS + official OAuth")
 Rel(cli, mobileApi, "호출하지 않음", "future connector boundary")
 Rel(playwright, cli, "storage state 전달", "JSON file")
@@ -114,7 +116,7 @@ System_Boundary(system, "tossinvest-cli") {
 }
 
 System_Ext(tossWeb, "Toss Securities Web", "브라우저 로그인 화면")
-System_Ext(wtsApi, "Toss Securities WTS APIs", "조회 / 설정 / CLI 일반주문 엔드포인트")
+System_Ext(wtsApi, "Toss Securities WTS APIs", "조회 / 설정 / CLI 일반주문 / 모의투자 엔드포인트")
 System_Ext(officialApi, "Toss Securities Open API", "공식 조회 / 주문 엔드포인트")
 
 Rel(user, goCli, "Uses")
@@ -123,7 +125,7 @@ Rel(goCli, authHelper, "Starts for login", "subprocess")
 Rel(authHelper, tossWeb, "Captures login session", "browser automation")
 Rel(authHelper, localFiles, "Writes storage state-derived session", "JSON")
 Rel(goCli, localFiles, "Reads/writes config, session, lineage", "JSON files")
-Rel(goCli, wtsApi, "Calls WTS reads, guarded settings, selected CLI regular orders", "HTTPS + session")
+Rel(goCli, wtsApi, "Calls WTS reads, guarded settings and orders, isolated paper operations", "HTTPS + session")
 Rel(goCli, officialApi, "Calls official reads and guarded orders", "HTTPS + OAuth")
 Rel(goCli, docs, "Uses captured knowledge", "dev workflow")
 ```
@@ -147,7 +149,8 @@ Container_Boundary(core, "Application Core") {
   Component(clientSvc, "internal/client", "WTS connector", "Uses the Securities web session and parses WTS responses")
   Component(officialSvc, "internal/official", "Official connector", "Uses Open API OAuth and owns order transport")
   Component(tradingSvc, "internal/trading", "Trading service", "Preview, gate, broker-agnostic mutation orchestration, unknown-outcome boundary")
-  Component(watchlistSvc, "internal/watchlist", "Watchlist mutation service", "Session-bound preview, irreversible acknowledgement, post-read")
+  Component(preferenceSvc, "internal/watchlist · pricealert · hiddenholding", "WTS preference services", "Session-bound preview, confirmation, post-read; irreversible acknowledgement when required")
+  Component(paperSvc, "internal/papertrading", "Paper trading service", "Opt-in simulation preview, execution, and supported post-write checks")
   Component(confirmSvc, "internal/confirmation", "Confirmation tokens", "Signs exact state and intent; not a distributed single-use lock")
   Component(monitorSvc, "internal/monitor", "Contract monitor", "Runs registry-derived and CLI-only read probes")
   Component(intentSvc, "internal/orderintent", "Intent normalization", "Canonical order inputs and confirm tokens")
@@ -160,19 +163,23 @@ Rel(commands, authSvc, "Runs login/status/logout")
 Rel(commands, doctorSvc, "Runs doctor")
 Rel(commands, routerSvc, "Executes routed reads")
 Rel(commands, tradingSvc, "Executes preview/place/cancel/amend")
-Rel(commands, watchlistSvc, "Executes guarded preference changes")
+Rel(commands, preferenceSvc, "Executes guarded preference changes")
+Rel(commands, paperSvc, "Executes opt-in paper operations")
 Rel(mcpSvc, opsSvc, "Publishes operation contracts")
 Rel(opsSvc, routerSvc, "Dispatches typed reads")
 Rel(opsSvc, tradingSvc, "Dispatches guarded orders")
-Rel(opsSvc, watchlistSvc, "Dispatches guarded watchlist changes")
+Rel(opsSvc, preferenceSvc, "Dispatches guarded preference changes")
+Rel(opsSvc, paperSvc, "Publishes experimental paper operations")
 Rel(monitorSvc, opsSvc, "Derives dependency probes")
 Rel(routerSvc, clientSvc, "Routes WTS reads")
 Rel(routerSvc, officialSvc, "Routes official reads")
 Rel(tradingSvc, intentSvc, "Uses canonical inputs")
 Rel(tradingSvc, routerSvc, "Top-level CLI regular orders use one selected broker")
 Rel(tradingSvc, officialSvc, "ops/MCP and conditional orders use official transport")
-Rel(watchlistSvc, clientSvc, "Runs WTS mutation + post-read")
-Rel(watchlistSvc, confirmSvc, "Binds session, state, intent, expiry")
+Rel(preferenceSvc, clientSvc, "Runs WTS mutation + post-read")
+Rel(preferenceSvc, confirmSvc, "Binds session, state, intent, expiry")
+Rel(paperSvc, clientSvc, "Uses dedicated /paper/ endpoints")
+Rel(paperSvc, intentSvc, "Reuses canonical option intent")
 Rel(authSvc, sessionSvc, "Stores session")
 Rel(clientSvc, sessionSvc, "Reads session")
 Rel(commands, outputSvc, "Renders results")
@@ -261,19 +268,49 @@ official-only다. 조건주문은 모든 표면에서 official-only다. 현재 o
 자동 post-read를 하지 않으므로 transport error가 나면 성공/실패를 단정하지 않고 관련 주문
 상태를 확인한 뒤에만 재시도한다.
 
+### 4. Paper simulation and live preview handoff
+
+```mermaid
+sequenceDiagram
+    actor Caller as User / Agent
+    participant Surface as CLI / ops / MCP
+    participant Config as config.json
+    participant Paper as internal/papertrading
+    participant PaperAPI as WTS /paper/ ledger
+    participant Trading as internal/trading
+
+    Surface->>Config: require experimental.paper_trading
+    Caller->>Surface: paper mutation preview
+    Surface->>Paper: canonical option intent
+    Paper-->>Caller: simulation preview
+    Caller->>Surface: execute=true
+    Paper->>PaperAPI: isolated simulation mutation
+    PaperAPI-->>Paper: result
+    Paper-->>Caller: receipt / supported post-write check
+
+    opt User requests live-preview
+        Caller->>Surface: paper order live-preview
+        Surface->>Trading: same canonical intent, preview only
+        Trading-->>Caller: live-order preview + separate confirmation token
+    end
+```
+
+모의 실행은 실거래 권한이나 확인 토큰을 열지 않는다. `live-preview`도 의도 변환만 수행하며,
+실주문은 별도의 실거래 게이트를 다시 모두 통과해야 한다.
+
 ## Safety Model
 
-거래 mutation은 아래 순서로 열립니다.
+모든 쓰기는 preview가 기본이며 실행 환경에 따라 다음 경계를 사용합니다.
 
-1. `config.json`
-   - **경로 게이트:** `place`, `cancel`, `amend`, `conditional` (broker API 분기별 허용)
-   - **스코프 선언:** `sell`, `fractional` (유저 자가 제한; 시장 US/KR 은 게이트 아님)
-   - **마스터 킬스위치:** `allow_live_order_actions` (실계좌 도달 차단)
-   - **자동화:** `dangerous_automation.accept_fx_consent`
-2. `--execute`
-3. `--confirm <token>` (해당 주문 명령의 preview 또는 `order preview`에서 받은 토큰)
+| 쓰기 종류 | 실행 조건 | 검증·격리 |
+|---|---|---|
+| 실거래 주문 | `config.json`의 기능별 게이트와 `allow_live_order_actions` + `--execute` + 해당 preview의 `--confirm <token>` | 한 backend만 호출. 전송 결과가 불명확하면 상태 확인 전 재시도 금지 |
+| WTS 사용자 설정 | `--execute` + 해당 preview의 `--confirm <token>`; 되돌릴 수 없는 삭제는 별도 acknowledgement | 계좌·세션·현재 상태에 묶인 토큰과 사후 재조회 |
+| 모의투자 | `experimental.paper_trading=true` + `--execute` (`simulation_execute`) | `/paper/` 격리 원장만 호출하며 실거래 권한을 부여하지 않음 |
 
-즉, config가 열려 있어도 매번 CLI 실행 시점의 명시적 확인이 필요합니다.
+실거래의 기능별 게이트는 `place`, `cancel`, `amend`, `conditional`이고, `sell`과
+`fractional`은 사용자 자가 제한이다. 환전 동의 자동화는
+`dangerous_automation.accept_fx_consent`로 별도 관리한다.
 
 > `v0.4.3`에서 `trading.grant`, `dangerous_automation.complete_trade_auth`, `dangerous_automation.accept_product_ack`는 제거되었습니다 — 모두 실제로 어떤 동작도 제어하지 않던 dead toggle이었습니다. `v0.5.0`에서는 중복이던 TTL grant 레이어(`internal/permissions`)도 제거되었고, `v0.5.x`에서는 거짓 이름이던 `--dangerously-skip-permissions` 런타임 게이트도 은퇴했습니다(가리킬 permissions 가 없고 `--execute`와 의미 중복 — 실제 안전장치는 주문별 `--confirm <token>`). 구 config에 남아있어도 무시되며, 일반 명령 실행 시 stderr 경고 1줄(24h backoff)로 안내되고 `tossctl doctor`의 `legacy_config` 체크에서도 감지됩니다. 은퇴한 플래그는 한 릴리즈 동안 deprecated no-op alias로 받아들입니다.
 
@@ -306,6 +343,9 @@ official-only다. 조건주문은 모든 표면에서 official-only다. 현재 o
 | `internal/mcp` | operation 레지스트리의 3-tool MCP adapter |
 | `internal/trading` | preview, gate, mutation orchestration |
 | `internal/watchlist` | 관심종목 폴더·membership preview/confirm/post-read |
+| `internal/pricealert` | 목표가 알림 preview/confirm/post-read |
+| `internal/hiddenholding` | 숨긴 보유종목 preview/confirm/post-read |
+| `internal/papertrading` | opt-in 모의 원장 조회·쓰기와 live-preview 변환 |
 | `internal/confirmation` | deterministic·time-bound confirmation primitives |
 | `internal/monitor` | 레지스트리 파생 및 CLI 전용 read probe 실행 |
 | `internal/orderintent` | canonical input, confirm token |
@@ -322,6 +362,7 @@ official-only다. 조건주문은 모든 표면에서 official-only다. 현재 o
 - `place`와 `amend`의 상태 판별 추가 검증
 - 비소수점 시장가 주문 (US/KR)
 - interactive auth challenge가 필요한 mutation 분기 일반화
+- 일부 계정에서 `/paper/init`이 반환하는 불투명한 500의 서버 측 허용 조건 확인
 
 ## Related Docs
 


### PR DESCRIPTION
## Summary

- consolidate duplicated WTS preference-service descriptions
- document the isolated paper-trading boundary and live-preview handoff
- align the safety model and package map with the released implementation

## Verification

- `go test ./...`
- `python3 -m unittest discover -s tools/tests -p 'test_*.py'`\n- `pnpm audit --audit-level high`\n- `pnpm build`


## Documentation

- docs/architecture.md: consolidated the shared WTS preference boundary and documented the isolated paper-trading/live-preview flow.
- Aligned the safety matrix, package map, and known gaps with v0.50.1.

Documentation debt: no uncovered public surface in the shipped release; the four remaining feature issues are all external-observation triggers.
