### PR TITLE
docs: simplify README and clarify WTS value

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <strong>Toss Securities beyond the official API, through CLI and MCP.</strong>
-  <br />Cover the official Open API and add WTS-only flows, AI signals, news, dividends, and watchlists through one <code>tossctl</code> interface.
+  <br />Accounts, quotes, and orders — plus investor flows, AI signals, dividends, and watchlists.<br />One <code>tossctl</code> for your terminal, scripts, and AI agents.
 </p>
 
 <p align="center">
@@ -30,13 +30,13 @@
 
 ## Why tossctl?
 
-tossctl does not discard or bypass the official Open API. **It prefers the official path where supported and fills the gaps with Toss Securities WTS.** You call one CLI, JSON, or MCP interface without having to know which backend provides each feature.
+**Bring more of Toss Securities into your automation, beyond accounts and orders.** Investor flows, AI signals, dividend history, and watchlist management are not exposed by the official Open API. tossctl provides them through WTS, Toss Securities' Web Trading System API.
 
 <p align="center">
   <img src="diagrams/official-vs-wts-v2.en.svg" alt="tossctl routes supported work to the official Open API and adds WTS-only capabilities" width="100%" />
 </p>
 
-If the official API is enough, you keep its safer supported path. When analysis or automation needs more, the same tool opens the additional WTS surface. The [support scope](https://tossinvest-cli.vercel.app/en/docs/reference/support-scope) tracks the complete current comparison.
+With an official key, supported reads prefer the official API by default. A web session connects WTS features. The current scope is **Toss Securities**, not general Toss banking or card spending. [Compare all supported features →](https://tossinvest-cli.vercel.app/en/docs/reference/support-scope)
 
 ## Quick Start
 
@@ -44,79 +44,68 @@ macOS / Linux:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/JungHoonGhae/tossinvest-cli/main/install.sh | sh
-tossctl doctor
 tossctl auth login
 tossctl account summary --output json
 ```
 
-Windows PowerShell:
+Complete phone authentication and approve **Keep this device signed in**. To use a phone link instead of a QR code, sign in with `tossctl auth login --link`.
+
+<details>
+<summary>Windows · Homebrew · Official API setup</summary>
+
+Install in Windows PowerShell, then run the login and query commands above:
 
 ```powershell
 irm https://raw.githubusercontent.com/JungHoonGhae/tossinvest-cli/main/install.ps1 | iex
 ```
 
-You can open a link on your phone instead of scanning a QR code:
+To connect an official Open API key:
 
 ```bash
-tossctl auth login --link
+tossctl openapi login
+tossctl openapi status
 ```
 
-After signing in, approve **Keep this device signed in** on your phone. See the [installation guide](https://tossinvest-cli.vercel.app/en/docs/getting-started/installation) for Homebrew, source builds, and the complete authentication flow.
+See the [installation guide](https://tossinvest-cli.vercel.app/en/docs/getting-started/installation) for Homebrew and source builds. Run `tossctl doctor --report` to diagnose authentication or connection problems.
 
-## What It Provides
+</details>
 
-| Area | Examples |
-|---|---|
-| Accounts and portfolios | Account summaries, positions, performance, dividends, transaction history |
-| Quotes and markets | Quotes, order books, charts, flows, indices, news, screener, AI signals |
-| Watchlists and settings | Watchlist folders, price alerts, hidden holdings, Open API allowed IPs |
-| Trading | Korean and US stocks, fractional and conditional orders, cancel, amend, preview |
-| Real-time and automation | WebSocket streams, SSE push, JSON and CSV output, API regression monitoring |
-| Experimental | Isolated US-options paper-trading environment |
+## Put It to Work
 
-tossctl covers the official Open API and adds Toss-specific features discovered in WTS. See the [command reference](https://tossinvest-cli.vercel.app/en/docs/reference/commands) and [support scope](https://tossinvest-cli.vercel.app/en/docs/reference/support-scope) for the complete matrix.
+```bash
+# Explore investor flows and AI signals — WTS-only
+tossctl quote flows A005930
+tossctl market signals
 
-## How It Works
+# Review dividends and assets across accounts — WTS-only
+tossctl portfolio dividends
+tossctl account overview
 
-```mermaid
-flowchart LR
-    U[User · Script · AI Agent] --> C[CLI]
-    U --> M[MCP]
-    C --> T[tossctl]
-    M --> T
-    T --> R{Automatic routing}
-    R -->|Official key| O[Toss Official Open API]
-    R -->|Web session| W[Toss Securities WTS]
-    T -->|Explicit opt-in| P[Paper environment]
+# Pass holdings to your scripts
+tossctl portfolio positions --output json
+
+# Stream trades and watch for API changes
+tossctl stream --trade A005930
+tossctl monitor api           # schema-probe 82 endpoints; exit 0 pass, 1 fail
 ```
 
-- When an official key is present, supported operations prefer the official Open API.
-- A web session unlocks reads and settings not exposed by the official API.
-- Either credential is enough to start; connect both for the broadest surface.
+You can also manage watchlist folders and price alerts, screen stocks, review transactions, and preview orders. See the [command reference](https://tossinvest-cli.vercel.app/en/docs/reference/commands) or run `tossctl <command> --help` for options.
 
 ## CLI and MCP
 
-The same binary supports two usage paths.
+Use the CLI from your terminal or scripts, and MCP with agents such as Claude Code, Codex, and Cursor. Run `tossctl mcp` from the same binary — no separate server package to install.
 
-| | CLI | MCP |
-|---|---|---|
-| Best for | Terminals, scripts, cron, pipelines | AI agents such as Claude Code, Codex, and Cursor |
-| Run | `tossctl account summary` | Register `tossctl mcp` with a host |
-| Strength | Full surface, deterministic output, easy automation | Natural-language calls and schema discovery |
-| Output | table · JSON · CSV · stream | Structured MCP responses |
-
-The MCP surface is **111 operations**, but it does not keep each one resident as a separate tool. Three catalog tools discover and load only the schema needed for each call, keeping context usage constant.
+The default MCP surface is **111 operations**. Three catalog tools discover the right operation, load its schema, and call it, without loading every operation's description into context at once.
 
 ```bash
 # Claude Code
 claude mcp add tossctl tossctl mcp
-
-# Shell-capable agents
-tossctl ops list --query dividend
-tossctl ops describe dividends
 ```
 
-For other MCP hosts:
+<details>
+<summary>Other MCP hosts · Discover operations from the CLI</summary>
+
+Add this configuration if your host supports this format. See the [MCP guide](https://tossinvest-cli.vercel.app/en/docs/guide/mcp) for host-specific setup.
 
 ```json
 {
@@ -126,85 +115,55 @@ For other MCP hosts:
 }
 ```
 
+Shell-capable agents can explore the same catalog:
+
+```bash
+tossctl ops list --query dividend
+tossctl ops describe dividends
+```
+
+</details>
+
 See the [AI agent guide](https://tossinvest-cli.vercel.app/en/docs/guide/agents) and [MCP guide](https://tossinvest-cli.vercel.app/en/docs/guide/mcp) for details.
 
-## Preview
-
-### Install through the first query
+<details>
+<summary>Demo — installation through the first query</summary>
 
 <p align="center">
   <img src="docs/assets/demo/install.gif" alt="Install and sign in to tossctl, then run the first account query" width="760" />
 </p>
 
-### Connect MCP to an AI agent
+</details>
+
+<details>
+<summary>Demo — connect MCP to an AI agent</summary>
 
 <p align="center">
   <img src="docs/assets/demo/mcp.gif" alt="Connect the tossctl MCP server to an AI agent" width="760" />
 </p>
 
-## Examples
-
-```bash
-# Accounts and portfolios
-tossctl account overview
-tossctl portfolio positions --output json
-
-# Quotes and market data
-tossctl quote get A005930
-tossctl market index
-tossctl market news --limit 10
-
-# Real-time data
-tossctl stream --trade A005930
-
-# Watch for API contract changes
-tossctl monitor api           # schema-probe 82 endpoints; exit 0 pass, 1 fail
-```
-
-Use `--output json` or `--output csv` to connect commands to automation. `tossctl <command> --help` always shows the current options.
+</details>
 
 ## Safety Model
 
 > [!IMPORTANT]
 > Live trading is disabled after installation. Even after an action is enabled in config, every real submission requires a preview and confirmation token.
 
-```mermaid
-flowchart LR
-    I[Order intent] --> V[Preview validation]
-    V --> G{Allowed by config?}
-    G -->|No| B[Blocked]
-    G -->|Yes| H[Human checks confirm token]
-    H --> E[Submit through official API]
-```
-
 ```bash
 tossctl order preview --symbol AAPL --side buy --qty 1 --price 200
-# Run order place only after a human checks the result and token
+# Preview only. A human must review the result and confirmation token before placing an order.
 ```
 
-- Live place, cancel, and amend operations use only the official Open API path.
-- WTS settings writes preview by default and re-read server state after execution.
-- Irreversible operations require an additional acknowledgement.
-- Paper trading has separate authorization and appears only after explicit opt-in.
+- **Live orders:** regular CLI orders use either the official API or WTS, without retrying through another backend on failure. MCP and `ops` orders, and all conditional orders, are official-API-only.
+- **Settings:** watchlists, price alerts, and similar changes require a preview and a state-bound confirmation token. Irreversible actions require an additional acknowledgement.
+- **Paper trading:** activation and authorization are separate. Approval for a paper trade never authorizes a live trade.
 
 See the [safety guide](https://tossinvest-cli.vercel.app/en/docs/guide/safety) and [`docs/configuration.md`](docs/configuration.md) for the full policy.
 
-## Authentication and Diagnostics
+<details>
+<summary>Experimental — US-options paper trading</summary>
 
-| Purpose | Command |
-|---|---|
-| Sign in to a WTS web session | `tossctl auth login` |
-| Sign in with a phone link | `tossctl auth login --link` |
-| Check session state | `tossctl auth status` |
-| Connect the official Open API | `tossctl openapi login` |
-| Diagnose official API and allowed IPs | `tossctl openapi status` |
-| Diagnose the complete environment | `tossctl doctor --report` |
-
-When session expiry is near, `tossctl auth extend --if-expiring 48h` asks for phone approval only when needed. See [`docs/operations.md`](docs/operations.md) for scheduled checks and failure notifications.
-
-## Experimental Features
-
-US-options paper trading runs in a separate environment while it stabilizes. It stays hidden unless the user opts in, at which point its commands and MCP operations become discoverable.
+This feature is still stabilizing and hidden by default. Add the following to `config.json` to expose its commands and MCP operations. Enabling it does not bypass server-side eligibility requirements.
 
 ```json
 {
@@ -216,6 +175,8 @@ US-options paper trading runs in a separate environment while it stabilizes. It 
 
 Experimental APIs may change and never promote themselves to live-trading authorization. Their current status and limits are tracked in the [support scope](https://tossinvest-cli.vercel.app/en/docs/reference/support-scope).
 
+</details>
+
 ## Documentation
 
 | Document | Covers |
@@ -223,20 +184,14 @@ Experimental APIs may change and never promote themselves to live-trading author
 | [Quick start](https://tossinvest-cli.vercel.app/en/docs/getting-started/quickstart) | Install through first query |
 | [Command reference](https://tossinvest-cli.vercel.app/en/docs/reference/commands) | All CLI commands and examples |
 | [Support scope](https://tossinvest-cli.vercel.app/en/docs/reference/support-scope) | Official API and WTS feature matrix |
-| [MCP](https://tossinvest-cli.vercel.app/en/docs/guide/mcp) | Agent setup and catalog design |
 | [Configuration](docs/configuration.md) | Config fields and local state |
-| [Operations](docs/operations.md) | 82 API probes and change monitoring |
+| [Operations](docs/operations.md) | Session renewal, API monitoring, scheduled checks and alerts |
 | [Architecture](docs/architecture.md) | Routing, modules, and safety boundaries |
 | [Changelog](CHANGELOG.md) | Release changes and contributor credits |
 
 ## Development and Contributing
 
-```bash
-make build
-make test
-make fmt
-make tidy
-```
+Build locally with `make build` and run tests with `make test`.
 
 Use [Issues](https://github.com/JungHoonGhae/tossinvest-cli/issues) for bugs and proposals, and Pull Requests for changes. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for project conventions and [`SECURITY.md`](SECURITY.md) for security reports.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <strong>공식 API로는 못 보는 토스증권 데이터까지, CLI와 MCP로.</strong>
-  <br />공식 Open API 범위를 포함하고 수급·AI 시그널·뉴스·배당·관심종목 등 WTS 전용 기능까지 하나의 <code>tossctl</code>로 연결합니다.
+  <br />계좌·시세·주문에 수급·AI 시그널·배당·관심종목을 더하세요.<br />터미널, 스크립트, AI 에이전트에서 같은 <code>tossctl</code>로 사용합니다.
 </p>
 
 <p align="center">
@@ -30,13 +30,13 @@
 
 ## 왜 tossctl인가?
 
-공식 Open API를 버리거나 우회하기 위한 도구가 아닙니다. **공식 API가 지원하는 작업은 공식 경로를 우선 사용하고, 지원하지 않는 토스증권 기능은 WTS로 보완**합니다. 사용자는 어느 API에 있는지 구분하지 않고 같은 CLI·JSON·MCP 인터페이스로 호출할 수 있습니다.
+**계좌와 주문을 넘어, 토스증권에서 보던 정보를 자동화에 연결합니다.** 공식 Open API에 없는 투자자 수급, AI 시그널, 배당 내역, 관심종목 관리까지 WTS(토스증권 웹 트레이딩 시스템) API로 제공합니다.
 
 <p align="center">
   <img src="diagrams/official-vs-wts-v2.svg" alt="tossctl에서 공식 Open API와 WTS 전용 기능으로 이어지는 경로" width="100%" />
 </p>
 
-공식 API만 필요한 사용자는 더 안전한 공식 경로를 그대로 쓰고, 그 범위를 넘어서는 분석·자동화가 필요할 때만 WTS 기능을 함께 얻습니다. 전체 비교는 [지원 범위](https://tossinvest-cli.vercel.app/docs/reference/support-scope)에서 추적합니다.
+공식 키가 있으면 지원되는 조회는 기본적으로 공식 API를 우선 사용합니다. WTS 기능은 웹 세션으로 연결합니다. 현재 지원 대상은 **토스증권**이며, 일반 토스뱅킹·카드 소비 내역은 지원하지 않습니다. [전체 기능 비교 →](https://tossinvest-cli.vercel.app/docs/reference/support-scope)
 
 ## 빠른 시작
 
@@ -44,79 +44,68 @@ macOS / Linux:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/JungHoonGhae/tossinvest-cli/main/install.sh | sh
-tossctl doctor
 tossctl auth login
 tossctl account summary --output json
 ```
 
-Windows PowerShell:
+휴대폰 인증 후 **이 기기 로그인 유지**까지 승인하세요. QR 대신 링크를 쓰려면 `tossctl auth login --link`로 로그인합니다.
+
+<details>
+<summary>Windows · Homebrew · 공식 API 연결</summary>
+
+Windows PowerShell에서 설치한 뒤 위의 로그인·조회 명령을 실행하세요.
 
 ```powershell
 irm https://raw.githubusercontent.com/JungHoonGhae/tossinvest-cli/main/install.ps1 | iex
 ```
 
-QR 대신 휴대폰에서 링크를 열어 로그인할 수도 있습니다.
+공식 Open API 키를 연결하려면:
 
 ```bash
-tossctl auth login --link
+tossctl openapi login
+tossctl openapi status
 ```
 
-로그인 후 휴대폰의 **이 기기 로그인 유지** 확인까지 완료하세요. Homebrew·소스 빌드와 자세한 인증 과정은 [설치 문서](https://tossinvest-cli.vercel.app/docs/getting-started/installation)에 있습니다.
+Homebrew·소스 빌드는 [설치 문서](https://tossinvest-cli.vercel.app/docs/getting-started/installation), 인증·연결 문제는 `tossctl doctor --report`를 참고하세요.
 
-## 무엇을 할 수 있나요?
+</details>
 
-| 영역 | 예시 |
-|---|---|
-| 계좌·포트폴리오 | 계좌 요약, 보유 종목, 수익률, 배당, 거래 내역 |
-| 시세·시장 | 현재가, 호가, 차트, 수급, 지수, 뉴스, 스크리너, AI 시그널 |
-| 관심종목·설정 | 관심종목 폴더, 목표가 알림, 숨긴 보유종목, Open API 허용 IP |
-| 거래 | 국내·미국 주식, 소수점·조건 주문, 취소·정정, 주문 미리보기 |
-| 실시간·자동화 | WebSocket 스트림, SSE 푸시, JSON·CSV 출력, API 회귀 감시 |
-| 실험적 기능 | 격리된 미국 옵션 모의투자 환경 |
+## 이렇게 사용하세요
 
-공식 Open API의 지원 범위를 포함하며, WTS에서 확인된 토스 고유 기능도 제공합니다. 전체 명령과 지원 여부는 [명령 레퍼런스](https://tossinvest-cli.vercel.app/docs/reference/commands)와 [지원 범위](https://tossinvest-cli.vercel.app/docs/reference/support-scope)에서 확인하세요.
+```bash
+# 수급과 AI 시그널로 시장 살펴보기 — WTS 전용
+tossctl quote flows A005930
+tossctl market signals
 
-## 동작 방식
+# 배당과 전체 계좌 자산 모아보기 — WTS 전용
+tossctl portfolio dividends
+tossctl account overview
 
-```mermaid
-flowchart LR
-    U[사용자 · 스크립트 · AI 에이전트] --> C[CLI]
-    U --> M[MCP]
-    C --> T[tossctl]
-    M --> T
-    T --> R{자동 라우팅}
-    R -->|공식 키| O[토스 공식 Open API]
-    R -->|웹 세션| W[토스증권 WTS]
-    T -->|별도 opt-in| P[모의투자 환경]
+# 보유 종목을 스크립트로 넘기기
+tossctl portfolio positions --output json
+
+# 실시간 체결 구독과 API 변경 감시
+tossctl stream --trade A005930
+tossctl monitor api           # 82개 endpoint schema probe; 통과 0, 실패 1
 ```
 
-- 공식 키가 있으면 지원되는 작업은 공식 Open API를 우선 사용합니다.
-- 웹 세션은 공식 API에 없는 조회·설정 기능을 엽니다.
-- 인증 하나만으로 시작할 수 있고, 둘 다 연결하면 가장 넓은 기능 범위를 사용할 수 있습니다.
+관심종목 폴더·목표가 알림 관리, 조건검색, 거래 내역, 주문 미리보기도 제공합니다. 전체 사용법은 [명령 레퍼런스](https://tossinvest-cli.vercel.app/docs/reference/commands), 개별 옵션은 `tossctl <command> --help`에서 확인하세요.
 
 ## CLI와 MCP
 
-같은 바이너리를 두 가지 방식으로 사용합니다.
+터미널·스크립트에서는 CLI로, Claude Code·Codex·Cursor 같은 AI 에이전트에서는 MCP로 사용하세요. 별도 서버를 설치하지 않고 같은 바이너리에서 `tossctl mcp`를 실행합니다.
 
-| | CLI | MCP |
-|---|---|---|
-| 적합한 용도 | 터미널, 스크립트, cron, 파이프라인 | Claude Code·Codex·Cursor 등 AI 에이전트 |
-| 실행 | `tossctl account summary` | `tossctl mcp`를 호스트에 등록 |
-| 장점 | 전 기능, 결정적 출력, 자동화하기 쉬움 | 자연어 호출, 스키마 자동 탐색 |
-| 출력 | table · JSON · CSV · stream | 구조화된 MCP 응답 |
-
-MCP의 API 표면은 **111개 오퍼레이션**이지만 이를 개별 도구로 상주시켜 두지 않습니다. 필요한 스키마만 찾고 호출하는 세 개의 카탈로그 도구로 컨텍스트 사용량을 일정하게 유지합니다.
+MCP의 기본 API 표면은 **111개 오퍼레이션**입니다. 세 개의 카탈로그 도구가 필요한 기능과 스키마를 찾아 호출하므로, 모든 기능 설명을 한꺼번에 컨텍스트에 넣지 않습니다.
 
 ```bash
 # Claude Code
 claude mcp add tossctl tossctl mcp
-
-# 셸을 사용하는 에이전트
-tossctl ops list --query dividend
-tossctl ops describe dividends
 ```
 
-다른 MCP 호스트는 다음 설정을 사용합니다.
+<details>
+<summary>다른 MCP 호스트 설정 · CLI에서 기능 탐색</summary>
+
+MCP 호스트가 아래 형식의 설정을 지원하면 추가하세요. 호스트별 등록 방법은 [MCP 가이드](https://tossinvest-cli.vercel.app/docs/guide/mcp)를 참고하세요.
 
 ```json
 {
@@ -126,85 +115,55 @@ tossctl ops describe dividends
 }
 ```
 
+셸 기반 에이전트도 같은 카탈로그를 탐색할 수 있습니다.
+
+```bash
+tossctl ops list --query dividend
+tossctl ops describe dividends
+```
+
+</details>
+
 자세한 내용은 [AI 에이전트 가이드](https://tossinvest-cli.vercel.app/docs/guide/agents)와 [MCP 가이드](https://tossinvest-cli.vercel.app/docs/guide/mcp)를 참고하세요.
 
-## 사용 모습
-
-### 설치에서 첫 조회까지
+<details>
+<summary>설치부터 첫 조회까지 — 데모</summary>
 
 <p align="center">
   <img src="docs/assets/demo/install.gif" alt="tossctl 설치와 로그인 후 첫 계좌 조회" width="760" />
 </p>
 
-### AI 에이전트에 MCP 연결
+</details>
+
+<details>
+<summary>AI 에이전트에 MCP 연결 — 데모</summary>
 
 <p align="center">
   <img src="docs/assets/demo/mcp.gif" alt="tossctl MCP 서버를 AI 에이전트에 연결" width="760" />
 </p>
 
-## 사용 예
-
-```bash
-# 계좌와 포트폴리오
-tossctl account overview
-tossctl portfolio positions --output json
-
-# 시세와 시장 데이터
-tossctl quote get A005930
-tossctl market index
-tossctl market news --limit 10
-
-# 실시간 데이터
-tossctl stream --trade A005930
-
-# API 계약 변경 감시
-tossctl monitor api           # 82개 endpoint schema probe; 통과 0, 실패 1
-```
-
-명령은 `--output json` 또는 `--output csv`로 자동화에 연결할 수 있습니다. `tossctl <command> --help`에서 항상 현재 옵션을 확인할 수 있습니다.
+</details>
 
 ## 안전 모델
 
 > [!IMPORTANT]
 > 실거래는 설치 직후 모두 꺼져 있습니다. 설정에서 해당 액션을 허용하더라도 실제 제출 전마다 미리보기와 확인 토큰이 필요합니다.
 
-```mermaid
-flowchart LR
-    I[주문 의도] --> V[preview 검증]
-    V --> G{config 허용?}
-    G -->|아니요| B[차단]
-    G -->|예| H[사람이 confirm token 확인]
-    H --> E[공식 API로 제출]
-```
-
 ```bash
 tossctl order preview --symbol AAPL --side buy --qty 1 --price 200
-# 사람이 결과와 token을 확인한 뒤에만 order place 실행
+# 미리보기만 실행합니다. 실제 주문은 사람이 결과와 확인 토큰을 검토한 뒤 진행하세요.
 ```
 
-- 실주문 생성·취소·정정은 공식 Open API 경로만 사용합니다.
-- WTS 설정 변경도 기본값은 preview이며 실행 후 서버 상태를 다시 확인합니다.
-- 되돌릴 수 없는 작업은 추가 확인을 요구합니다.
-- 모의투자는 실거래 권한과 분리되어 있으며 명시적으로 활성화한 사용자에게만 노출됩니다.
+- **실주문:** CLI 일반 주문은 공식 API 또는 WTS 중 한 경로로 제출하며, 실패해도 다른 경로로 재주문하지 않습니다. MCP·`ops` 주문과 조건주문은 공식 API 전용입니다.
+- **설정 변경:** 관심종목·목표가 알림 등도 미리보기 후 현재 상태에 묶인 확인 토큰으로 실행합니다. 되돌릴 수 없는 작업은 추가 확인이 필요합니다.
+- **모의투자:** 별도 활성화·승인을 사용하며, 모의투자 승인이 실거래 승인으로 이어지지 않습니다.
 
 전체 정책과 설정 예시는 [안전 가이드](https://tossinvest-cli.vercel.app/docs/guide/safety)와 [`docs/configuration.md`](docs/configuration.md)를 참고하세요.
 
-## 인증과 상태 확인
+<details>
+<summary>실험적 기능 — 미국 옵션 모의투자</summary>
 
-| 목적 | 명령 |
-|---|---|
-| WTS 웹 세션 로그인 | `tossctl auth login` |
-| 휴대폰 링크 로그인 | `tossctl auth login --link` |
-| 세션 상태 확인 | `tossctl auth status` |
-| 공식 Open API 연결 | `tossctl openapi login` |
-| 공식 API·허용 IP 진단 | `tossctl openapi status` |
-| 전체 환경 진단 | `tossctl doctor --report` |
-
-세션 만료가 가까우면 `tossctl auth extend --if-expiring 48h`로 필요한 때에만 휴대폰 승인을 요청할 수 있습니다. 예약 실행과 장애 알림 구성은 [`docs/operations.md`](docs/operations.md)에 있습니다.
-
-## 실험적 기능
-
-미국 옵션 모의투자는 안정화 중인 별도 환경입니다. 일반 사용자에게는 숨겨져 있고 다음 설정으로 opt-in한 경우에만 명령과 MCP 오퍼레이션에 나타납니다.
+아직 안정화 중인 기능으로, 기본적으로 숨겨져 있습니다. `config.json`에 아래 설정을 추가하면 명령과 MCP 오퍼레이션에 나타납니다. 활성화해도 서버 측 이용 자격은 별도로 충족해야 합니다.
 
 ```json
 {
@@ -216,6 +175,8 @@ tossctl order preview --symbol AAPL --side buy --qty 1 --price 200
 
 실험적 API는 변경될 수 있으며 실거래로 자동 승격되지 않습니다. 상태와 제한은 [지원 범위 문서](https://tossinvest-cli.vercel.app/docs/reference/support-scope)에 표시합니다.
 
+</details>
+
 ## 문서
 
 | 문서 | 내용 |
@@ -223,20 +184,14 @@ tossctl order preview --symbol AAPL --side buy --qty 1 --price 200
 | [빠른 시작](https://tossinvest-cli.vercel.app/docs/getting-started/quickstart) | 설치 후 첫 조회까지 |
 | [명령 레퍼런스](https://tossinvest-cli.vercel.app/docs/reference/commands) | 전체 CLI 명령과 예시 |
 | [지원 범위](https://tossinvest-cli.vercel.app/docs/reference/support-scope) | 공식 API·WTS 기능 비교 |
-| [MCP](https://tossinvest-cli.vercel.app/docs/guide/mcp) | 에이전트 등록과 카탈로그 구조 |
 | [설정](docs/configuration.md) | config 필드와 로컬 상태 |
-| [운영](docs/operations.md) | 82개 API probe와 변경 감시 |
+| [운영](docs/operations.md) | 세션 갱신, API 변경 감시, 예약 실행과 알림 |
 | [아키텍처](docs/architecture.md) | 라우팅·모듈·안전 경계 |
 | [변경 내역](CHANGELOG.md) | 버전별 변경 사항과 기여자 크레딧 |
 
 ## 개발과 기여
 
-```bash
-make build
-make test
-make fmt
-make tidy
-```
+로컬 빌드는 `make build`, 테스트는 `make test`로 실행합니다.
 
 버그와 제안은 [Issues](https://github.com/JungHoonGhae/tossinvest-cli/issues), 변경 사항은 Pull Request로 보내주세요. 자세한 기준은 [`CONTRIBUTING.md`](CONTRIBUTING.md), 보안 문제는 [`SECURITY.md`](SECURITY.md)를 확인하세요.
 

--- a/tools/tests/test_readme_visuals.py
+++ b/tools/tests/test_readme_visuals.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 import unittest
 
 
@@ -6,6 +7,42 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 
 
 class TestReadmeVisuals(unittest.TestCase):
+    def test_readmes_preserve_visuals_and_automation_markers(self):
+        for name in ("README.md", "README.en.md"):
+            with self.subTest(readme=name):
+                readme = (ROOT / name).read_text(encoding="utf-8")
+                for asset in (
+                    "docs/assets/hero-banner-v5.png",
+                    "docs/assets/demo/install.gif",
+                    "docs/assets/demo/mcp.gif",
+                    "docs/assets/star-history/star-history-v2-dark.svg",
+                    "docs/assets/star-history/star-history-v2-light.svg",
+                ):
+                    self.assertIn(asset, readme)
+                    self.assertTrue((ROOT / asset).is_file(), asset)
+                self.assertIn(
+                    "https://contrib.rocks/image?repo=JungHoonGhae/tossinvest-cli",
+                    readme,
+                )
+                for section in ("sponsors", "star-history"):
+                    start, end = f"<!-- {section}:start -->", f"<!-- {section}:end -->"
+                    self.assertEqual(readme.count(start), 1)
+                    self.assertEqual(readme.count(end), 1)
+                    self.assertLess(readme.index(start), readme.index(end))
+
+    def test_translations_keep_the_same_command_examples(self):
+        examples = []
+        for name in ("README.md", "README.en.md"):
+            readme = (ROOT / name).read_text(encoding="utf-8")
+            examples.append([
+                line.split("#", 1)[0].strip()
+                for block in re.findall(r"```bash\n(.*?)```", readme, re.DOTALL)
+                for line in block.splitlines()
+                if line.strip() and not line.startswith("#")
+            ])
+        self.assertTrue(examples[0])
+        self.assertEqual(*examples)
+
     def test_readmes_use_versioned_polished_routing_diagrams(self):
         cases = (
             ("README.md", "diagrams/official-vs-wts-v2.svg"),


### PR DESCRIPTION
## Summary
- Lead the Korean and English READMEs with WTS-only capabilities and practical examples; collapse advanced setup and demos.
- Preserve the hero, contributors, sponsor automation and Star History; correct live-order routing and paper-trading eligibility descriptions.
- Add regression checks for visual assets, automation markers and bilingual command examples.

## Validation
- Python tooling suite: 95 tests passed.
- Documented operation/probe counts match the runtime catalog.
- Example command help and git diff whitespace checks passed.

Documentation only; no version bump or release. GitHub description and relevant topics were updated separately.