### PR TITLE
docs: README 도입부를 간결하고 자연스럽게 정리

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -7,7 +7,7 @@
 <h1 align="center">tossinvest-cli</h1>
 
 <p align="center">
-  <strong>Give your AI the investment data the official API leaves out.</strong>
+  <strong>Give your AI investment data beyond the official API.</strong>
   <br />From stock discovery to assets, profit, taxes, and watchlists — one <code>tossctl</code>.
 </p>
 
@@ -19,7 +19,7 @@
 
 <p align="center">
   <a href="#quick-start"><strong>Quick Start</strong></a> ·
-  <a href="#what-the-official-api-leaves-out"><strong>Go Beyond the API</strong></a> ·
+  <a href="#beyond-the-official-api"><strong>Go Beyond the API</strong></a> ·
   <a href="#use-it-with-ai"><strong>Connect AI</strong></a> ·
   <a href="#before-you-place-an-order"><strong>Before Trading</strong></a> ·
   <a href="https://tossinvest-cli.vercel.app/en/docs"><strong>Docs</strong></a>
@@ -28,7 +28,7 @@
 > [!WARNING]
 > This is not an official Toss Securities product. Features outside the official Open API use Toss Securities' internal web API unofficially, may violate its Terms of Service, and can change without notice. You are responsible for account restrictions, losses, and other consequences of use.
 
-## What the Official API Leaves Out
+## Beyond the Official API
 
 tossctl brings [**30+ capabilities beyond the official API**](https://tossinvest-cli.vercel.app/en/docs/reference/support-scope) into your AI and automation. Discover stocks, track changes in your assets, and review tax records in one place.
 

--- a/README.en.md
+++ b/README.en.md
@@ -30,7 +30,7 @@
 
 ## What the Official API Leaves Out
 
-**AI signals, dividends, and watchlists are only part of it.** tossctl brings [**30+ capabilities beyond the official API**](https://tossinvest-cli.vercel.app/en/docs/reference/support-scope) into your AI and automation. Discover stocks, track changes in your assets, and review tax records in one place.
+tossctl brings [**30+ capabilities beyond the official API**](https://tossinvest-cli.vercel.app/en/docs/reference/support-scope) into your AI and automation. Discover stocks, track changes in your assets, and review tax records in one place.
 
 | What else you can do | Official Open API | What tossctl connects |
 |---|:---:|---|

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">tossinvest-cli</h1>
 
 <p align="center">
-  <strong>공식 API에서 빠진 투자 정보까지, 내 AI에게.</strong>
+  <strong>공식 API에 없는 투자 정보까지, 내 AI에게.</strong>
   <br />종목 탐색부터 자산·손익·세금·관심종목 관리까지, <code>tossctl</code> 하나로.
 </p>
 
@@ -19,7 +19,7 @@
 
 <p align="center">
   <a href="#빠른-시작"><strong>빠른 시작</strong></a> ·
-  <a href="#공식-api만으로는-빠지는-것들"><strong>더 쓸 수 있는 기능</strong></a> ·
+  <a href="#공식-api에-없는-기능"><strong>더 쓸 수 있는 기능</strong></a> ·
   <a href="#ai와-함께-사용하기"><strong>AI 연결</strong></a> ·
   <a href="#주문-전-확인하세요"><strong>주문 전 확인</strong></a> ·
   <a href="https://tossinvest-cli.vercel.app/docs"><strong>문서</strong></a>
@@ -28,7 +28,7 @@
 > [!WARNING]
 > 이 프로젝트는 토스증권 공식 제품이 아닙니다. 공식 Open API 외 기능은 토스증권 웹 내부 API를 비공식적으로 사용하며, 이용약관 위반에 해당할 수 있고 예고 없이 변경될 수 있습니다. 계좌 제한·손실 등 사용 결과는 사용자 본인의 책임입니다.
 
-## 공식 API만으로는 빠지는 것들
+## 공식 API에 없는 기능
 
 tossctl은 [공식 API에 없는 **30가지 이상의 기능**](https://tossinvest-cli.vercel.app/docs/reference/support-scope)을 내 AI와 자동화에 연결합니다. 종목을 찾는 일부터 내 자산의 변화와 세금 자료를 확인하는 일까지 한곳에서 다루세요.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ## 공식 API만으로는 빠지는 것들
 
-**AI 시그널·배당·관심종목은 일부입니다.** tossctl은 [공식 API에 없는 **30가지 이상의 기능**](https://tossinvest-cli.vercel.app/docs/reference/support-scope)을 내 AI와 자동화에 연결합니다. 종목을 찾는 일부터 내 자산의 변화와 세금 자료를 확인하는 일까지 한곳에서 다루세요.
+tossctl은 [공식 API에 없는 **30가지 이상의 기능**](https://tossinvest-cli.vercel.app/docs/reference/support-scope)을 내 AI와 자동화에 연결합니다. 종목을 찾는 일부터 내 자산의 변화와 세금 자료를 확인하는 일까지 한곳에서 다루세요.
 
 | 더 할 수 있는 일 | 공식 Open API | tossctl에서 연결하는 기능 |
 |---|:---:|---|


### PR DESCRIPTION
## 변경 사항

한·영 README에서 “AI 시그널·배당·관심종목은 일부입니다”라는 도입 문장을 삭제해 30+ 기능 설명으로 바로 시작합니다. “공식 API에서 빠진”은 “공식 API에 없는”으로 바꾸고, 섹션 제목과 이동 링크 및 영어 표현도 맞췄습니다.

## 영향 범위

- [x] 문서

## 테스트

- [x] README 검증 테스트 4개 통과
- [x] `git diff --check` 통과
- [x] GitHub Markdown 렌더링에서 한·영 제목 및 이동 링크 확인

## 체크리스트

- [x] 문구만 수정해 기존 동작에 영향 없음
