### PR TITLE
fix(ci): label automation PRs at creation

### DIFF
--- a/tools/open_automation_pr.sh
+++ b/tools/open_automation_pr.sh
@@ -33,6 +33,7 @@ pr_url="$(gh pr create \
   --base main \
   --head "$branch" \
   --title "$title" \
+  --label maintenance \
   --body "$body")"
 
 # Events emitted by GITHUB_TOKEN do not recursively trigger ordinary push/PR

--- a/tools/tests/test_automation_identity.py
+++ b/tools/tests/test_automation_identity.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"
+AUTOMATION_PR_HELPER = ROOT / "tools" / "open_automation_pr.sh"
 BOT_NAME = "github-actions[bot]"
 # The numeric prefix links commits to GitHub's bot account. Without it, the
 # main ruleset treats automation commits as unattributed and requires approval.
@@ -39,6 +40,14 @@ class AutomationIdentityTests(unittest.TestCase):
             missing_email,
             [],
             "every workflow that commits as github-actions[bot] needs its attributed email",
+        )
+
+    def test_automation_prs_receive_their_label_at_creation(self):
+        source = AUTOMATION_PR_HELPER.read_text(encoding="utf-8")
+        self.assertIn(
+            "--label maintenance",
+            source,
+            "GITHUB_TOKEN-created PRs cannot rely on a follow-up labeling workflow",
         )
 
 


### PR DESCRIPTION
## Root cause

PRs created with `GITHUB_TOKEN` cannot rely on the follow-up `pull_request_target` classifier firing. The closed star-history PR #207 therefore had no release-note label.

## Fix

- add the existing `maintenance` label when the shared automation helper creates a PR
- add a regression assertion for the direct-label contract

## Verification

- `python3 -m unittest discover -s tools/tests -p 'test_*.py'` (86 tests)\n- `bash -n tools/open_automation_pr.sh`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`\n- `go test ./...`