### PR TITLE
[breaking-risk] docs(analysis): API 변경 분석 2026-09-10

### DIFF
--- a/docs/reverse-engineering/change-analysis/2026-09-10.md
+++ b/docs/reverse-engineering/change-analysis/2026-09-10.md
@@ -1,0 +1,60 @@
+> breaking-risk
+
+# API 변경 분석 — 2026-09-10
+
+## 요약
+
+**분류: (c) breaking risk.** 커밋 `1aab714599f91194cbe4a83c302d5930d59a932c`를 부모 `bfdd329601154c813b1c2faf10fcba6fc5ba521b`와 비교했다. 버전은 `1.2.15 → 1.2.15`, 경로는 `33 → 33`, 스키마는 `90 → 90`으로 추가·삭제가 없다. 그러나 캔들 시각의 의미와 주문 오류의 HTTP 상태 설명이 바뀌어 no-op으로 분류할 수 없다. 이는 스냅샷의 계약 변경 분석이며, 서버 동작이 해당 날짜에 바뀌었다고 확인한 것은 아니다.
+
+- `Candle.timestamp`: 기존 “봉 시작 시각”에서 “봉 기준 시각”으로 변경. `1m`은 종료 시각이며 `[timestamp - 1분, timestamp)` 체결을 집계한다. `1d`는 해당 거래일의 현지 자정이다.
+- 일봉 예제의 시각과 `nextBefore`가 `09:00:00+09:00`에서 `00:00:00+09:00`으로 변경됐다.
+- `POST /api/v1/orders`의 `opposite-pending-order-exists` 오류 예제가 HTTP **422에서 409로 이동**했다. 오류 코드와 메시지는 동일하다. 422 응답 전체가 삭제된 것은 아니다.
+- AsyncAPI는 부모·대상 커밋의 blob이 모두 `cfdfff7d78438ff39d1cbea44c11e327ed514979`로 동일하고 변경 파일 목록에도 없다. 추가 diff 대상이 아니다.
+
+## 구현·공유 레지스트리 커버리지 비교
+
+신규 endpoint는 없어 새 공식 구현이나 ops 등록 후보는 없다. 변경은 다음 기존 구현에 연결된다.
+
+| 변경 대상 | `internal/official/` | `internal/ops/` 및 소비자 | 영향·분류 |
+| --- | --- | --- | --- |
+| `GET /api/v1/candles`, `Candle.timestamp` | `candle_reads.go: Candles`, `adaptCandles`가 RFC3339 시각을 `domain.Candle.Time`에 그대로 보존한다. 스키마 주석은 여전히 `bar open time`이다. | `read_operations.go`의 `candles`가 등록돼 있다. 설명은 과거→최신 순서만 다루고 시각 의미는 설명하지 않는다. `internal/hybrid/client.go:GetChart`와 `internal/output/chart.go`의 CSV 출력에도 해당 시각이 전달된다. | **breaking risk**: 파싱은 가능하지만 시작 시각으로 해석하면 분봉 구간이 1분 어긋난다. 일봉을 장 시작 시각과 결합하는 소비자도 확인해야 한다. |
+| 일봉 예제·`nextBefore` | 같은 파일의 `apiCandlePage.NextBefore`가 수신하고 `Candles`는 입력 `before`를 그대로 전송한다. `adaptCandles`는 응답 커서를 `domain.Chart`에 전달하지 않는다. | `candles`의 `before` 입력은 있으나 반환 커서 노출은 기존부터 없다. `candle_reads_test.go:TestAdaptCandlesUnit`의 일봉 fixture는 아직 오전 9시다. | 예제는 새 시각 의미와 일치하도록 수정됐다. 기존 커서 노출 공백을 이번 회귀로 오인하지 말고, 소비자가 임의로 오전 9시 커서를 합성하는지 점검한다. |
+| `POST /api/v1/orders` 오류 예제 이동 | `orders_write.go:PlaceOrder`가 클라이언트 오류를 반환한다. `errors.go:classifyStatus`는 409와 422 모두 `*APIError`로 처리하고 상태·본문을 보존한다. `ShouldFallback`은 이 오류의 WTS 전환을 막는다. | `write_operations.go`의 `place_order`에 기존 공식 주문 경로가 등록돼 있다. | 내부 오류 분류는 대응 가능하다. 다만 외부 소비자가 422만 처리하면 해당 오류를 놓칠 수 있어 **상태 코드 계약의 호환성 위험**이다. |
+
+`Candle`은 `CandlePageResponse`를 통해 일반 캔들 endpoint에 연결된다. 지수 캔들은 별도 `MarketIndicatorCandlePageResponse`를 사용하므로 이번 설명 변경을 지수 캔들 계약까지 확대해서 해석하지 않는다. 기존 캔들 순서 반전은 그대로 동작하며 이번 위험은 정렬이 아닌 시각의 의미에 있다.
+
+## 미분류 경로 전수 검토
+
+`python3 tools/openapi_diff.py --rev 1aab714599f91194cbe4a83c302d5930d59a932c` 실행 결과는 필드 의미 변경 1건과 미분류 12건이다. 양쪽 JSON을 도구의 `flatten`으로 펼쳐 전체 값을 확인했다. 아래에서 `C`와 `O`는 각각 다음 경로 접두사다.
+
+- `C` = `paths./api/v1/candles.get.responses.200.content.application/json.examples.`
+- `O` = `paths./api/v1/orders.post.responses.`
+
+| 미분류 경로 (`접두사 + 아래 문자열`) | 검토 결과 |
+| --- | --- |
+| `C` + `dailyCandles.value.result.candles[0].timestamp` | 2026-03-25 오전 9시 → 같은 날 현지 자정. 일봉 계약 보강 |
+| `C` + `dailyCandles.value.result.candles[1].timestamp` | 2026-03-24 오전 9시 → 같은 날 현지 자정. 일봉 계약 보강 |
+| `C` + `dailyCandles.value.result.nextBefore` | 2026-03-24 오전 9시 → 같은 날 현지 자정. 커서 예제 정합성 변경 |
+| `C` + `lastPage.value.result.candles[0].timestamp` | 2026-03-20 오전 9시 → 같은 날 현지 자정. 일봉 계약 보강 |
+| `O` + `409.content.application/json.examples.oppositePendingOrderExists.summary` | 반대 방향 미체결 주문 존재 예제 제목 추가 |
+| `O` + `409.content.application/json.examples.oppositePendingOrderExists.value.error.code` | 동일 오류 코드가 409 예제에 추가. 상태 계약 위험 |
+| `O` + `409.content.application/json.examples.oppositePendingOrderExists.value.error.message` | 동일 종목의 반대 방향 체결 대기 주문 안내가 409로 이동 |
+| `O` + `409.content.application/json.examples.oppositePendingOrderExists.value.error.requestId` | 문서용 식별자 예제가 409로 이동. 식별자 스키마 변경 아님 |
+| `O` + `422.content.application/json.examples.oppositePendingOrderExists.summary` | 위 예제 제목이 422에서 삭제 |
+| `O` + `422.content.application/json.examples.oppositePendingOrderExists.value.error.code` | 위 오류 코드가 422 예제에서 삭제. 상태 계약 위험 |
+| `O` + `422.content.application/json.examples.oppositePendingOrderExists.value.error.message` | 위 안내 메시지가 422 예제에서 삭제 |
+| `O` + `422.content.application/json.examples.oppositePendingOrderExists.value.error.requestId` | 문서용 식별자 예제가 422에서 삭제. 런타임 필드 삭제 아님 |
+
+도구가 직접 분류한 `components.schemas.Candle.properties.timestamp.description` 1개와 위 12개를 합친 집합이 전체 변경 경로 13개와 정확히 일치함을 메모리 내 assertion으로 검증했다. **최종 수동 검토 잔여 [미분류 변경] 없음(0건)**. 원본 도구의 미분류 출력 12건을 숨기거나 도구를 수정한 것은 아니다.
+
+## 권장 후속 조치
+
+1. 공식 캔들 주석과 ops·사용자 문서에 분봉 종료 시각 및 일봉 현지 자정 계약을 명시한다. 시각을 일괄적으로 1분 차감하지 말고, 원본 시각 보존과 소비자 표시 기준을 구분한다.
+2. 오프라인 fixture로 분봉 반개구간, 일봉 자정·시간대 보존, `before` 전달을 검증한다. 기존 일봉 오전 9시 예제를 갱신하고 JSON·CSV 소비자가 시각을 시작 시각으로 오해하는지 점검한다.
+3. 주문 오류 테스트에 `opposite-pending-order-exists`의 409 응답을 추가해 상태·본문 보존과 fallback 차단을 확인한다. 422로 고정된 외부 오류 분기가 있다면 수정한다. 이 분석을 이유로 실주문을 실행할 필요는 없다.
+
+## 분석 범위와 실행 기록
+
+로컬 스냅샷·소스·테스트만 정적으로 읽었으며 실제 계좌 데이터와 실서비스 API는 사용하지 않았다. OpenAPI raw text diff, 커밋, push는 수행하지 않았다. 작성한 파일은 이 보고서 하나이며 테스트는 실행하지 않았다.
+
+최초 도구 실행 시 부분 복제 저장소에 부모 OpenAPI blob `e2ca461e0e80116f455abde3efedfaaacd60865b`가 없어 Git이 GitHub 자동 fetch를 시도했으나 DNS 오류로 실패했다. 이는 GitHub 호출 금지 조건을 완전히 지키지 못한 실행상 이탈이다. 이후 `GIT_NO_LAZY_FETCH=1`과 `protocol.allow=never`로 네트워크를 차단하고, `GIT_ALTERNATE_OBJECT_DIRECTORIES`로 기존 로컬 저장소의 객체를 읽어 지정 명령을 성공시켰다. Git 설정이나 객체 파일을 직접 변경하지 않았다.


### PR DESCRIPTION
> breaking-risk

# API 변경 분석 — 2026-09-10

## 요약

**분류: (c) breaking risk.** 커밋 `1aab714599f91194cbe4a83c302d5930d59a932c`를 부모 `bfdd329601154c813b1c2faf10fcba6fc5ba521b`와 비교했다. 버전은 `1.2.15 → 1.2.15`, 경로는 `33 → 33`, 스키마는 `90 → 90`으로 추가·삭제가 없다. 그러나 캔들 시각의 의미와 주문 오류의 HTTP 상태 설명이 바뀌어 no-op으로 분류할 수 없다. 이는 스냅샷의 계약 변경 분석이며, 서버 동작이 해당 날짜에 바뀌었다고 확인한 것은 아니다.

- `Candle.timestamp`: 기존 “봉 시작 시각”에서 “봉 기준 시각”으로 변경. `1m`은 종료 시각이며 `[timestamp - 1분, timestamp)` 체결을 집계한다. `1d`는 해당 거래일의 현지 자정이다.
- 일봉 예제의 시각과 `nextBefore`가 `09:00:00+09:00`에서 `00:00:00+09:00`으로 변경됐다.
- `POST /api/v1/orders`의 `opposite-pending-order-exists` 오류 예제가 HTTP **422에서 409로 이동**했다. 오류 코드와 메시지는 동일하다. 422 응답 전체가 삭제된 것은 아니다.
- AsyncAPI는 부모·대상 커밋의 blob이 모두 `cfdfff7d78438ff39d1cbea44c11e327ed514979`로 동일하고 변경 파일 목록에도 없다. 추가 diff 대상이 아니다.

## 구현·공유 레지스트리 커버리지 비교

신규 endpoint는 없어 새 공식 구현이나 ops 등록 후보는 없다. 변경은 다음 기존 구현에 연결된다.

| 변경 대상 | `internal/official/` | `internal/ops/` 및 소비자 | 영향·분류 |
| --- | --- | --- | --- |
| `GET /api/v1/candles`, `Candle.timestamp` | `candle_reads.go: Candles`, `adaptCandles`가 RFC3339 시각을 `domain.Candle.Time`에 그대로 보존한다. 스키마 주석은 여전히 `bar open time`이다. | `read_operations.go`의 `candles`가 등록돼 있다. 설명은 과거→최신 순서만 다루고 시각 의미는 설명하지 않는다. `internal/hybrid/client.go:GetChart`와 `internal/output/chart.go`의 CSV 출력에도 해당 시각이 전달된다. | **breaking risk**: 파싱은 가능하지만 시작 시각으로 해석하면 분봉 구간이 1분 어긋난다. 일봉을 장 시작 시각과 결합하는 소비자도 확인해야 한다. |
| 일봉 예제·`nextBefore` | 같은 파일의 `apiCandlePage.NextBefore`가 수신하고 `Candles`는 입력 `before`를 그대로 전송한다. `adaptCandles`는 응답 커서를 `domain.Chart`에 전달하지 않는다. | `candles`의 `before` 입력은 있으나 반환 커서 노출은 기존부터 없다. `candle_reads_test.go:TestAdaptCandlesUnit`의 일봉 fixture는 아직 오전 9시다. | 예제는 새 시각 의미와 일치하도록 수정됐다. 기존 커서 노출 공백을 이번 회귀로 오인하지 말고, 소비자가 임의로 오전 9시 커서를 합성하는지 점검한다. |
| `POST /api/v1/orders` 오류 예제 이동 | `orders_write.go:PlaceOrder`가 클라이언트 오류를 반환한다. `errors.go:classifyStatus`는 409와 422 모두 `*APIError`로 처리하고 상태·본문을 보존한다. `ShouldFallback`은 이 오류의 WTS 전환을 막는다. | `write_operations.go`의 `place_order`에 기존 공식 주문 경로가 등록돼 있다. | 내부 오류 분류는 대응 가능하다. 다만 외부 소비자가 422만 처리하면 해당 오류를 놓칠 수 있어 **상태 코드 계약의 호환성 위험**이다. |

`Candle`은 `CandlePageResponse`를 통해 일반 캔들 endpoint에 연결된다. 지수 캔들은 별도 `MarketIndicatorCandlePageResponse`를 사용하므로 이번 설명 변경을 지수 캔들 계약까지 확대해서 해석하지 않는다. 기존 캔들 순서 반전은 그대로 동작하며 이번 위험은 정렬이 아닌 시각의 의미에 있다.

## 미분류 경로 전수 검토

`python3 tools/openapi_diff.py --rev 1aab714599f91194cbe4a83c302d5930d59a932c` 실행 결과는 필드 의미 변경 1건과 미분류 12건이다. 양쪽 JSON을 도구의 `flatten`으로 펼쳐 전체 값을 확인했다. 아래에서 `C`와 `O`는 각각 다음 경로 접두사다.

- `C` = `paths./api/v1/candles.get.responses.200.content.application/json.examples.`
- `O` = `paths./api/v1/orders.post.responses.`

| 미분류 경로 (`접두사 + 아래 문자열`) | 검토 결과 |
| --- | --- |
| `C` + `dailyCandles.value.result.candles[0].timestamp` | 2026-03-25 오전 9시 → 같은 날 현지 자정. 일봉 계약 보강 |
| `C` + `dailyCandles.value.result.candles[1].timestamp` | 2026-03-24 오전 9시 → 같은 날 현지 자정. 일봉 계약 보강 |
| `C` + `dailyCandles.value.result.nextBefore` | 2026-03-24 오전 9시 → 같은 날 현지 자정. 커서 예제 정합성 변경 |
| `C` + `lastPage.value.result.candles[0].timestamp` | 2026-03-20 오전 9시 → 같은 날 현지 자정. 일봉 계약 보강 |
| `O` + `409.content.application/json.examples.oppositePendingOrderExists.summary` | 반대 방향 미체결 주문 존재 예제 제목 추가 |
| `O` + `409.content.application/json.examples.oppositePendingOrderExists.value.error.code` | 동일 오류 코드가 409 예제에 추가. 상태 계약 위험 |
| `O` + `409.content.application/json.examples.oppositePendingOrderExists.value.error.message` | 동일 종목의 반대 방향 체결 대기 주문 안내가 409로 이동 |
| `O` + `409.content.application/json.examples.oppositePendingOrderExists.value.error.requestId` | 문서용 식별자 예제가 409로 이동. 식별자 스키마 변경 아님 |
| `O` + `422.content.application/json.examples.oppositePendingOrderExists.summary` | 위 예제 제목이 422에서 삭제 |
| `O` + `422.content.application/json.examples.oppositePendingOrderExists.value.error.code` | 위 오류 코드가 422 예제에서 삭제. 상태 계약 위험 |
| `O` + `422.content.application/json.examples.oppositePendingOrderExists.value.error.message` | 위 안내 메시지가 422 예제에서 삭제 |
| `O` + `422.content.application/json.examples.oppositePendingOrderExists.value.error.requestId` | 문서용 식별자 예제가 422에서 삭제. 런타임 필드 삭제 아님 |

도구가 직접 분류한 `components.schemas.Candle.properties.timestamp.description` 1개와 위 12개를 합친 집합이 전체 변경 경로 13개와 정확히 일치함을 메모리 내 assertion으로 검증했다. **최종 수동 검토 잔여 [미분류 변경] 없음(0건)**. 원본 도구의 미분류 출력 12건을 숨기거나 도구를 수정한 것은 아니다.

## 권장 후속 조치

1. 공식 캔들 주석과 ops·사용자 문서에 분봉 종료 시각 및 일봉 현지 자정 계약을 명시한다. 시각을 일괄적으로 1분 차감하지 말고, 원본 시각 보존과 소비자 표시 기준을 구분한다.
2. 오프라인 fixture로 분봉 반개구간, 일봉 자정·시간대 보존, `before` 전달을 검증한다. 기존 일봉 오전 9시 예제를 갱신하고 JSON·CSV 소비자가 시각을 시작 시각으로 오해하는지 점검한다.
3. 주문 오류 테스트에 `opposite-pending-order-exists`의 409 응답을 추가해 상태·본문 보존과 fallback 차단을 확인한다. 422로 고정된 외부 오류 분기가 있다면 수정한다. 이 분석을 이유로 실주문을 실행할 필요는 없다.

## 분석 범위와 실행 기록

로컬 스냅샷·소스·테스트만 정적으로 읽었으며 실제 계좌 데이터와 실서비스 API는 사용하지 않았다. OpenAPI raw text diff, 커밋, push는 수행하지 않았다. 작성한 파일은 이 보고서 하나이며 테스트는 실행하지 않았다.

최초 도구 실행 시 부분 복제 저장소에 부모 OpenAPI blob `e2ca461e0e80116f455abde3efedfaaacd60865b`가 없어 Git이 GitHub 자동 fetch를 시도했으나 DNS 오류로 실패했다. 이는 GitHub 호출 금지 조건을 완전히 지키지 못한 실행상 이탈이다. 이후 `GIT_NO_LAZY_FETCH=1`과 `protocol.allow=never`로 네트워크를 차단하고, `GIT_ALTERNATE_OBJECT_DIRECTORIES`로 기존 로컬 저장소의 객체를 읽어 지정 명령을 성공시켰다. Git 설정이나 객체 파일을 직접 변경하지 않았다.

---
Codex 정기 분석입니다. 검토 후 병합하거나 닫아 주세요.