### PR TITLE
[breaking-risk] docs(analysis): API 변경 분석 2026-09-08

### DIFF
--- a/docs/reverse-engineering/change-analysis/2026-09-08.md
+++ b/docs/reverse-engineering/change-analysis/2026-09-08.md
@@ -1,0 +1,63 @@
+> breaking-risk
+
+# API 변경 분석 — 2026-09-08
+
+## 요약
+
+**분류: (c) breaking risk.** 공식 스펙은 `1.2.14 → 1.2.15`로 바뀌었다. 경로는 33개, 스키마는 90개로 각각 추가·삭제가 없다. 설명과 오류 예제 변경이지만, 명시된 캔들 정렬 순서가 현재 차트 출력의 가정과 충돌한다. 주문 조회 범위와 국내 영숫자 종목코드도 기존 소비자가 확인해야 할 계약이다. 서버가 이번 커밋 시점에 실제 동작을 바꿨다는 의미는 아니다.
+
+- 대상: `f74ab97d329ab7ec75e0a4e7252d47cf7359e81d`와 그 부모.
+- 분석 명령: `python3 tools/openapi_diff.py --rev f74ab97d329ab7ec75e0a4e7252d47cf7359e81d`.
+- 결과: 필드 설명 7건, 오퍼레이션 설명 3건, 도구 미분류 11건. 미분류 경로는 원문 전체를 읽고 아래에서 모두 분류했다.
+- AsyncAPI는 두 리비전의 blob이 `cfdfff7d78438ff39d1cbea44c11e327ed514979`로 동일하다. 해당 커밋의 변경 파일에도 없어 추가 diff 대상이 아니다.
+
+## 구현·공유 레지스트리 커버리지 비교
+
+신규 endpoint는 없다. 따라서 이번 변경으로 추가해야 할 endpoint 구현은 없으며, 기존 구현과 설명의 정합성이 검토 대상이다.
+
+| 변경 | `internal/official/` 구현 | `internal/ops/` 및 소비자 영향 | 판단 |
+| --- | --- | --- | --- |
+| `GET /api/v1/candles`, `CandlePageResponse.candles`: timestamp 내림차순 명시 | `candle_reads.go`의 `Candles`·`adaptCandles`가 응답 순서를 그대로 보존 | `read_operations.go`의 `candles` 등록은 있으나 순서 설명이 없다. `internal/hybrid/client.go:GetChart`도 그대로 전달한다. `internal/output/chart.go:writeChartTable`은 마지막 요소의 종가를 대표 가격으로 사용하므로 가장 오래된 봉을 표시한다. | breaking risk: 여러 봉 응답에서 출력 가정 불일치 |
+| `GET /api/v1/market-indicators/{symbol}/candles`, `MarketIndicatorCandlePageResponse.candles`: 같은 정렬 설명 | `market_reads.go:MarketIndicatorCandles`·`adaptMarketIndicatorCandles`가 순서 보존 | 공유 ops에 이 endpoint의 직접 등록은 없다. `cmd/tossctl/market.go`와 hybrid에는 호출 경로가 있다. | 순서 계약 문서화 대상. 등록 공백은 기존 상태 |
+| `GET /api/v1/orders`: 지원 호가 유형만 목록·상세에 노출 | `orders_reads.go:Orders`·`OrderByID`가 공식 응답 사용 | `read_operations.go`의 `orders`·`order`는 등록돼 있다. 목록 설명에는 페이지 제한만 있고 호가 유형 제한은 없다. | breaking risk: 전체 주문 내역으로 해석하면 누락 오판 |
+| 국내 종목 심볼: 숫자 전용 설명을 6자리 영숫자 조합까지 확장 | `orders_write.go`, `conditional_writes.go`, `conditional_reads.go`, `orders_reads.go`, `reads.go`, `market_reads.go`는 심볼을 문자열로 전달·수신한다. 공용 파라미터 참조 구현도 문자열 사용 | `holdings`, `orders`, `conditional_orders`, `place_order`, `place_conditional_order` 등 기존 등록 사용. 별도 인접 위험으로 `stream.go:marketOf`는 숫자 6자리만 `kr`로 분류해 스펙 예시 `0101N0`를 `us`로 보낸다. | REST 설명 확장 자체는 호환적. 스트림 시장 추론은 후속 점검 필요 |
+| Unauthorized의 `tokenRevoked` 예제 추가 | `client.go:send`가 모든 HTTP 401에 토큰 재발급 후 한 번 재시도. 이후 `errors.go:classifyStatus`가 인증 오류로 분류 | 공유 ops는 기존 공식 클라이언트의 인증 처리를 사용 | (a) no-op: 새 오류 코드에 따른 필수 분기 추가는 없음 |
+
+공용 `KrSymbol`은 신용거래·투자자매매·프로그램매매·대차거래·공매도 5개 경로가 참조한다. 구현은 `supply_reads.go:Supply`, 공유 등록은 `stock_supply`다. `Symbol`은 `warnings_reads.go`와 `warnings`에 연결된다. `SymbolQuery`는 캔들·호가·가격 제한·매도 가능 수량·체결에 쓰이며 `candle_reads.go`, `market_reads.go`, `price_limits_reads.go`, `sellable_qty_reads.go` 및 기존 ops가 처리한다. 이번 커밋에서 파라미터 타입이나 허용 패턴이 바뀐 것은 아니다.
+
+필드 설명 변경 7건은 두 캔들 응답과 `ConditionalOrderCreateRequest.symbol`, `ConditionalOrderDetailResponse.symbol`, `HoldingsItem.symbol`, `Order.symbol`, `RankingItem.symbol`이다. 순위 응답도 `market_reads.go`에서 문자열을 보존한다. 공유 레지스트리의 `stock_ranking`은 WTS 등록이므로 공식 순위 응답 변경을 그 등록의 직접 변경으로 보지 않는다.
+
+주문 조회 설명은 지정가·시장가·장마감지정가만 포함한다고 명시한다. 시간외단일가·장후시간외 종가·장전시간외 종가 등은 `OPEN`·`CLOSED` 목록과 상세 조회에서 제외된다. 성공한 조회의 빈 목록을 “주문 없음”으로 단정하거나 페이지를 모두 읽으면 전체 내역이 확보된다고 안내해서는 안 된다. 상세 조회에서 제외 주문에 어떤 상태 코드를 반환하는지는 이번 설명으로 확정할 수 없다.
+
+## 미분류 경로 전수 검토
+
+도구가 출력한 11개 경로를 아래처럼 분류했다. 잘린 출력에 의존하지 않고 양쪽 JSON의 전체 값을 확인했다. 도구 파일은 수정하지 않았으며, 원본 도구의 미분류 11건과 수동 검토 후 잔여 0건을 구분한다.
+
+| 경로 | 확인 결과·분류 |
+| --- | --- |
+| `components.parameters.KrSymbol.description` | 국내 영숫자 코드 설명·예시 추가. 호환적 문서 보강, 시장 추론 점검에 포함 |
+| `components.parameters.Symbol.description` | 같은 설명 확장. 기존 허용 문자 설명은 유지 |
+| `components.parameters.SymbolQuery.description` | 같은 설명 확장. 기존 허용 문자 설명은 유지 |
+| `components.responses.Unauthorized.content.application/json.examples.tokenRevoked.summary` | 토큰 재발급에 따른 무효화 예제 제목 추가. no-op |
+| `components.responses.Unauthorized.content.application/json.examples.tokenRevoked.value.error.code` | `token-revoked` 예제 추가. 기존 401 처리로 대응 |
+| `components.responses.Unauthorized.content.application/json.examples.tokenRevoked.value.error.message` | 최신 토큰으로 재시도하라는 예제 메시지 추가. no-op |
+| `components.responses.Unauthorized.content.application/json.examples.tokenRevoked.value.error.requestId` | 문서용 요청 식별자 예제 추가. 런타임 필드 계약 변경 아님 |
+| `components.schemas.OrderCreateRequest.oneOf[0].properties.symbol.description` | 일반 주문 요청의 국내 영숫자 코드 설명 확장. 문자열 전송 구현 유지 |
+| `paths./api/v1/conditional-orders.get.parameters[2].description` | 선택적 심볼 필터의 국내 코드 설명 확장. `OPEN`·`CLOSED` 지원 유지 |
+| `paths./api/v1/holdings.get.parameters[1].description` | 국내 코드 설명 확장. 심볼 필터에 따른 요약 재계산 및 미지정 시 전체 반환 설명 유지 |
+| `paths./api/v1/orders.get.parameters[2].description` | 국내 코드 설명 확장. 선택적 필터 및 허용 문자 설명 유지 |
+
+최종 **[미분류 변경] 없음**. 도구에서 추출한 11개 경로 집합과 수동 분류 집합이 정확히 일치하는지 별도 메모리 내 검증으로 확인했다.
+
+## 권장 후속 조치
+
+1. 차트의 시간 순서 계약을 먼저 정하고 어댑터·표 출력·JSON/CSV 소비자를 맞춘다. 최신순의 서로 다른 봉 두 개 이상을 넣는 오프라인 테스트로 대표 가격과 시간축을 검증한다. 지수 캔들도 같은 순서 설명을 문서에 추가한다.
+2. `orders`·`order`의 ops 설명과 CLI 도움말에 호가 유형에 따른 조회 제외 범위를 적는다. 주문 동기화·대사 소비자가 공식 조회를 전체 주문의 근거로 삼는지 점검한다.
+3. `stream.go:marketOf`와 스트림 도움말의 숫자 전용 가정을 재검토한다. `0101N0`와 미국 티커를 함께 다루는 오프라인 회귀 테스트를 추가한다. AsyncAPI 변경이 없으므로 REST 설명만으로 스트림 서버의 지원 범위까지 확정하지 않는다.
+4. 기존 401 재발급 테스트에 `token-revoked` 예제 응답을 추가해 복구와 한 번 재시도 제한을 확인한다. 새 endpoint 개발보다 위 호환성 점검을 우선한다.
+
+## 분석 범위와 실행 기록
+
+실제 계좌 데이터와 실서비스 API는 사용하지 않았다. 코드·테스트 수정, 커밋, push는 하지 않았다. 검토는 로컬 스펙과 코드의 정적 분석이며 런타임 테스트는 수행하지 않았다.
+
+최초 도구 실행에서 부분 복제 저장소의 부모 스냅샷 객체가 누락돼 Git이 GitHub 자동 fetch를 시도했으나 DNS 오류로 실패했다. 이는 GitHub 호출 금지 조건을 완전히 지키지 못한 실행상 이탈이다. 이후 `GIT_NO_LAZY_FETCH=1`, `protocol.allow=never`로 네트워크를 차단하고 `GIT_ALTERNATE_OBJECT_DIRECTORIES`로 기존 로컬 저장소의 객체를 읽어 동일 명령을 성공시켰다. Git 설정과 객체 파일은 직접 변경하지 않았고 OpenAPI raw text diff도 사용하지 않았다.


### PR DESCRIPTION
> breaking-risk

# API 변경 분석 — 2026-09-08

## 요약

**분류: (c) breaking risk.** 공식 스펙은 `1.2.14 → 1.2.15`로 바뀌었다. 경로는 33개, 스키마는 90개로 각각 추가·삭제가 없다. 설명과 오류 예제 변경이지만, 명시된 캔들 정렬 순서가 현재 차트 출력의 가정과 충돌한다. 주문 조회 범위와 국내 영숫자 종목코드도 기존 소비자가 확인해야 할 계약이다. 서버가 이번 커밋 시점에 실제 동작을 바꿨다는 의미는 아니다.

- 대상: `f74ab97d329ab7ec75e0a4e7252d47cf7359e81d`와 그 부모.
- 분석 명령: `python3 tools/openapi_diff.py --rev f74ab97d329ab7ec75e0a4e7252d47cf7359e81d`.
- 결과: 필드 설명 7건, 오퍼레이션 설명 3건, 도구 미분류 11건. 미분류 경로는 원문 전체를 읽고 아래에서 모두 분류했다.
- AsyncAPI는 두 리비전의 blob이 `cfdfff7d78438ff39d1cbea44c11e327ed514979`로 동일하다. 해당 커밋의 변경 파일에도 없어 추가 diff 대상이 아니다.

## 구현·공유 레지스트리 커버리지 비교

신규 endpoint는 없다. 따라서 이번 변경으로 추가해야 할 endpoint 구현은 없으며, 기존 구현과 설명의 정합성이 검토 대상이다.

| 변경 | `internal/official/` 구현 | `internal/ops/` 및 소비자 영향 | 판단 |
| --- | --- | --- | --- |
| `GET /api/v1/candles`, `CandlePageResponse.candles`: timestamp 내림차순 명시 | `candle_reads.go`의 `Candles`·`adaptCandles`가 응답 순서를 그대로 보존 | `read_operations.go`의 `candles` 등록은 있으나 순서 설명이 없다. `internal/hybrid/client.go:GetChart`도 그대로 전달한다. `internal/output/chart.go:writeChartTable`은 마지막 요소의 종가를 대표 가격으로 사용하므로 가장 오래된 봉을 표시한다. | breaking risk: 여러 봉 응답에서 출력 가정 불일치 |
| `GET /api/v1/market-indicators/{symbol}/candles`, `MarketIndicatorCandlePageResponse.candles`: 같은 정렬 설명 | `market_reads.go:MarketIndicatorCandles`·`adaptMarketIndicatorCandles`가 순서 보존 | 공유 ops에 이 endpoint의 직접 등록은 없다. `cmd/tossctl/market.go`와 hybrid에는 호출 경로가 있다. | 순서 계약 문서화 대상. 등록 공백은 기존 상태 |
| `GET /api/v1/orders`: 지원 호가 유형만 목록·상세에 노출 | `orders_reads.go:Orders`·`OrderByID`가 공식 응답 사용 | `read_operations.go`의 `orders`·`order`는 등록돼 있다. 목록 설명에는 페이지 제한만 있고 호가 유형 제한은 없다. | breaking risk: 전체 주문 내역으로 해석하면 누락 오판 |
| 국내 종목 심볼: 숫자 전용 설명을 6자리 영숫자 조합까지 확장 | `orders_write.go`, `conditional_writes.go`, `conditional_reads.go`, `orders_reads.go`, `reads.go`, `market_reads.go`는 심볼을 문자열로 전달·수신한다. 공용 파라미터 참조 구현도 문자열 사용 | `holdings`, `orders`, `conditional_orders`, `place_order`, `place_conditional_order` 등 기존 등록 사용. 별도 인접 위험으로 `stream.go:marketOf`는 숫자 6자리만 `kr`로 분류해 스펙 예시 `0101N0`를 `us`로 보낸다. | REST 설명 확장 자체는 호환적. 스트림 시장 추론은 후속 점검 필요 |
| Unauthorized의 `tokenRevoked` 예제 추가 | `client.go:send`가 모든 HTTP 401에 토큰 재발급 후 한 번 재시도. 이후 `errors.go:classifyStatus`가 인증 오류로 분류 | 공유 ops는 기존 공식 클라이언트의 인증 처리를 사용 | (a) no-op: 새 오류 코드에 따른 필수 분기 추가는 없음 |

공용 `KrSymbol`은 신용거래·투자자매매·프로그램매매·대차거래·공매도 5개 경로가 참조한다. 구현은 `supply_reads.go:Supply`, 공유 등록은 `stock_supply`다. `Symbol`은 `warnings_reads.go`와 `warnings`에 연결된다. `SymbolQuery`는 캔들·호가·가격 제한·매도 가능 수량·체결에 쓰이며 `candle_reads.go`, `market_reads.go`, `price_limits_reads.go`, `sellable_qty_reads.go` 및 기존 ops가 처리한다. 이번 커밋에서 파라미터 타입이나 허용 패턴이 바뀐 것은 아니다.

필드 설명 변경 7건은 두 캔들 응답과 `ConditionalOrderCreateRequest.symbol`, `ConditionalOrderDetailResponse.symbol`, `HoldingsItem.symbol`, `Order.symbol`, `RankingItem.symbol`이다. 순위 응답도 `market_reads.go`에서 문자열을 보존한다. 공유 레지스트리의 `stock_ranking`은 WTS 등록이므로 공식 순위 응답 변경을 그 등록의 직접 변경으로 보지 않는다.

주문 조회 설명은 지정가·시장가·장마감지정가만 포함한다고 명시한다. 시간외단일가·장후시간외 종가·장전시간외 종가 등은 `OPEN`·`CLOSED` 목록과 상세 조회에서 제외된다. 성공한 조회의 빈 목록을 “주문 없음”으로 단정하거나 페이지를 모두 읽으면 전체 내역이 확보된다고 안내해서는 안 된다. 상세 조회에서 제외 주문에 어떤 상태 코드를 반환하는지는 이번 설명으로 확정할 수 없다.

## 미분류 경로 전수 검토

도구가 출력한 11개 경로를 아래처럼 분류했다. 잘린 출력에 의존하지 않고 양쪽 JSON의 전체 값을 확인했다. 도구 파일은 수정하지 않았으며, 원본 도구의 미분류 11건과 수동 검토 후 잔여 0건을 구분한다.

| 경로 | 확인 결과·분류 |
| --- | --- |
| `components.parameters.KrSymbol.description` | 국내 영숫자 코드 설명·예시 추가. 호환적 문서 보강, 시장 추론 점검에 포함 |
| `components.parameters.Symbol.description` | 같은 설명 확장. 기존 허용 문자 설명은 유지 |
| `components.parameters.SymbolQuery.description` | 같은 설명 확장. 기존 허용 문자 설명은 유지 |
| `components.responses.Unauthorized.content.application/json.examples.tokenRevoked.summary` | 토큰 재발급에 따른 무효화 예제 제목 추가. no-op |
| `components.responses.Unauthorized.content.application/json.examples.tokenRevoked.value.error.code` | `token-revoked` 예제 추가. 기존 401 처리로 대응 |
| `components.responses.Unauthorized.content.application/json.examples.tokenRevoked.value.error.message` | 최신 토큰으로 재시도하라는 예제 메시지 추가. no-op |
| `components.responses.Unauthorized.content.application/json.examples.tokenRevoked.value.error.requestId` | 문서용 요청 식별자 예제 추가. 런타임 필드 계약 변경 아님 |
| `components.schemas.OrderCreateRequest.oneOf[0].properties.symbol.description` | 일반 주문 요청의 국내 영숫자 코드 설명 확장. 문자열 전송 구현 유지 |
| `paths./api/v1/conditional-orders.get.parameters[2].description` | 선택적 심볼 필터의 국내 코드 설명 확장. `OPEN`·`CLOSED` 지원 유지 |
| `paths./api/v1/holdings.get.parameters[1].description` | 국내 코드 설명 확장. 심볼 필터에 따른 요약 재계산 및 미지정 시 전체 반환 설명 유지 |
| `paths./api/v1/orders.get.parameters[2].description` | 국내 코드 설명 확장. 선택적 필터 및 허용 문자 설명 유지 |

최종 **[미분류 변경] 없음**. 도구에서 추출한 11개 경로 집합과 수동 분류 집합이 정확히 일치하는지 별도 메모리 내 검증으로 확인했다.

## 권장 후속 조치

1. 차트의 시간 순서 계약을 먼저 정하고 어댑터·표 출력·JSON/CSV 소비자를 맞춘다. 최신순의 서로 다른 봉 두 개 이상을 넣는 오프라인 테스트로 대표 가격과 시간축을 검증한다. 지수 캔들도 같은 순서 설명을 문서에 추가한다.
2. `orders`·`order`의 ops 설명과 CLI 도움말에 호가 유형에 따른 조회 제외 범위를 적는다. 주문 동기화·대사 소비자가 공식 조회를 전체 주문의 근거로 삼는지 점검한다.
3. `stream.go:marketOf`와 스트림 도움말의 숫자 전용 가정을 재검토한다. `0101N0`와 미국 티커를 함께 다루는 오프라인 회귀 테스트를 추가한다. AsyncAPI 변경이 없으므로 REST 설명만으로 스트림 서버의 지원 범위까지 확정하지 않는다.
4. 기존 401 재발급 테스트에 `token-revoked` 예제 응답을 추가해 복구와 한 번 재시도 제한을 확인한다. 새 endpoint 개발보다 위 호환성 점검을 우선한다.

## 분석 범위와 실행 기록

실제 계좌 데이터와 실서비스 API는 사용하지 않았다. 코드·테스트 수정, 커밋, push는 하지 않았다. 검토는 로컬 스펙과 코드의 정적 분석이며 런타임 테스트는 수행하지 않았다.

최초 도구 실행에서 부분 복제 저장소의 부모 스냅샷 객체가 누락돼 Git이 GitHub 자동 fetch를 시도했으나 DNS 오류로 실패했다. 이는 GitHub 호출 금지 조건을 완전히 지키지 못한 실행상 이탈이다. 이후 `GIT_NO_LAZY_FETCH=1`, `protocol.allow=never`로 네트워크를 차단하고 `GIT_ALTERNATE_OBJECT_DIRECTORIES`로 기존 로컬 저장소의 객체를 읽어 동일 명령을 성공시켰다. Git 설정과 객체 파일은 직접 변경하지 않았고 OpenAPI raw text diff도 사용하지 않았다.

---
Codex 정기 분석입니다. 검토 후 병합하거나 닫아 주세요.