### PR TITLE
docs: WTS 확장 가치를 README 전면에 명시

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -7,8 +7,8 @@
 <h1 align="center">tossinvest-cli</h1>
 
 <p align="center">
-  A CLI and MCP server for using Toss Securities accounts, quotes, market data, and orders from terminals and AI agents.
-  <br />One <code>tossctl</code> interface connects the official Open API with features otherwise available only on the web.
+  <strong>Toss Securities beyond the official API, through CLI and MCP.</strong>
+  <br />Cover the official Open API and add WTS-only flows, AI signals, news, dividends, and watchlists through one <code>tossctl</code> interface.
 </p>
 
 <p align="center">
@@ -20,7 +20,7 @@
 
 <p align="center">
   <a href="#quick-start"><strong>Quick Start</strong></a> ·
-  <a href="#what-it-provides"><strong>Features</strong></a> ·
+  <a href="#why-tossctl"><strong>Why tossctl</strong></a> ·
   <a href="#cli-and-mcp"><strong>CLI and MCP</strong></a> ·
   <a href="#safety-model"><strong>Safety</strong></a> ·
   <a href="https://tossinvest-cli.vercel.app/en/docs"><strong>Docs</strong></a>
@@ -28,6 +28,27 @@
 
 > [!WARNING]
 > This is not an official Toss Securities product. Features outside the official Open API use Toss Securities' internal web API unofficially, may violate its Terms of Service, and can change without notice. You are responsible for account restrictions, losses, and other consequences of use.
+
+## Why tossctl?
+
+tossctl does not discard or bypass the official Open API. **It prefers the official path where supported and fills the gaps with Toss Securities WTS.** You call one CLI, JSON, or MCP interface without having to know which backend provides each feature.
+
+<p align="center">
+  <img src="docs/assets/api-comparison.en.svg" alt="tossctl includes the complete official Open API surface and adds WTS-only features" width="840" />
+</p>
+
+| Representative feature | Official Open API | tossctl |
+|---|:---:|:---:|
+| Accounts, balances, quotes, order books, orders | ✅ | ✅ official first |
+| Live rankings, investor flows, market issues | ❌ | ✅ WTS |
+| AI price reasoning, signals, screener | ❌ | ✅ WTS |
+| News, earnings calls, dividends, realized profit | ❌ | ✅ WTS |
+| Watchlist folders, price alerts, hidden holdings | ❌ | ✅ WTS |
+| All-account overview, portfolio folders and history | ❌ | ✅ WTS |
+| Transaction ledger, cash overview, SSE push | ❌ | ✅ WTS |
+| JSON, CSV, MCP, API-contract regression monitoring | ❌ | ✅ |
+
+If the official API is enough, you keep its safer supported path. When analysis or automation needs more, the same tool opens the additional WTS surface. These are representative examples; the [support scope](https://tossinvest-cli.vercel.app/en/docs/reference/support-scope) tracks the complete current comparison.
 
 ## Quick Start
 
@@ -118,6 +139,20 @@ For other MCP hosts:
 ```
 
 See the [AI agent guide](https://tossinvest-cli.vercel.app/en/docs/guide/agents) and [MCP guide](https://tossinvest-cli.vercel.app/en/docs/guide/mcp) for details.
+
+## Preview
+
+### Install through the first query
+
+<p align="center">
+  <img src="docs/assets/demo/install.gif" alt="Install and sign in to tossctl, then run the first account query" width="760" />
+</p>
+
+### Connect MCP to an AI agent
+
+<p align="center">
+  <img src="docs/assets/demo/mcp.gif" alt="Connect the tossctl MCP server to an AI agent" width="760" />
+</p>
 
 ## Examples
 
@@ -233,17 +268,20 @@ Use [Issues](https://github.com/JungHoonGhae/tossinvest-cli/issues) for bugs and
 
 <!-- sponsors:end -->
 
+## Contributors
+
+Thanks to everyone who has helped build tossinvest-cli. See [`CONTRIBUTING.md`](CONTRIBUTING.md) to join in.
+
+[![tossinvest-cli contributors](https://contrib.rocks/image?repo=JungHoonGhae/tossinvest-cli)](https://github.com/JungHoonGhae/tossinvest-cli/graphs/contributors)
+
 ## Star History
 
-<p align="center">
-  <a href="https://www.star-history.com/#JungHoonGhae/tossinvest-cli&Date">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="docs/assets/star-history/star-history-dark.svg" />
-      <source media="(prefers-color-scheme: light)" srcset="docs/assets/star-history/star-history-light.svg" />
-      <img alt="Star History Chart" src="docs/assets/star-history/star-history-light.svg" width="600" />
-    </picture>
-  </a>
-</p>
+<!-- star-history:start -->
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/star-history/star-history-dark.svg">
+  <img alt="Star history" src="docs/assets/star-history/star-history-light.svg">
+</picture>
+<!-- star-history:end -->
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 <h1 align="center">tossinvest-cli</h1>
 
 <p align="center">
-  토스증권 계좌·시세·시장 데이터·주문을 터미널과 AI 에이전트에서 다루는 CLI + MCP 서버.
-  <br />공식 Open API와 웹에서만 제공되는 기능을 하나의 <code>tossctl</code> 인터페이스로 연결합니다.
+  <strong>공식 API로는 못 보는 토스증권 데이터까지, CLI와 MCP로.</strong>
+  <br />공식 Open API 범위를 포함하고 수급·AI 시그널·뉴스·배당·관심종목 등 WTS 전용 기능까지 하나의 <code>tossctl</code>로 연결합니다.
 </p>
 
 <p align="center">
@@ -20,7 +20,7 @@
 
 <p align="center">
   <a href="#빠른-시작"><strong>빠른 시작</strong></a> ·
-  <a href="#무엇을-할-수-있나요"><strong>기능</strong></a> ·
+  <a href="#왜-tossctl인가"><strong>왜 tossctl인가</strong></a> ·
   <a href="#cli와-mcp"><strong>CLI와 MCP</strong></a> ·
   <a href="#안전-모델"><strong>안전</strong></a> ·
   <a href="https://tossinvest-cli.vercel.app/docs"><strong>문서</strong></a>
@@ -28,6 +28,27 @@
 
 > [!WARNING]
 > 이 프로젝트는 토스증권 공식 제품이 아닙니다. 공식 Open API 외 기능은 토스증권 웹 내부 API를 비공식적으로 사용하며, 이용약관 위반에 해당할 수 있고 예고 없이 변경될 수 있습니다. 계좌 제한·손실 등 사용 결과는 사용자 본인의 책임입니다.
+
+## 왜 tossctl인가?
+
+공식 Open API를 버리거나 우회하기 위한 도구가 아닙니다. **공식 API가 지원하는 작업은 공식 경로를 우선 사용하고, 지원하지 않는 토스증권 기능은 WTS로 보완**합니다. 사용자는 어느 API에 있는지 구분하지 않고 같은 CLI·JSON·MCP 인터페이스로 호출할 수 있습니다.
+
+<p align="center">
+  <img src="docs/assets/api-comparison.svg" alt="tossctl은 공식 Open API 전 범위를 포함하고 WTS 전용 기능까지 제공합니다" width="840" />
+</p>
+
+| 대표 기능 | 공식 Open API | tossctl |
+|---|:---:|:---:|
+| 계좌·잔고·시세·호가·주문 | ✅ | ✅ 공식 API 우선 |
+| 실시간 인기 순위·투자자 수급·시장 이슈 | ❌ | ✅ WTS |
+| AI 등락 사유·종목 시그널·조건검색 | ❌ | ✅ WTS |
+| 뉴스·어닝콜·배당·누적 실현손익 | ❌ | ✅ WTS |
+| 관심종목 폴더·목표가 알림·숨긴 종목 관리 | ❌ | ✅ WTS |
+| 전체 계좌 합산·포트폴리오 폴더·평가 이력 | ❌ | ✅ WTS |
+| 거래내역 ledger·현금 overview·SSE 푸시 | ❌ | ✅ WTS |
+| JSON·CSV·MCP·API 계약 회귀 감시 | ❌ | ✅ |
+
+즉, 공식 API만 필요한 사용자는 더 안전한 공식 경로를 그대로 쓰고, 그 범위를 넘어서는 분석·자동화가 필요할 때만 WTS 기능을 함께 얻습니다. 위 표는 대표 사례이며 현재 전체 비교는 [지원 범위](https://tossinvest-cli.vercel.app/docs/reference/support-scope)에서 추적합니다.
 
 ## 빠른 시작
 
@@ -118,6 +139,20 @@ tossctl ops describe dividends
 ```
 
 자세한 내용은 [AI 에이전트 가이드](https://tossinvest-cli.vercel.app/docs/guide/agents)와 [MCP 가이드](https://tossinvest-cli.vercel.app/docs/guide/mcp)를 참고하세요.
+
+## 사용 모습
+
+### 설치에서 첫 조회까지
+
+<p align="center">
+  <img src="docs/assets/demo/install.gif" alt="tossctl 설치와 로그인 후 첫 계좌 조회" width="760" />
+</p>
+
+### AI 에이전트에 MCP 연결
+
+<p align="center">
+  <img src="docs/assets/demo/mcp.gif" alt="tossctl MCP 서버를 AI 에이전트에 연결" width="760" />
+</p>
 
 ## 사용 예
 
@@ -233,17 +268,20 @@ make tidy
 
 <!-- sponsors:end -->
 
+## Contributors
+
+기여해 주신 모든 분께 감사합니다. 참여 방법은 [`CONTRIBUTING.md`](CONTRIBUTING.md)를 참고하세요.
+
+[![tossinvest-cli contributors](https://contrib.rocks/image?repo=JungHoonGhae/tossinvest-cli)](https://github.com/JungHoonGhae/tossinvest-cli/graphs/contributors)
+
 ## Star History
 
-<p align="center">
-  <a href="https://www.star-history.com/#JungHoonGhae/tossinvest-cli&Date">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="docs/assets/star-history/star-history-dark.svg" />
-      <source media="(prefers-color-scheme: light)" srcset="docs/assets/star-history/star-history-light.svg" />
-      <img alt="Star History Chart" src="docs/assets/star-history/star-history-light.svg" width="600" />
-    </picture>
-  </a>
-</p>
+<!-- star-history:start -->
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/star-history/star-history-dark.svg">
+  <img alt="Star history" src="docs/assets/star-history/star-history-light.svg">
+</picture>
+<!-- star-history:end -->
 
 ## License
 

--- a/docs/assets/api-comparison.en.svg
+++ b/docs/assets/api-comparison.en.svg
@@ -19,7 +19,7 @@
   <rect width="1080" height="660" fill="#FFFFFF"/>
 
   <text x="32" y="42" class="title">Read &amp; trade coverage</text>
-  <text x="32" y="66" class="subtitle">tossctl = <tspan font-weight="800" fill="#191F28">100% of the official Open API</tspan> ＋ 12 features it doesn't have</text>
+  <text x="32" y="66" class="subtitle">tossctl = <tspan font-weight="800" fill="#191F28">the complete official Open API surface</tspan> ＋ WTS-only features</text>
 
   <rect x="24" y="86" width="1032" height="512" rx="16" fill="#EAF2FF" stroke="#3182F6" stroke-width="2.5"/>
   <rect x="44" y="100" width="318" height="32" rx="16" fill="#3182F6"/>
@@ -56,8 +56,8 @@
   <text x="462" y="420" class="plus">＋</text><text x="484" y="420" class="item-strong">Transaction ledger &amp; cash overview</text>
   <text x="462" y="451" class="plus">＋</text><text x="484" y="451" class="item-strong">Multi-quote &amp; live refresh</text>
   <text x="462" y="482" class="plus">＋</text><text x="484" y="482" class="item-strong">Real-time push (SSE stream)</text>
-  <text x="462" y="513" class="plus">＋</text><text x="484" y="513" class="item-strong">Fractional orders (amount-based)</text>
+  <text x="462" y="513" class="plus">＋</text><text x="484" y="513" class="item-strong">KRW-settled fractional orders</text>
   <text x="462" y="544" class="plus">＋</text><text x="484" y="544" class="item-strong">Dry-run preview · safety gates · CSV</text>
 
-  <text x="32" y="626" class="foot">The official Open API is rolling out in stages to pre-applicants (REST only) and its scope may change. tossctl covers 100% of it and adds 12+ more.</text>
+  <text x="32" y="626" class="foot">The official Open API may change. tossctl prefers its supported path and fills the remaining gaps through WTS.</text>
 </svg>

--- a/docs/assets/api-comparison.svg
+++ b/docs/assets/api-comparison.svg
@@ -19,7 +19,7 @@
   <rect width="940" height="660" fill="#FFFFFF"/>
 
   <text x="32" y="42" class="title">조회 · 거래 기능 비교</text>
-  <text x="32" y="66" class="subtitle">tossctl = 공식 Open API <tspan font-weight="800" fill="#191F28">100% 커버</tspan> ＋ 공식엔 없는 12개 기능까지</text>
+  <text x="32" y="66" class="subtitle">tossctl = 공식 Open API <tspan font-weight="800" fill="#191F28">전 범위</tspan> ＋ WTS 전용 기능</text>
 
   <rect x="24" y="86" width="892" height="512" rx="16" fill="#EAF2FF" stroke="#3182F6" stroke-width="2.5"/>
   <rect x="44" y="100" width="276" height="32" rx="16" fill="#3182F6"/>
@@ -58,8 +58,8 @@
   <text x="402" y="420" class="plus">＋</text><text x="424" y="420" class="item-strong">거래내역 ledger · 현금 overview</text>
   <text x="402" y="451" class="plus">＋</text><text x="424" y="451" class="item-strong">멀티 시세 · 실시간 갱신</text>
   <text x="402" y="482" class="plus">＋</text><text x="424" y="482" class="item-strong">실시간 푸시 (SSE 스트림)</text>
-  <text x="402" y="513" class="plus">＋</text><text x="424" y="513" class="item-strong">소수점 주문 (금액 기반)</text>
+  <text x="402" y="513" class="plus">＋</text><text x="424" y="513" class="item-strong">원화 소수점 주문</text>
   <text x="402" y="544" class="plus">＋</text><text x="424" y="544" class="item-strong">dry-run preview · 안전 게이트 · CSV</text>
 
-  <text x="32" y="626" class="foot">공식 Open API 는 사전 신청자 대상 단계적 롤아웃 중(REST only) — 범위는 변동될 수 있습니다. tossctl 은 공식 전 범위를 100% 커버하고 12개 이상을 더 제공합니다.</text>
+  <text x="32" y="626" class="foot">공식 Open API 범위는 변동될 수 있습니다. tossctl은 공식 경로를 우선 사용하고, 없는 기능은 WTS로 보완합니다.</text>
 </svg>


### PR DESCRIPTION
## 요약
- README 첫 문장에서 공식 API 밖의 WTS 확장 가치를 명시
- 공식 Open API와 tossctl의 대표 지원 범위를 표와 갱신된 비교 이미지로 제시
- 공식 경로 우선 + WTS 보완이라는 라우팅 원칙을 설명
- 기존 설치·MCP 데모 GIF를 Preview 섹션으로 복원
- OpenConnector처럼 기여자 아바타 그리드와 marker + picture Star History 적용
- 한국어와 영문 README를 같은 구조로 유지

## 검증
- `go test ./...`
- Python 테스트 87개
- 한·영 비교 SVG XML 및 실제 렌더링 확인
- `git diff --check`