### PR TITLE
docs: README에서 tossctl이 제공하는 공식 API 밖의 기능 강조

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -19,7 +19,7 @@
 
 <p align="center">
   <a href="#quick-start"><strong>Quick Start</strong></a> ·
-  <a href="#do-more-with-tossctl"><strong>Do More</strong></a> ·
+  <a href="#go-beyond-the-official-api-with-tossctl"><strong>Beyond the API</strong></a> ·
   <a href="#use-it-with-ai"><strong>Connect AI</strong></a> ·
   <a href="#before-you-place-an-order"><strong>Before Trading</strong></a> ·
   <a href="https://tossinvest-cli.vercel.app/en/docs"><strong>Docs</strong></a>
@@ -28,7 +28,7 @@
 > [!WARNING]
 > This is not an official Toss Securities product. Features outside the official Open API use Toss Securities' internal web API unofficially, may violate its Terms of Service, and can change without notice. You are responsible for account restrictions, losses, and other consequences of use.
 
-## Do More with tossctl
+## Go Beyond the Official API with tossctl
 
 tossctl brings [**30+ capabilities beyond the official API**](https://tossinvest-cli.vercel.app/en/docs/reference/support-scope) into your AI and automation. Discover stocks, track changes in your assets, and review tax records in one place.
 

--- a/README.en.md
+++ b/README.en.md
@@ -19,7 +19,7 @@
 
 <p align="center">
   <a href="#quick-start"><strong>Quick Start</strong></a> ·
-  <a href="#beyond-the-official-api"><strong>Go Beyond the API</strong></a> ·
+  <a href="#do-more-with-tossctl"><strong>Do More</strong></a> ·
   <a href="#use-it-with-ai"><strong>Connect AI</strong></a> ·
   <a href="#before-you-place-an-order"><strong>Before Trading</strong></a> ·
   <a href="https://tossinvest-cli.vercel.app/en/docs"><strong>Docs</strong></a>
@@ -28,7 +28,7 @@
 > [!WARNING]
 > This is not an official Toss Securities product. Features outside the official Open API use Toss Securities' internal web API unofficially, may violate its Terms of Service, and can change without notice. You are responsible for account restrictions, losses, and other consequences of use.
 
-## Beyond the Official API
+## Do More with tossctl
 
 tossctl brings [**30+ capabilities beyond the official API**](https://tossinvest-cli.vercel.app/en/docs/reference/support-scope) into your AI and automation. Discover stocks, track changes in your assets, and review tax records in one place.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 <p align="center">
   <a href="#빠른-시작"><strong>빠른 시작</strong></a> ·
-  <a href="#공식-api에-없는-기능"><strong>더 쓸 수 있는 기능</strong></a> ·
+  <a href="#tossctl로-더-할-수-있는-일"><strong>더 할 수 있는 일</strong></a> ·
   <a href="#ai와-함께-사용하기"><strong>AI 연결</strong></a> ·
   <a href="#주문-전-확인하세요"><strong>주문 전 확인</strong></a> ·
   <a href="https://tossinvest-cli.vercel.app/docs"><strong>문서</strong></a>
@@ -28,7 +28,7 @@
 > [!WARNING]
 > 이 프로젝트는 토스증권 공식 제품이 아닙니다. 공식 Open API 외 기능은 토스증권 웹 내부 API를 비공식적으로 사용하며, 이용약관 위반에 해당할 수 있고 예고 없이 변경될 수 있습니다. 계좌 제한·손실 등 사용 결과는 사용자 본인의 책임입니다.
 
-## 공식 API에 없는 기능
+## tossctl로 더 할 수 있는 일
 
 tossctl은 [공식 API에 없는 **30가지 이상의 기능**](https://tossinvest-cli.vercel.app/docs/reference/support-scope)을 내 AI와 자동화에 연결합니다. 종목을 찾는 일부터 내 자산의 변화와 세금 자료를 확인하는 일까지 한곳에서 다루세요.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 <p align="center">
   <a href="#빠른-시작"><strong>빠른 시작</strong></a> ·
-  <a href="#tossctl로-더-할-수-있는-일"><strong>더 할 수 있는 일</strong></a> ·
+  <a href="#공식-api에-없는-기능까지-tossctl로"><strong>더 할 수 있는 일</strong></a> ·
   <a href="#ai와-함께-사용하기"><strong>AI 연결</strong></a> ·
   <a href="#주문-전-확인하세요"><strong>주문 전 확인</strong></a> ·
   <a href="https://tossinvest-cli.vercel.app/docs"><strong>문서</strong></a>
@@ -28,7 +28,7 @@
 > [!WARNING]
 > 이 프로젝트는 토스증권 공식 제품이 아닙니다. 공식 Open API 외 기능은 토스증권 웹 내부 API를 비공식적으로 사용하며, 이용약관 위반에 해당할 수 있고 예고 없이 변경될 수 있습니다. 계좌 제한·손실 등 사용 결과는 사용자 본인의 책임입니다.
 
-## tossctl로 더 할 수 있는 일
+## 공식 API에 없는 기능까지, tossctl로
 
 tossctl은 [공식 API에 없는 **30가지 이상의 기능**](https://tossinvest-cli.vercel.app/docs/reference/support-scope)을 내 AI와 자동화에 연결합니다. 종목을 찾는 일부터 내 자산의 변화와 세금 자료를 확인하는 일까지 한곳에서 다루세요.
 


### PR DESCRIPTION
## 변경 사항

README의 “공식 API에 없는 기능”을 “공식 API에 없는 기능까지, tossctl로”로 바꿔 공식 API와의 차별점과 tossctl에서 사용할 수 있다는 점을 함께 전달합니다. 영어 제목과 상단 이동 링크도 같은 의미로 맞췄습니다.

## 영향 범위

- [x] 문서

## 테스트

- [x] README 검증 테스트 4개 통과
- [x] `git diff --check` 통과
- [x] 한·영 제목과 이동 링크 일치 확인

## 체크리스트

- [x] 문구만 수정해 기존 동작에 영향 없음
